### PR TITLE
feat(sync): atomic domain RPCs + enqueue coalescing + leaky-write fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,4 +39,36 @@ Transform tasks into verifiable goals:
 - “Fix the bug” → “Reproduce it in a test, then fix”
 - “Refactor X” → “Ensure tests pass before and after”
 
-## 5. Cautious with Dependencies
+## 5. Sync invariants
+
+Every write to a synced table (anything in `_syncedTenantTables` in
+[lib/core/database/app_database.dart](lib/core/database/app_database.dart))
+must reach the cloud. The contract is:
+
+- All writes go through a DAO method that calls `enqueueUpsert` /
+  `enqueueDelete` on `SyncDao` (or enqueues a `domain:<rpc>` envelope
+  for atomic multi-table actions). Writes via `db.into(...)`,
+  `db.update(...)`, `db.delete(...)` *outside* a DAO are leaks — the
+  cloud never sees them.
+- Two legitimate exceptions, both narrow:
+  1. `_restoreTableData` in `supabase_sync_service.dart` (incoming pull
+     and realtime).
+  2. `_applyDomainResponse` in `supabase_sync_service.dart` (server's
+     authoritative response after a domain RPC succeeds — the server
+     already has the truth; pushing it back would be a no-op round
+     trip).
+- Soft-delete (`is_deleted=true`) goes through `enqueueUpsert`. Only
+  use `enqueueDelete` for hard tombstones the cloud needs to forget;
+  it also clears any pending upsert for the same row.
+- Domain envelopes (`domain:pos_record_sale`, `domain:pos_inventory_delta`,
+  `domain:pos_create_product`) skip enqueue-time coalescing — each is an
+  independent atomic transaction. Their payloads sit at `$.p_<arg>` and
+  are dispatched via `_pushDomainItems`, not the per-table batched upsert
+  path.
+- Stream providers for synced tables live in
+  [lib/core/providers/stream_providers.dart](lib/core/providers/stream_providers.dart).
+  When a screen reads a synced table, prefer the existing provider over a
+  one-shot `db.select(...).get()` so realtime events propagate without a
+  manual refresh.
+
+## 6. Cautious with Dependencies

--- a/lib/core/database/app_database.dart
+++ b/lib/core/database/app_database.dart
@@ -1042,7 +1042,7 @@ class AppDatabase extends _$AppDatabase {
   String? get currentBusinessId => businessIdResolver();
 
   @override
-  int get schemaVersion => 3;
+  int get schemaVersion => 4;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -1066,6 +1066,37 @@ class AppDatabase extends _$AppDatabase {
         await m.addColumn(businesses, businesses.onboardingComplete);
         await customStatement(
           'UPDATE businesses SET onboarding_complete = 1',
+        );
+      }
+      if (from < 4) {
+        // v4: enqueue-time coalescing. Adds a partial unique index on
+        // sync_queue keyed on (action_type, payload->id) WHERE status =
+        // 'pending'. Before adding it, collapse any duplicate pending rows
+        // that may already exist — keep the latest by created_at and mark
+        // the rest as completed so the index can be created without
+        // violating uniqueness. Domain actions (action_type LIKE 'domain:%')
+        // are exempt since each is an independent atomic envelope.
+        await customStatement(
+          "UPDATE sync_queue SET status = 'completed', is_synced = 1 "
+          "WHERE id IN ("
+          "  SELECT id FROM ("
+          "    SELECT id, ROW_NUMBER() OVER ("
+          "      PARTITION BY action_type, json_extract(payload, '\$.id') "
+          "      ORDER BY created_at DESC"
+          "    ) AS rn "
+          "    FROM sync_queue "
+          "    WHERE status = 'pending' "
+          "      AND action_type NOT LIKE 'domain:%' "
+          "      AND json_extract(payload, '\$.id') IS NOT NULL"
+          "  ) WHERE rn > 1"
+          ")",
+        );
+        await customStatement(
+          "CREATE UNIQUE INDEX IF NOT EXISTS idx_sync_queue_dedup_pending "
+          "ON sync_queue (action_type, json_extract(payload, '\$.id')) "
+          "WHERE status = 'pending' "
+          "  AND action_type NOT LIKE 'domain:%' "
+          "  AND json_extract(payload, '\$.id') IS NOT NULL",
         );
       }
     },
@@ -1322,6 +1353,18 @@ List<String> get _postCreateStatements {
   // -- Partial unique on invites.code WHERE status='pending' --
   stmts.add(
     "CREATE UNIQUE INDEX uq_invites_pending_code ON invites (code) WHERE status = 'pending'",
+  );
+
+  // Enqueue-time coalescing: at most one pending sync_queue row per
+  // (action_type, payload.id). The trailing AND clause excludes domain
+  // actions (each domain envelope is an independent atomic call) and
+  // payloads without a top-level id (delete tombstones).
+  stmts.add(
+    "CREATE UNIQUE INDEX idx_sync_queue_dedup_pending "
+    "ON sync_queue (action_type, json_extract(payload, '\$.id')) "
+    "WHERE status = 'pending' "
+    "  AND action_type NOT LIKE 'domain:%' "
+    "  AND json_extract(payload, '\$.id') IS NOT NULL",
   );
 
   // -- bump_<table>_last_updated_at triggers --

--- a/lib/core/database/daos.dart
+++ b/lib/core/database/daos.dart
@@ -10,6 +10,14 @@ import 'package:reebaplus_pos/core/database/sync_helpers.dart';
 
 part 'daos.g.dart';
 
+/// Sentinel for "argument was not provided" on optional setter parameters,
+/// distinct from "argument was provided as null". Used by methods that
+/// accept partial-update payloads (e.g. `CatalogDao.updateProductDetails`)
+/// to map missing args to `Value.absent()` and explicit-null args to
+/// `Value(null)` — the latter clears the column, the former leaves it
+/// untouched.
+const Object _unset = Object();
+
 @DriftAccessor(
   tables: [Suppliers, Products, Categories, Warehouses, Manufacturers],
 )
@@ -50,6 +58,129 @@ class CatalogDao extends DatabaseAccessor<AppDatabase>
     );
     await into(products).insert(row);
     await db.syncDao.enqueueUpsert('products', row);
+    return id;
+  }
+
+  /// Combined product + optional initial-stock create. Replaces the
+  /// `insertProduct(...)` + `adjustStock(...)` two-step pattern with one
+  /// transactional local write + one domain envelope when the
+  /// `feature.domain_rpcs.product_create` flag is on. Without the flag,
+  /// behaviour is identical to the legacy two-step path (3-4 outbox
+  /// rows). With the flag, it's one row.
+  Future<String> insertProductWithInitialStock(
+    ProductsCompanion companion, {
+    int? initialStock,
+    String? warehouseId,
+    String? performedBy,
+  }) async {
+    final id = UuidV7.generate();
+    final productRow = companion.copyWith(
+      id: Value(id),
+      lastUpdatedAt: Value(DateTime.now()),
+    );
+
+    final flagValue =
+        await db.systemConfigDao.get('feature.domain_rpcs.product_create');
+    final useDomainRpc = flagValue == 'true' || flagValue == '"true"';
+    final hasInitialStock =
+        initialStock != null && initialStock > 0 && warehouseId != null;
+
+    await transaction(() async {
+      await into(products).insert(productRow);
+      if (!useDomainRpc) {
+        await db.syncDao.enqueueUpsert('products', productRow);
+      }
+
+      if (hasInitialStock) {
+        // 1. stock_adjustments parent row (anchor for the ledger insert).
+        final adjId = UuidV7.generate();
+        final adjComp = StockAdjustmentsCompanion.insert(
+          id: Value(adjId),
+          businessId: requireBusinessId(),
+          productId: id,
+          warehouseId: warehouseId,
+          quantityDiff: initialStock,
+          reason: 'initial_stock',
+          performedBy: Value(performedBy),
+          lastUpdatedAt: Value(DateTime.now()),
+        );
+        await db.into(db.stockAdjustments).insert(adjComp);
+        if (!useDomainRpc) {
+          await db.syncDao.enqueueUpsert('stock_adjustments', adjComp);
+        }
+
+        // 2. stock_transactions ledger row.
+        final txId = UuidV7.generate();
+        final txComp = StockTransactionsCompanion.insert(
+          id: Value(txId),
+          businessId: requireBusinessId(),
+          productId: id,
+          locationId: warehouseId,
+          quantityDelta: initialStock,
+          movementType: 'adjustment',
+          adjustmentId: Value(adjId),
+          performedBy: Value(performedBy),
+          lastUpdatedAt: Value(DateTime.now()),
+        );
+        await db.into(db.stockTransactions).insert(txComp);
+        if (!useDomainRpc) {
+          await db.syncDao.enqueueUpsert('stock_transactions', txComp);
+        }
+
+        // 3. Inventory cache upsert.
+        await customInsert(
+          'INSERT INTO inventory (id, business_id, product_id, warehouse_id, quantity) '
+          'VALUES (?, ?, ?, ?, ?) '
+          'ON CONFLICT(business_id, product_id, warehouse_id) DO UPDATE SET '
+          'quantity = quantity + excluded.quantity, '
+          'last_updated_at = CURRENT_TIMESTAMP',
+          variables: [
+            Variable(UuidV7.generate()),
+            Variable(requireBusinessId()),
+            Variable(id),
+            Variable(warehouseId),
+            Variable(initialStock),
+          ],
+          updates: {db.inventory},
+        );
+        if (!useDomainRpc) {
+          final invRow = await (db.select(db.inventory)
+                ..where((t) =>
+                    t.productId.equals(id) &
+                    t.warehouseId.equals(warehouseId) &
+                    t.businessId.equals(requireBusinessId())))
+              .getSingle();
+          await db.syncDao.enqueueUpsert('inventory', invRow);
+        }
+      }
+
+      if (useDomainRpc) {
+        final bundle = <String, dynamic>{
+          'p_business_id': requireBusinessId(),
+          'p_product': serializeInsertable(productRow),
+          'p_initial_stock': hasInitialStock
+              ? <String, dynamic>{
+                  'warehouse_id': warehouseId,
+                  'quantity': initialStock,
+                  'performed_by': performedBy,
+                }
+              : null,
+        };
+        await db.syncDao
+            .enqueue('domain:pos_create_product', jsonEncode(bundle));
+      }
+    });
+    return id;
+  }
+
+  Future<String> insertCategory(CategoriesCompanion companion) async {
+    final id = UuidV7.generate();
+    final row = companion.copyWith(
+      id: Value(id),
+      lastUpdatedAt: Value(DateTime.now()),
+    );
+    await into(categories).insert(row);
+    await db.syncDao.enqueueUpsert('categories', row);
     return id;
   }
 
@@ -114,6 +245,14 @@ class CatalogDao extends DatabaseAccessor<AppDatabase>
     bool? trackEmpties,
     int? lowStockThreshold,
     String? imagePath,
+    // Optional cosmetic / metadata fields. Wrapped with present-check
+    // sentinels so the caller can leave any of them out and the column
+    // stays untouched (Value.absent vs Value(null) — the latter would
+    // null-out the column).
+    Object? subtitle = _unset,
+    Object? colorHex = _unset,
+    Object? supplierId = _unset,
+    Object? size = _unset,
   }) async {
     final now = DateTime.now();
     final comp = ProductsCompanion(
@@ -136,6 +275,18 @@ class CatalogDao extends DatabaseAccessor<AppDatabase>
           ? const Value.absent()
           : Value(lowStockThreshold),
       imagePath: Value(imagePath),
+      subtitle: identical(subtitle, _unset)
+          ? const Value.absent()
+          : Value(subtitle as String?),
+      colorHex: identical(colorHex, _unset)
+          ? const Value.absent()
+          : Value(colorHex as String?),
+      supplierId: identical(supplierId, _unset)
+          ? const Value.absent()
+          : Value(supplierId as String?),
+      size: identical(size, _unset)
+          ? const Value.absent()
+          : Value(size as String?),
       lastUpdatedAt: Value(now),
     );
     await (update(
@@ -372,6 +523,14 @@ class InventoryDao extends DatabaseAccessor<AppDatabase>
   ) async {
     if (delta == 0) return;
     await transaction(() async {
+      // Feature flag: when on, the whole adjustment enqueues as a single
+      // `domain:pos_inventory_delta` envelope (one outbox row vs three).
+      // The server applies the same writes atomically with row-locked
+      // inventory deltas.
+      final flagValue =
+          await db.systemConfigDao.get('feature.domain_rpcs.inventory');
+      final useDomainRpc = flagValue == 'true' || flagValue == '"true"';
+
       // 1. Append stock_adjustments
       final adjustmentId = UuidV7.generate();
       final adjComp = StockAdjustmentsCompanion.insert(
@@ -385,7 +544,9 @@ class InventoryDao extends DatabaseAccessor<AppDatabase>
         lastUpdatedAt: Value(DateTime.now()),
       );
       await into(stockAdjustments).insert(adjComp);
-      await db.syncDao.enqueueUpsert('stock_adjustments', adjComp);
+      if (!useDomainRpc) {
+        await db.syncDao.enqueueUpsert('stock_adjustments', adjComp);
+      }
 
       // 2. Append stock_transactions ledger row
       final txId = UuidV7.generate();
@@ -401,7 +562,9 @@ class InventoryDao extends DatabaseAccessor<AppDatabase>
         lastUpdatedAt: Value(DateTime.now()),
       );
       await into(stockTransactions).insert(txComp);
-      await db.syncDao.enqueueUpsert('stock_transactions', txComp);
+      if (!useDomainRpc) {
+        await db.syncDao.enqueueUpsert('stock_transactions', txComp);
+      }
 
       // 3. UPSERT inventory cache
       if (delta >= 0) {
@@ -444,15 +607,38 @@ class InventoryDao extends DatabaseAccessor<AppDatabase>
         }
       }
 
-      final invRow =
-          await (select(inventory)..where(
-                (t) =>
-                    t.productId.equals(productId) &
-                    t.warehouseId.equals(warehouseId) &
-                    whereBusiness(t),
-              ))
-              .getSingle();
-      await db.syncDao.enqueueUpsert('inventory', invRow);
+      if (useDomainRpc) {
+        // Single domain envelope: server applies the delta atomically and
+        // returns the new quantity, which SyncService writes back to the
+        // local cache. No need to enqueue the inventory row separately.
+        final bundle = <String, dynamic>{
+          'p_business_id': requireBusinessId(),
+          'p_movements': [
+            {
+              'id': txId,
+              'product_id': productId,
+              'warehouse_id': warehouseId,
+              'quantity_delta': delta,
+              'movement_type': 'adjustment',
+              'ref_type': 'adjustment',
+              'ref_id': adjustmentId,
+              'performed_by': staffId,
+            },
+          ],
+        };
+        await db.syncDao
+            .enqueue('domain:pos_inventory_delta', jsonEncode(bundle));
+      } else {
+        final invRow =
+            await (select(inventory)..where(
+                  (t) =>
+                      t.productId.equals(productId) &
+                      t.warehouseId.equals(warehouseId) &
+                      whereBusiness(t),
+                ))
+                .getSingle();
+        await db.syncDao.enqueueUpsert('inventory', invRow);
+      }
     });
   }
 
@@ -772,15 +958,27 @@ class OrdersDao extends DatabaseAccessor<AppDatabase>
     return db.transaction(() async {
       final orderId = order.id.present ? order.id.value : UuidV7.generate();
 
+      // Feature flag: when on, this whole sale enqueues as a single
+      // domain envelope (`domain:pos_record_sale`) instead of 9-12
+      // separate per-table outbox rows. The server applies the entire
+      // sale atomically — see supabase/migrations/0006_domain_rpcs.sql.
+      // Off → legacy per-row enqueues (rollback path).
+      final flagValue =
+          await db.systemConfigDao.get('feature.domain_rpcs.sales');
+      final useDomainRpc = flagValue == 'true' || flagValue == '"true"';
+
       // 1. Insert Order
       final orderWithTime = order.copyWith(
         id: Value(orderId),
         lastUpdatedAt: Value(DateTime.now()),
       );
       await into(orders).insert(orderWithTime);
-      await db.syncDao.enqueueUpsert('orders', orderWithTime);
+      if (!useDomainRpc) {
+        await db.syncDao.enqueueUpsert('orders', orderWithTime);
+      }
 
       // 2. Insert OrderItems
+      final itemRecords = <OrderItemsCompanion>[];
       for (final item in items) {
         final itemId = item.id.present ? item.id.value : UuidV7.generate();
         final itemWithTime = item.copyWith(
@@ -789,7 +987,10 @@ class OrdersDao extends DatabaseAccessor<AppDatabase>
           lastUpdatedAt: Value(DateTime.now()),
         );
         await into(orderItems).insert(itemWithTime);
-        await db.syncDao.enqueueUpsert('order_items', itemWithTime);
+        itemRecords.add(itemWithTime);
+        if (!useDomainRpc) {
+          await db.syncDao.enqueueUpsert('order_items', itemWithTime);
+        }
       }
 
       // 3. Deduct Inventory — atomic guard (Issue #8)
@@ -820,6 +1021,7 @@ class OrdersDao extends DatabaseAccessor<AppDatabase>
       }
 
       // 4. Insert StockTransactions ledger rows
+      final stockTxRecords = <StockTransactionsCompanion>[];
       for (final item in items) {
         final txId = UuidV7.generate();
         final txComp = StockTransactionsCompanion.insert(
@@ -834,12 +1036,16 @@ class OrdersDao extends DatabaseAccessor<AppDatabase>
           lastUpdatedAt: Value(DateTime.now()),
         );
         await into(stockTransactions).insert(txComp);
-        await db.syncDao.enqueueUpsert('stock_transactions', txComp);
+        stockTxRecords.add(txComp);
+        if (!useDomainRpc) {
+          await db.syncDao.enqueueUpsert('stock_transactions', txComp);
+        }
       }
 
       // 5. Insert PaymentTransactions only when cash actually changed hands.
       // Wallet/credit sales are recorded by the wallet ledger, not as a
       // 0-kobo payment row.
+      PaymentTransactionsCompanion? paymentRecord;
       if (amountPaidKobo > 0) {
         final payId = UuidV7.generate();
         final payComp = PaymentTransactionsCompanion.insert(
@@ -853,11 +1059,15 @@ class OrdersDao extends DatabaseAccessor<AppDatabase>
           lastUpdatedAt: Value(DateTime.now()),
         );
         await into(paymentTransactions).insert(payComp);
-        await db.syncDao.enqueueUpsert('payment_transactions', payComp);
+        paymentRecord = payComp;
+        if (!useDomainRpc) {
+          await db.syncDao.enqueueUpsert('payment_transactions', payComp);
+        }
       }
 
       // 6. Insert WalletTransactions debit when the customer carries part or
       // all of the bill on their wallet (partial cash, full wallet, credit).
+      WalletTransactionsCompanion? walletTxRecord;
       if (walletDebitKobo > 0) {
         if (customerId == null) {
           throw ArgumentError(
@@ -892,22 +1102,51 @@ class OrdersDao extends DatabaseAccessor<AppDatabase>
           lastUpdatedAt: Value(DateTime.now()),
         );
         await into(walletTransactions).insert(walletTxComp);
-        await db.syncDao.enqueueUpsert('wallet_transactions', walletTxComp);
+        walletTxRecord = walletTxComp;
+        if (!useDomainRpc) {
+          await db.syncDao.enqueueUpsert('wallet_transactions', walletTxComp);
+        }
       }
 
-      // Update and enqueue updated inventory cache
-      for (final item in items) {
-        final productId = item.productId.value;
-        final whId = item.warehouseId.value;
-        final invRow =
-            await (select(inventory)..where(
-                  (t) =>
-                      t.productId.equals(productId) &
-                      t.warehouseId.equals(whId) &
-                      whereBusiness(t),
-                ))
-                .getSingle();
-        await db.syncDao.enqueueUpsert('inventory', invRow);
+      if (useDomainRpc) {
+        // One outbox row for the entire sale. The server transaction
+        // re-applies the same writes atomically; on insufficient_stock it
+        // raises P0001 and the whole RPC rolls back, leaving the cloud
+        // unchanged. The local optimistic state is reconciled when
+        // SyncService applies the RPC response (`inventory_after`).
+        final bundle = <String, dynamic>{
+          'p_business_id': requireBusinessId(),
+          'p_order': serializeInsertable(orderWithTime),
+          'p_items': itemRecords.map(serializeInsertable).toList(),
+          'p_stock_movements':
+              stockTxRecords.map(serializeInsertable).toList(),
+          'p_payment': paymentRecord != null
+              ? serializeInsertable(paymentRecord)
+              : null,
+          'p_wallet_tx': walletTxRecord != null
+              ? serializeInsertable(walletTxRecord)
+              : null,
+        };
+        await db.syncDao
+            .enqueue('domain:pos_record_sale', jsonEncode(bundle));
+      } else {
+        // Legacy: also enqueue the updated inventory cache so the cloud
+        // converges. Under the domain RPC path, the server is the
+        // authoritative writer and emits inventory_after — no enqueue
+        // needed.
+        for (final item in items) {
+          final productId = item.productId.value;
+          final whId = item.warehouseId.value;
+          final invRow =
+              await (select(inventory)..where(
+                    (t) =>
+                        t.productId.equals(productId) &
+                        t.warehouseId.equals(whId) &
+                        whereBusiness(t),
+                  ))
+                  .getSingle();
+          await db.syncDao.enqueueUpsert('inventory', invRow);
+        }
       }
 
       return orderId;
@@ -1824,6 +2063,64 @@ class SyncDao extends DatabaseAccessor<AppDatabase>
     );
   }
 
+  /// Looks up an existing pending sync_queue row for `(actionType, rowId)`
+  /// using the partial unique index `idx_sync_queue_dedup_pending`. Returns
+  /// the row id of the match, or null. Domain envelopes (action_type
+  /// 'domain:%') are exempt from coalescing — each is an independent
+  /// atomic call — so callers must skip this lookup for them.
+  Future<String?> _findPendingDuplicateId(
+    String actionType,
+    String rowId,
+  ) async {
+    final result = await customSelect(
+      "SELECT id FROM sync_queue "
+      "WHERE action_type = ?1 AND status = 'pending' "
+      "  AND json_extract(payload, '\$.id') = ?2 "
+      "LIMIT 1",
+      variables: [
+        Variable.withString(actionType),
+        Variable.withString(rowId),
+      ],
+      readsFrom: {syncQueue},
+    ).getSingleOrNull();
+    return result?.read<String>('id');
+  }
+
+  /// Finds a pending domain envelope by extracting an arbitrary JSON path
+  /// from the payload. Used by the checkout flow to locate the freshly
+  /// enqueued `domain:pos_record_sale` row matching a specific orderId
+  /// (the order id lives at `$.p_order.id`, not at the top-level `id`,
+  /// so the dedup lookup above doesn't match).
+  Future<SyncQueueData?> findPendingDomainItem(
+    String actionType, {
+    required String payloadIdPath,
+    required String idValue,
+  }) async {
+    final bid = db.businessIdResolver.call();
+    if (bid == null) return null;
+    final result = await customSelect(
+      "SELECT id FROM sync_queue "
+      "WHERE action_type = ?1 AND status = 'pending' "
+      "  AND business_id = ?2 "
+      "  AND json_extract(payload, ?3) = ?4 "
+      "LIMIT 1",
+      variables: [
+        Variable.withString(actionType),
+        Variable.withString(bid),
+        Variable.withString(payloadIdPath),
+        Variable.withString(idValue),
+      ],
+      readsFrom: {syncQueue},
+    ).getSingleOrNull();
+    if (result == null) return null;
+    return getQueueItem(result.read<String>('id'));
+  }
+
+  Future<SyncQueueData?> getQueueItem(String id) {
+    return (select(syncQueue)..where((t) => t.id.equals(id)))
+        .getSingleOrNull();
+  }
+
   Future<void> enqueueUpsert(String tableName, Insertable row) async {
     final payloadMap = serializeInsertable(row);
     if (payloadMap['business_id'] == null) {
@@ -1832,7 +2129,44 @@ class SyncDao extends DatabaseAccessor<AppDatabase>
         payloadMap['business_id'] = bid;
       }
     }
-    await enqueue('$tableName:upsert', jsonEncode(payloadMap));
+    final actionType = '$tableName:upsert';
+    final payloadJson = jsonEncode(payloadMap);
+    final rowId = payloadMap['id'];
+
+    // Without an id we can't coalesce safely — fall back to plain insert.
+    if (rowId is! String) {
+      await enqueue(actionType, payloadJson);
+      return;
+    }
+
+    // Coalesce: a burst of writes to the same row only needs the *latest*
+    // payload. Earlier pending entries are stale and must not produce
+    // separate outbox rows. The partial unique index guarantees at most
+    // one pending row per (action_type, payload.id); the transaction here
+    // makes the SELECT-then-INSERT atomic against concurrent enqueues from
+    // the same isolate (Drift serializes writes on a single connection).
+    await transaction(() async {
+      final existingId = await _findPendingDuplicateId(actionType, rowId);
+      if (existingId != null) {
+        await (update(syncQueue)..where((t) => t.id.equals(existingId)))
+            .write(SyncQueueCompanion(
+          payload: Value(payloadJson),
+          createdAt: Value(DateTime.now()),
+          attempts: const Value(0),
+          nextAttemptAt: const Value(null),
+          errorMessage: const Value(null),
+        ));
+      } else {
+        await into(syncQueue).insert(
+          SyncQueueCompanion.insert(
+            id: Value(UuidV7.generate()),
+            businessId: requireBusinessId(),
+            actionType: actionType,
+            payload: payloadJson,
+          ),
+        );
+      }
+    });
   }
 
   Future<void> enqueueDelete(String tableName, String rowId) async {
@@ -1845,7 +2179,48 @@ class SyncDao extends DatabaseAccessor<AppDatabase>
     if (bid != null) {
       payloadMap['business_id'] = bid;
     }
-    await enqueue('$tableName:delete', jsonEncode(payloadMap));
+    final upsertActionType = '$tableName:upsert';
+    final deleteActionType = '$tableName:delete';
+    final payloadJson = jsonEncode(payloadMap);
+
+    // A delete supersedes any pending upsert for the same row — pushing the
+    // upsert first would race against the delete and leave the cloud row
+    // in an inconsistent state. Mark any pending upsert as completed (so it
+    // doesn't push), then coalesce against an existing pending delete.
+    await transaction(() async {
+      final pendingUpsertId =
+          await _findPendingDuplicateId(upsertActionType, rowId);
+      if (pendingUpsertId != null) {
+        await (update(syncQueue)..where((t) => t.id.equals(pendingUpsertId)))
+            .write(const SyncQueueCompanion(
+          isSynced: Value(true),
+          status: Value('completed'),
+          nextAttemptAt: Value(null),
+        ));
+      }
+
+      final existingDeleteId =
+          await _findPendingDuplicateId(deleteActionType, rowId);
+      if (existingDeleteId != null) {
+        await (update(syncQueue)..where((t) => t.id.equals(existingDeleteId)))
+            .write(SyncQueueCompanion(
+          payload: Value(payloadJson),
+          createdAt: Value(DateTime.now()),
+          attempts: const Value(0),
+          nextAttemptAt: const Value(null),
+          errorMessage: const Value(null),
+        ));
+      } else {
+        await into(syncQueue).insert(
+          SyncQueueCompanion.insert(
+            id: Value(UuidV7.generate()),
+            businessId: requireBusinessId(),
+            actionType: deleteActionType,
+            payload: payloadJson,
+          ),
+        );
+      }
+    });
   }
 }
 

--- a/lib/core/providers/app_providers.dart
+++ b/lib/core/providers/app_providers.dart
@@ -102,7 +102,10 @@ final activityLogProvider =
 
 // ── Order ───────────────────────────────────────────────────────────────────
 final orderServiceProvider = Provider<OrderService>((ref) {
-  return OrderService(ref.read(databaseProvider));
+  return OrderService(
+    ref.read(databaseProvider),
+    ref.read(supabaseSyncServiceProvider),
+  );
 });
 
 // ── Customer ────────────────────────────────────────────────────────────────

--- a/lib/core/providers/stream_providers.dart
+++ b/lib/core/providers/stream_providers.dart
@@ -4,6 +4,7 @@
 /// automatically — Riverpod deduplicates by provider identity.
 library;
 
+import 'package:drift/drift.dart' show OrderingTerm;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:reebaplus_pos/core/database/app_database.dart';
@@ -44,4 +45,33 @@ final productsByWarehouseProvider =
       .watch(databaseProvider)
       .inventoryDao
       .watchProductDatasWithStockByWarehouse(warehouseId);
+});
+
+// ── Categories ──────────────────────────────────────────────────────────────
+final allCategoriesProvider = StreamProvider<List<CategoryData>>((ref) {
+  return ref.watch(databaseProvider).inventoryDao.watchAllCategories();
+});
+
+// ── Manufacturers ───────────────────────────────────────────────────────────
+final allManufacturersProvider =
+    StreamProvider<List<ManufacturerData>>((ref) {
+  final db = ref.watch(databaseProvider);
+  return (db.select(db.manufacturers)
+        ..where((t) => t.isDeleted.equals(false))
+        ..orderBy([(t) => OrderingTerm(expression: t.name)]))
+      .watch();
+});
+
+// ── Warehouse by id ─────────────────────────────────────────────────────────
+/// Streams a single warehouse row keyed by id. Returns null when the
+/// warehouse hasn't loaded yet or has been (soft-)deleted. Used wherever
+/// a screen needs to display the *active* warehouse and have it auto-update
+/// when the cloud renames or marks it deleted.
+final warehouseByIdProvider =
+    StreamProvider.family<WarehouseData?, String>((ref, warehouseId) {
+  final db = ref.watch(databaseProvider);
+  return (db.select(db.warehouses)
+        ..where((t) => t.id.equals(warehouseId))
+        ..limit(1))
+      .watchSingleOrNull();
 });

--- a/lib/core/services/supabase_sync_service.dart
+++ b/lib/core/services/supabase_sync_service.dart
@@ -7,6 +7,22 @@ import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:reebaplus_pos/core/database/app_database.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+/// Thrown by [SupabaseSyncService.flushSale] when a `domain:pos_record_sale`
+/// envelope fails permanently at the server (insufficient_stock, FK / unique
+/// violation, tenant mismatch). The local optimistic sale has already
+/// committed; the caller is responsible for compensating (cancelling the
+/// order, refunding stock, voiding ledgers) and surfacing to the UI.
+class SaleSyncException implements Exception {
+  final String orderId;
+  final String errorMessage;
+  const SaleSyncException({
+    required this.orderId,
+    required this.errorMessage,
+  });
+  @override
+  String toString() => 'SaleSyncException(orderId=$orderId): $errorMessage';
+}
+
 /// Result of decoding the current Supabase session's access token.
 /// `businessId` is non-null only when the JWT actually carries a
 /// `business_id` claim (top-level or under `app_metadata` /
@@ -260,6 +276,25 @@ class SupabaseSyncService {
     }
     if (pendingItems.isEmpty) return;
 
+    // Partition off domain envelopes: each `domain:<rpc>` row is an atomic
+    // multi-table call routed through Postgres functions (see migration
+    // 0006_domain_rpcs.sql). They are not batched against each other — each
+    // one is an independent transaction — so they bypass the per-table
+    // grouping path entirely.
+    final domainItems = <SyncQueueData>[];
+    final tableItems = <SyncQueueData>[];
+    for (final item in pendingItems) {
+      if (item.actionType.startsWith('domain:')) {
+        domainItems.add(item);
+      } else {
+        tableItems.add(item);
+      }
+    }
+
+    if (domainItems.isNotEmpty) {
+      await _pushDomainItems(domainItems, sessionBusinessId);
+    }
+
     // Group items by their action signature (table + action + optional
     // conflict target). One Supabase round-trip per group, batched as an
     // array. PostgREST's array-upsert preserves partial-row semantics: only
@@ -267,7 +302,7 @@ class SupabaseSyncService {
     // Companions (e.g. markCompleted writing only {status, completed_at})
     // don't NULL-out untouched columns.
     final groups = <_PushGroup, List<SyncQueueData>>{};
-    for (final item in pendingItems) {
+    for (final item in tableItems) {
       final parts = item.actionType.split(':');
       if (parts.length < 2) continue;
       final group = _PushGroup(
@@ -370,6 +405,169 @@ class SupabaseSyncService {
     // next tick rather than recursing (avoids stack growth on huge backlogs).
     if (rawItems.length == 200) {
       Future.microtask(pushPending);
+    }
+  }
+
+  /// Pushes one outbox row per call to a Postgres RPC defined in
+  /// 0006_domain_rpcs.sql. Used for atomic multi-table actions
+  /// (`domain:pos_record_sale`, `domain:pos_inventory_delta`,
+  /// `domain:pos_create_product`) where the server applies the entire
+  /// business action in a single transaction. On success, applies the
+  /// server's authoritative response to the local cache without
+  /// re-enqueueing — this and `_restoreTableData` (for pull/realtime) are
+  /// the only legitimate paths that write to a synced table without
+  /// going through `enqueueUpsert`.
+  Future<void> _pushDomainItems(
+    List<SyncQueueData> items,
+    String sessionBusinessId,
+  ) async {
+    for (final item in items) {
+      await _db.syncDao.markInProgressBatch([item.id]);
+
+      Map<String, dynamic> payload;
+      try {
+        payload = jsonDecode(item.payload) as Map<String, dynamic>;
+      } catch (e) {
+        await _db.syncDao
+            .markFailed(item.id, 'decode_error: $e', permanent: true);
+        continue;
+      }
+
+      // Tenant guard. The RPC also checks server-side, but failing locally
+      // saves a round-trip and avoids a misleading 'tenant_mismatch' RPC
+      // error in the Sync Issues UI.
+      final payloadBiz = payload['p_business_id'];
+      if (item.businessId != sessionBusinessId ||
+          payloadBiz is! String ||
+          payloadBiz != sessionBusinessId) {
+        await _db.syncDao
+            .markFailed(item.id, 'missing_business_id', permanent: true);
+        continue;
+      }
+
+      final rpcName = item.actionType.substring('domain:'.length);
+      try {
+        final response = await _supabase.rpc(rpcName, params: payload);
+        await _applyDomainResponse(rpcName, response);
+        await _db.syncDao.markDone(item.id);
+      } on PostgrestException catch (e) {
+        // P0001 = app-level RAISE EXCEPTION (insufficient_stock,
+        // tenant_mismatch, etc.). 23xxx = integrity violations
+        // (unique, FK, check). Both are permanent — retrying without a
+        // schema/data change cannot succeed.
+        final code = e.code ?? '';
+        final isPermanent = code == 'P0001' ||
+            code.startsWith('23') ||
+            code == 'insufficient_privilege' ||
+            code == 'invalid_parameter_value';
+        debugPrint(
+          '[SyncService] Domain RPC $rpcName failed '
+          '(code=$code, permanent=$isPermanent): ${e.message}',
+        );
+        await _db.syncDao
+            .markFailed(item.id, 'pg_$code: ${e.message}', permanent: isPermanent);
+      } catch (e) {
+        debugPrint('[SyncService] Domain RPC $rpcName transient error: $e');
+        await _db.syncDao.markFailed(item.id, e.toString());
+      }
+    }
+  }
+
+  /// Reconciles the local cache with the server's authoritative response
+  /// from a domain RPC. Bypasses `enqueueUpsert` because the server already
+  /// has the truth — pushing it back would be a no-op round trip.
+  Future<void> _applyDomainResponse(
+    String rpcName,
+    dynamic response,
+  ) async {
+    if (response is! Map) return;
+    final map = Map<String, dynamic>.from(response);
+
+    // Inventory cache: pos_record_sale and pos_inventory_delta both return
+    // an `inventory_after` array of {product_id, warehouse_id, quantity,
+    // last_updated_at}. The Drift `bump_inventory_last_updated_at` trigger
+    // only fires when OLD.last_updated_at IS NEW.last_updated_at; we
+    // explicitly write the server's value, so the trigger is a no-op and
+    // the local row matches the cloud exactly.
+    final invAfter = map['inventory_after'];
+    if (invAfter is List) {
+      for (final raw in invAfter) {
+        if (raw is! Map) continue;
+        final productId = raw['product_id'] as String?;
+        final warehouseId = raw['warehouse_id'] as String?;
+        final quantity = raw['quantity'];
+        final luaStr = raw['last_updated_at'] as String?;
+        if (productId == null || warehouseId == null || quantity is! int) {
+          continue;
+        }
+        final lua = luaStr != null ? DateTime.tryParse(luaStr) : null;
+        await (_db.update(_db.inventory)
+              ..where((t) =>
+                  t.productId.equals(productId) &
+                  t.warehouseId.equals(warehouseId)))
+            .write(InventoryCompanion(
+          quantity: Value(quantity),
+          lastUpdatedAt: Value(lua ?? DateTime.now()),
+        ));
+      }
+    }
+
+    // pos_record_sale: bump the local order's last_updated_at to the
+    // server's value so the next pull's incremental cursor doesn't re-fetch
+    // it on every sync.
+    final orderId = map['order_id'] as String?;
+    final orderLua = map['order_last_updated_at'] as String?;
+    if (orderId != null && orderLua != null) {
+      final parsed = DateTime.tryParse(orderLua);
+      if (parsed != null) {
+        await (_db.update(_db.orders)..where((t) => t.id.equals(orderId)))
+            .write(OrdersCompanion(lastUpdatedAt: Value(parsed)));
+      }
+    }
+
+    // pos_create_product: same for products.
+    final productId = map['product_id'] as String?;
+    final productLua = map['product_last_updated_at'] as String?;
+    if (productId != null && productLua != null) {
+      final parsed = DateTime.tryParse(productLua);
+      if (parsed != null) {
+        await (_db.update(_db.products)..where((t) => t.id.equals(productId)))
+            .write(ProductsCompanion(lastUpdatedAt: Value(parsed)));
+      }
+    }
+  }
+
+  /// Synchronously pushes the pending `domain:pos_record_sale` envelope for
+  /// the given order. Used by the checkout flow when `isOnline = true` to
+  /// surface server-side errors (insufficient_stock, FK/unique violations)
+  /// to the user *before* the receipt prints.
+  ///
+  /// Throws [SaleSyncException] on permanent failure (P0001 / 23xxx).
+  /// Returns silently when:
+  ///   - the queue row is absent (already pushed by background drain), OR
+  ///   - the device is offline (the row stays pending and will drain later), OR
+  ///   - the RPC fails with a transient error (queued for backoff retry).
+  Future<void> flushSale(String orderId) async {
+    if (_supabase.auth.currentUser == null) return;
+    if (!isOnline.value) return;
+    final sessionBusinessId = _db.currentBusinessId;
+    if (sessionBusinessId == null) return;
+
+    final item = await _db.syncDao.findPendingDomainItem(
+      'domain:pos_record_sale',
+      payloadIdPath: r'$.p_order.id',
+      idValue: orderId,
+    );
+    if (item == null) return;
+
+    await _pushDomainItems([item], sessionBusinessId);
+
+    final updated = await _db.syncDao.getQueueItem(item.id);
+    if (updated?.status == 'failed') {
+      throw SaleSyncException(
+        orderId: orderId,
+        errorMessage: updated?.errorMessage ?? 'unknown error',
+      );
     }
   }
 
@@ -665,7 +863,18 @@ class SupabaseSyncService {
   Future<void> _initAutoPush() async {
     try {
       await _db.syncDao.resetStuckInProgress();
-      await _backfillAllUnsyncedTables();
+      // One-shot recovery: re-enqueue rows that were inserted before
+      // their owning DAO method was wired to call `enqueueUpsert` (i.e.
+      // pre-redesign leaks). Drift's NOT-NULL DEFAULT on `last_updated_at`
+      // means new writes are always tagged, so there's nothing to find on
+      // the second-and-beyond app launches. The flag prevents this scan
+      // from running per-launch.
+      final prefs = await SharedPreferences.getInstance();
+      const oneShotKey = 'global_unsynced_backfill_v2_2026Q2';
+      if (prefs.getBool(oneShotKey) != true) {
+        await _backfillAllUnsyncedTables();
+        await prefs.setBool(oneShotKey, true);
+      }
 
       if (_supabase.auth.currentUser != null) {
         await _db.syncDao.clearFailureBackoff();
@@ -850,9 +1059,43 @@ class SupabaseSyncService {
     }
   }
 
+  /// One-shot recovery for categories created before the
+  /// CatalogDao.insertCategory wiring landed. Earlier builds wrote default
+  /// categories straight into Drift without ever enqueueing them, so cloud
+  /// `categories` stayed empty and every product/inventory/stock_* push
+  /// FK-failed against it. Re-enqueue every local category once; the server's
+  /// ON CONFLICT (id) DO UPDATE makes this idempotent. Gated by a one-shot
+  /// SharedPreferences flag so subsequent launches don't re-flood the queue.
+  Future<void> _backfillUnsyncedCategories() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      const flagKey = 'categories_backfill_v1';
+      if (prefs.getBool(flagKey) == true) return;
+
+      final cats = await _db.select(_db.categories).get();
+      if (cats.isEmpty) {
+        await prefs.setBool(flagKey, true);
+        return;
+      }
+
+      var enqueued = 0;
+      for (final c in cats) {
+        await _db.syncDao.enqueueUpsert('categories', c);
+        enqueued++;
+      }
+      await prefs.setBool(flagKey, true);
+      if (enqueued > 0) {
+        debugPrint('[SyncService] Categories backfill: enqueued=$enqueued');
+      }
+    } catch (e) {
+      debugPrint('[SyncService] Categories backfill failed: $e');
+    }
+  }
+
   Future<void> _backfillAllUnsyncedTables() async {
     try {
       await _backfillUnsyncedWarehouses();
+      await _backfillUnsyncedCategories();
       await _backfillTable(_db.products, 'products', (row) => row.id);
       await _backfillTable(_db.categories, 'categories', (row) => row.id);
       await _backfillTable(_db.customers, 'customers', (row) => row.id);

--- a/lib/features/inventory/screens/inventory_screen.dart
+++ b/lib/features/inventory/screens/inventory_screen.dart
@@ -61,12 +61,14 @@ class _InventoryScreenState extends ConsumerState<InventoryScreen>
   bool _isFirstLoad = true;
   late Future<void> _minLoading;
   StreamSubscription<List<ProductDataWithStock>>? _productsSub;
+  StreamSubscription<List<WarehouseData>>? _warehousesSub;
   StreamSubscription<List<ManufacturerData>>? _manufacturersSub;
   StreamSubscription<List<CategoryData>>? _categoriesSub;
   StreamSubscription<List<CrateGroupData>>? _crateGroupsSub;
   StreamSubscription<Map<String, int>>? _bottlesSub;
   StreamSubscription<Map<String, int>>? _emptyCratesSub;
   StreamSubscription<int>? _emptyCratesSumSub;
+  bool _initialWarehouseSelectionDone = false;
   Color get _bg => Theme.of(context).scaffoldBackgroundColor;
   Color get _surface => Theme.of(context).colorScheme.surface;
 
@@ -101,26 +103,32 @@ class _InventoryScreenState extends ConsumerState<InventoryScreen>
       final db = ref.read(databaseProvider);
       final auth = ref.read(authProvider);
 
-      // Determine initial warehouse selection, then start product stream.
-      db.select(db.warehouses).get().then((list) {
+      // Stream warehouses so a remote add/rename/soft-delete on another
+      // device updates the dropdown without a manual refresh. The first
+      // emission also seeds the initial warehouse selection and kicks
+      // off the products subscription.
+      _warehousesSub = db.select(db.warehouses).watch().listen((list) {
         if (!mounted) return;
         setState(() {
           _warehouses = list;
-          final locked = _nav.warehouseLocked.value;
-          final lockedId = _nav.lockedWarehouseId.value;
-          final userTier = auth.currentUser?.roleTier ?? 5;
-          if (locked && lockedId != null && userTier < 4) {
-            _selectedWarehouseId = lockedId.toString();
-          } else {
-            final mainStore = list
-                .where((w) => w.name.toLowerCase().contains('main store'))
-                .firstOrNull;
-            if (mainStore != null) {
-              _selectedWarehouseId = mainStore.id.toString();
+          if (!_initialWarehouseSelectionDone) {
+            _initialWarehouseSelectionDone = true;
+            final locked = _nav.warehouseLocked.value;
+            final lockedId = _nav.lockedWarehouseId.value;
+            final userTier = auth.currentUser?.roleTier ?? 5;
+            if (locked && lockedId != null && userTier < 4) {
+              _selectedWarehouseId = lockedId.toString();
+            } else {
+              final mainStore = list
+                  .where((w) => w.name.toLowerCase().contains('main store'))
+                  .firstOrNull;
+              if (mainStore != null) {
+                _selectedWarehouseId = mainStore.id.toString();
+              }
             }
           }
         });
-        _subscribeToProducts();
+        if (_productsSub == null) _subscribeToProducts();
       });
 
       _manufacturersSub = db.inventoryDao.watchAllManufacturers().listen((
@@ -153,6 +161,7 @@ class _InventoryScreenState extends ConsumerState<InventoryScreen>
   @override
   void dispose() {
     _productsSub?.cancel();
+    _warehousesSub?.cancel();
     _manufacturersSub?.cancel();
     _categoriesSub?.cancel();
     _crateGroupsSub?.cancel();

--- a/lib/features/inventory/widgets/add_product_sheet.dart
+++ b/lib/features/inventory/widgets/add_product_sheet.dart
@@ -101,9 +101,9 @@ class _AddProductSheetState extends ConsumerState<AddProductSheet> {
       final businessId = ref.read(authProvider).currentUser?.businessId;
       if (businessId != null) {
         for (final name in defaultCats) {
-          await db.into(db.categories).insert(
-                CategoriesCompanion.insert(name: name, businessId: businessId),
-              );
+          await db.catalogDao.insertCategory(
+            CategoriesCompanion.insert(name: name, businessId: businessId),
+          );
         }
       }
       cats = await db.select(db.categories).get();
@@ -396,21 +396,13 @@ class _AddProductSheetState extends ConsumerState<AddProductSheet> {
           categoryId: _selectedCategory?.id,
           unit: _unit,
           trackEmpties: _trackEmpties,
-        );
-        await (db.update(
-          db.products,
-        )..where((t) => t.id.equals(productId))).write(
-          ProductsCompanion(
-            subtitle: drift.Value(
-              _subtitleCtrl.text.trim().isEmpty
-                  ? null
-                  : _subtitleCtrl.text.trim(),
-            ),
-            colorHex: drift.Value(_colorHex),
-            supplierId: drift.Value(_selectedSupplier?.id),
-            size: drift.Value(_size),
-            lowStockThreshold: drift.Value(lowStock),
-          ),
+          lowStockThreshold: lowStock,
+          subtitle: _subtitleCtrl.text.trim().isEmpty
+              ? null
+              : _subtitleCtrl.text.trim(),
+          colorHex: _colorHex,
+          supplierId: _selectedSupplier?.id,
+          size: _size,
         );
 
         // 2. Add stock
@@ -550,7 +542,7 @@ class _AddProductSheetState extends ConsumerState<AddProductSheet> {
       final buyingKobo = (buyingPrice * 100).round();
       final lowStock = int.tryParse(_lowStockCtrl.text) ?? 5;
       final initialStock = int.tryParse(_initialStockCtrl.text) ?? 0;
-      final productId = await db.catalogDao.insertProduct(
+      final productId = await db.catalogDao.insertProductWithInitialStock(
         ProductsCompanion.insert(
           name: name,
           businessId: productBusinessId,
@@ -571,17 +563,10 @@ class _AddProductSheetState extends ConsumerState<AddProductSheet> {
           supplierId: drift.Value(_selectedSupplier?.id),
           categoryId: drift.Value(_selectedCategory?.id),
         ),
+        initialStock: initialStock > 0 ? initialStock : null,
+        warehouseId: _selectedWarehouse?.id,
+        performedBy: auth.currentUser?.id,
       );
-
-      if (initialStock > 0 && _selectedWarehouse != null) {
-        await db.inventoryDao.adjustStock(
-          productId,
-          _selectedWarehouse!.id,
-          initialStock,
-          'Initial stock by ${auth.currentUser?.name ?? 'Unknown'}',
-          auth.currentUser?.id,
-        );
-      }
 
       await ref
           .read(activityLogProvider)

--- a/lib/features/inventory/widgets/update_product_sheet.dart
+++ b/lib/features/inventory/widgets/update_product_sheet.dart
@@ -1,5 +1,4 @@
 import 'dart:io';
-import 'package:drift/drift.dart' as drift;
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
@@ -358,7 +357,7 @@ class _UpdateProductSheetState extends ConsumerState<UpdateProductSheet> {
       final buyingKobo = (buyingPrice * 100).round();
       final lowStock = int.tryParse(_lowStockCtrl.text) ?? 5;
 
-      // 1. Update core product fields
+      // 1. Update product (core + cosmetic fields in one enqueue).
       await db.catalogDao.updateProductDetails(
         widget.product.id,
         name: name,
@@ -369,23 +368,13 @@ class _UpdateProductSheetState extends ConsumerState<UpdateProductSheet> {
         unit: _unit,
         trackEmpties: _trackEmpties,
         imagePath: _imagePath,
-      );
-
-      // 2. Update remaining fields (subtitle, color, size, supplier, lowStockThreshold)
-      await (db.update(
-        db.products,
-      )..where((t) => t.id.equals(widget.product.id))).write(
-        ProductsCompanion(
-          subtitle: drift.Value(
-            _subtitleCtrl.text.trim().isEmpty
-                ? null
-                : _subtitleCtrl.text.trim(),
-          ),
-          colorHex: drift.Value(_colorHex),
-          supplierId: drift.Value(_selectedSupplier?.id),
-          size: drift.Value(_size),
-          lowStockThreshold: drift.Value(lowStock),
-        ),
+        lowStockThreshold: lowStock,
+        subtitle: _subtitleCtrl.text.trim().isEmpty
+            ? null
+            : _subtitleCtrl.text.trim(),
+        colorHex: _colorHex,
+        supplierId: _selectedSupplier?.id,
+        size: _size,
       );
 
       // 3. Add stock if quantity entered

--- a/lib/features/pos/controllers/pos_controller.dart
+++ b/lib/features/pos/controllers/pos_controller.dart
@@ -23,6 +23,8 @@ class PosController extends ChangeNotifier {
   bool isLoading = true;
   bool _disposed = false;
   StreamSubscription? _productsSub;
+  StreamSubscription<List<CategoryData>>? _categoriesSub;
+  StreamSubscription<List<ManufacturerData>>? _manufacturersSub;
   Timer? _debounce;
 
   PosController({
@@ -47,22 +49,31 @@ class PosController extends ChangeNotifier {
   void dispose() {
     _disposed = true;
     _productsSub?.cancel();
+    _categoriesSub?.cancel();
+    _manufacturersSub?.cancel();
     _debounce?.cancel();
     _cartService.activeCustomer.removeListener(_onCustomerSelected);
     _navigationService.lockedWarehouseId.removeListener(_subscribeToProducts);
     super.dispose();
   }
 
-  Future<void> _loadCategories() async {
-    categories = await _database.select(_database.categories).get();
-    if (_disposed) return;
-    notifyListeners();
+  void _loadCategories() {
+    // Stream-based: a remote add/rename of a category propagates to the
+    // POS chip row without needing a screen rebuild.
+    _categoriesSub = _database.inventoryDao.watchAllCategories().listen((list) {
+      if (_disposed) return;
+      categories = list;
+      notifyListeners();
+    });
   }
 
-  Future<void> _loadManufacturers() async {
-    manufacturers = await _database.catalogDao.getAllManufacturers();
-    if (_disposed) return;
-    notifyListeners();
+  void _loadManufacturers() {
+    _manufacturersSub =
+        _database.inventoryDao.watchAllManufacturers().listen((list) {
+      if (_disposed) return;
+      manufacturers = list;
+      notifyListeners();
+    });
   }
 
   void _subscribeToProducts() {

--- a/lib/features/pos/screens/checkout_page.dart
+++ b/lib/features/pos/screens/checkout_page.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 import 'dart:typed_data';
 
@@ -66,6 +67,8 @@ class _CheckoutPageState extends ConsumerState<CheckoutPage> {
   bool _isProcessing = false;
   Map<String, String> _manufacturerNames = {};
   String? _branchName;
+  StreamSubscription<List<ManufacturerData>>? _manufacturersSub;
+  StreamSubscription<WarehouseData?>? _activeWarehouseSub;
   late final Customer? _initialCustomer;
 
   // Computed on confirm — passed to receipt
@@ -113,23 +116,24 @@ class _CheckoutPageState extends ConsumerState<CheckoutPage> {
     final warehouseId =
         nav.lockedWarehouseId.value ?? auth.currentUser?.warehouseId;
 
-    final results = await Future.wait([
-      db.inventoryDao.getAllManufacturers(),
-      if (warehouseId != null)
-        (db.select(
-          db.warehouses,
-        )..where((t) => t.id.equals(warehouseId))).getSingleOrNull(),
-    ]);
-
-    final list = results[0] as List<ManufacturerData>;
-    final activeWarehouse = results.length > 1
-        ? results[1] as WarehouseData?
-        : null;
-
-    if (mounted) {
+    // Stream-driven so a remote rename of the active warehouse or a new
+    // manufacturer arriving via realtime updates the receipt header / map
+    // without a manual refresh.
+    _manufacturersSub = db.inventoryDao.watchAllManufacturers().listen((list) {
+      if (!mounted) return;
       setState(() {
         _manufacturerNames = {for (final m in list) m.id: m.name};
-        _branchName = activeWarehouse?.name;
+      });
+    });
+
+    if (warehouseId != null) {
+      _activeWarehouseSub = (db.select(db.warehouses)
+            ..where((t) => t.id.equals(warehouseId))
+            ..limit(1))
+          .watchSingleOrNull()
+          .listen((w) {
+        if (!mounted) return;
+        setState(() => _branchName = w?.name);
       });
     }
   }
@@ -138,6 +142,8 @@ class _CheckoutPageState extends ConsumerState<CheckoutPage> {
   void dispose() {
     _cart.activeCustomer.removeListener(_onCustomerChanged);
     _cashReceivedCtrl.dispose();
+    _manufacturersSub?.cancel();
+    _activeWarehouseSub?.cancel();
     super.dispose();
   }
 

--- a/lib/features/pos/screens/pos_home_screen.dart
+++ b/lib/features/pos/screens/pos_home_screen.dart
@@ -55,8 +55,12 @@ class _PosHomeScreenState extends ConsumerState<PosHomeScreen> {
     final user = ref.read(authProvider).currentUser;
     if (user != null && user.roleTier >= 5) {
       if (ref.read(navigationProvider).lockedWarehouseId.value == null) {
+        // Stream-based first read: yields as soon as the warehouses table
+        // has at least one row, including after a fresh-login pull. The
+        // earlier one-shot `.get()` returned [] on a cold start and left
+        // the warehouse unlocked.
         final db = ref.read(databaseProvider);
-        final houses = await db.select(db.warehouses).get();
+        final houses = await db.select(db.warehouses).watch().first;
         if (houses.isNotEmpty && mounted) {
           ref.read(navigationProvider).setLockedWarehouse(houses.first.id);
         }

--- a/lib/features/staff/screens/staff_screen.dart
+++ b/lib/features/staff/screens/staff_screen.dart
@@ -875,17 +875,19 @@ class _StaffFormSheetState extends ConsumerState<_StaffFormSheet> {
     } else {
       // Update existing staff member
       final db = ref.read(databaseProvider);
+      final userComp = UsersCompanion(
+        id: Value(widget.user!.id),
+        name: Value(name),
+        email: Value(email),
+        role: Value(role),
+        roleTier: Value(tier),
+        warehouseId: Value(_selectedWarehouseId),
+        lastUpdatedAt: Value(DateTime.now()),
+      );
       await (db.update(
         db.users,
-      )..where((u) => u.id.equals(widget.user!.id))).write(
-        UsersCompanion(
-          name: Value(name),
-          email: Value(email),
-          role: Value(role),
-          roleTier: Value(tier),
-          warehouseId: Value(_selectedWarehouseId),
-        ),
-      );
+      )..where((u) => u.id.equals(widget.user!.id))).write(userComp);
+      await db.syncDao.enqueueUpsert('users', userComp);
       // PIN goes through the canonical hash-and-write path so it is never
       // persisted in cleartext.
       await ref.read(authProvider).setUserPin(widget.user!.id, pin);

--- a/lib/features/warehouse/screens/warehouse_screen.dart
+++ b/lib/features/warehouse/screens/warehouse_screen.dart
@@ -15,6 +15,7 @@ import 'package:reebaplus_pos/shared/widgets/app_input.dart';
 import 'package:reebaplus_pos/core/theme/design_tokens.dart';
 import 'package:reebaplus_pos/core/utils/responsive.dart';
 import 'package:reebaplus_pos/core/database/app_database.dart';
+import 'package:reebaplus_pos/core/database/uuid_v7.dart';
 import 'package:reebaplus_pos/core/utils/notifications.dart';
 import 'package:reebaplus_pos/features/warehouse/screens/warehouse_details_screen.dart';
 
@@ -196,15 +197,16 @@ class _WarehouseScreenState extends ConsumerState<WarehouseScreen> {
                                 final whBusinessId =
                                     ref.read(authProvider).currentUser?.businessId;
                                 if (whBusinessId == null) return;
-                                await db
-                                    .into(db.warehouses)
-                                    .insert(
-                                      WarehousesCompanion.insert(
-                                        name: nameCtrl.text.trim(),
-                                        businessId: whBusinessId,
-                                        location: Value(combinedLocation),
-                                      ),
-                                    );
+                                final whComp = WarehousesCompanion.insert(
+                                  id: Value(UuidV7.generate()),
+                                  name: nameCtrl.text.trim(),
+                                  businessId: whBusinessId,
+                                  location: Value(combinedLocation),
+                                  lastUpdatedAt: Value(DateTime.now()),
+                                );
+                                await db.into(db.warehouses).insert(whComp);
+                                await db.syncDao
+                                    .enqueueUpsert('warehouses', whComp);
                                 if (ctx.mounted) Navigator.pop(ctx);
                               } catch (e) {
                                 setSheet(() => saving = false);
@@ -366,14 +368,18 @@ class _WarehouseScreenState extends ConsumerState<WarehouseScreen> {
                               final combinedLocation =
                                   '${addressCtrl.text.trim()}, ${cityStateCtrl.text.trim()}, ${countryCtrl.text.trim()}';
 
+                              final whComp = WarehousesCompanion(
+                                id: Value(warehouse.id),
+                                name: Value(nameCtrl.text.trim()),
+                                location: Value(combinedLocation),
+                                lastUpdatedAt: Value(DateTime.now()),
+                              );
                               await (db.update(
                                 db.warehouses,
-                              )..where((t) => t.id.equals(warehouse.id))).write(
-                                WarehousesCompanion(
-                                  name: Value(nameCtrl.text.trim()),
-                                  location: Value(combinedLocation),
-                                ),
-                              );
+                              )..where((t) => t.id.equals(warehouse.id)))
+                                  .write(whComp);
+                              await db.syncDao
+                                  .enqueueUpsert('warehouses', whComp);
                               if (ctx.mounted) Navigator.pop(ctx);
                             },
                     ),
@@ -471,14 +477,21 @@ class _WarehouseScreenState extends ConsumerState<WarehouseScreen> {
             size: AppButtonSize.small,
             onPressed: () async {
               Navigator.pop(ctx);
-              // Delete inventory first (FK), then warehouse
+              // Soft-delete the warehouse: hard-delete would orphan
+              // inventory and ledger FKs. The cloud-side cascade in 0001
+              // is ON DELETE CASCADE for inventory, but realtime DELETE
+              // events confuse local listeners. Soft-delete + enqueue is
+              // the consistent path with the rest of the codebase.
               final db = ref.read(databaseProvider);
-              await (db.delete(
-                db.inventory,
-              )..where((t) => t.warehouseId.equals(warehouse.id))).go();
-              await (db.delete(
-                db.warehouses,
-              )..where((t) => t.id.equals(warehouse.id))).go();
+              final whComp = WarehousesCompanion(
+                id: Value(warehouse.id),
+                isDeleted: const Value(true),
+                lastUpdatedAt: Value(DateTime.now()),
+              );
+              await (db.update(db.warehouses)
+                    ..where((t) => t.id.equals(warehouse.id)))
+                  .write(whComp);
+              await db.syncDao.enqueueUpsert('warehouses', whComp);
             },
           ),
         ],

--- a/lib/shared/services/crate_return_approval_service.dart
+++ b/lib/shared/services/crate_return_approval_service.dart
@@ -22,35 +22,44 @@ class CrateReturnApprovalService {
     }
 
     await db.transaction(() async {
-      // 1. Update pending_crate_returns row
-      await db.pendingCrateReturnsDao.updateStatus(returnId, 'approved');
-      await (db.update(db.pendingCrateReturns)..where((t) => t.id.equals(returnId)))
-          .write(
-        PendingCrateReturnsCompanion(
-          approvedBy: Value(approvedBy),
-          approvedAt: Value(DateTime.now()),
-        ),
+      // 1. Update pending_crate_returns row (status + approval metadata in
+      //    one combined Companion so a single enqueue carries the whole
+      //    transition to the cloud).
+      final now = DateTime.now();
+      final pcrComp = PendingCrateReturnsCompanion(
+        id: Value(returnId),
+        status: const Value('approved'),
+        approvedBy: Value(approvedBy),
+        approvedAt: Value(now),
+        lastUpdatedAt: Value(now),
       );
+      await (db.update(db.pendingCrateReturns)
+            ..where((t) => t.id.equals(returnId)))
+          .write(pcrComp);
+      await db.syncDao.enqueueUpsert('pending_crate_returns', pcrComp);
 
-      // 2. Append crate_ledger row
+      // 2. Append crate_ledger row (append-only).
       // quantityDelta must be negative (customer returning crates reduces their balance)
       final delta = -pending.quantity;
 
-      await db.into(db.crateLedger).insert(
-            CrateLedgerCompanion.insert(
-              id: Value(UuidV7.generate()),
-              businessId: pending.businessId,
-              customerId: Value(pending.customerId),
-              manufacturerId: const Value.absent(), // CHECK constraint requires exactly one
-              crateGroupId: pending.crateGroupId,
-              quantityDelta: delta,
-              movementType: 'returned',
-              referenceReturnId: Value(returnId),
-              performedBy: Value(approvedBy),
-            ),
-          );
+      final ledgerComp = CrateLedgerCompanion.insert(
+        id: Value(UuidV7.generate()),
+        businessId: pending.businessId,
+        customerId: Value(pending.customerId),
+        manufacturerId:
+            const Value.absent(), // CHECK constraint requires exactly one
+        crateGroupId: pending.crateGroupId,
+        quantityDelta: delta,
+        movementType: 'returned',
+        referenceReturnId: Value(returnId),
+        performedBy: Value(approvedBy),
+        lastUpdatedAt: Value(now),
+      );
+      await db.into(db.crateLedger).insert(ledgerComp);
+      await db.syncDao.enqueueUpsert('crate_ledger', ledgerComp);
 
-      // 3. Update customer_crate_balances cache via upsert
+      // 3. Update customer_crate_balances cache via upsert + enqueue the
+      //    resulting row so the cloud cache converges.
       await db.customStatement(
         'INSERT INTO customer_crate_balances (id, business_id, customer_id, crate_group_id, balance) '
         'VALUES (?, ?, ?, ?, ?) '
@@ -64,6 +73,13 @@ class CrateReturnApprovalService {
           delta
         ],
       );
+      final balRow = await (db.select(db.customerCrateBalances)
+            ..where((t) =>
+                t.businessId.equals(pending.businessId) &
+                t.customerId.equals(pending.customerId) &
+                t.crateGroupId.equals(pending.crateGroupId)))
+          .getSingle();
+      await db.syncDao.enqueueUpsert('customer_crate_balances', balRow);
     });
   }
 
@@ -79,15 +95,19 @@ class CrateReturnApprovalService {
     }
 
     await db.transaction(() async {
-      await db.pendingCrateReturnsDao.updateStatus(returnId, 'rejected');
-      await (db.update(db.pendingCrateReturns)..where((t) => t.id.equals(returnId)))
-          .write(
-        PendingCrateReturnsCompanion(
-          approvedBy: Value(approvedBy),
-          approvedAt: Value(DateTime.now()),
-          rejectionReason: Value(rejectionReason),
-        ),
+      final now = DateTime.now();
+      final pcrComp = PendingCrateReturnsCompanion(
+        id: Value(returnId),
+        status: const Value('rejected'),
+        approvedBy: Value(approvedBy),
+        approvedAt: Value(now),
+        rejectionReason: Value(rejectionReason),
+        lastUpdatedAt: Value(now),
       );
+      await (db.update(db.pendingCrateReturns)
+            ..where((t) => t.id.equals(returnId)))
+          .write(pcrComp);
+      await db.syncDao.enqueueUpsert('pending_crate_returns', pcrComp);
     });
   }
 }

--- a/lib/shared/services/order_service.dart
+++ b/lib/shared/services/order_service.dart
@@ -1,15 +1,18 @@
 import 'dart:convert';
 
-import 'package:drift/drift.dart' show Value;
+import 'package:drift/drift.dart' show Value, Variable;
+import 'package:flutter/foundation.dart';
 import 'package:reebaplus_pos/core/database/app_database.dart';
 import 'package:reebaplus_pos/core/database/uuid_v7.dart';
+import 'package:reebaplus_pos/core/services/supabase_sync_service.dart';
 import 'package:reebaplus_pos/shared/models/order.dart' as domain;
 
 class OrderService {
   final AppDatabase _db;
+  final SupabaseSyncService? _syncService;
   late final OrdersDao _ordersDao = _db.ordersDao;
 
-  OrderService(this._db);
+  OrderService(this._db, [this._syncService]);
 
   /// Build an order from a UI cart and persist it atomically.
   ///
@@ -89,7 +92,76 @@ class OrderService {
       paymentMethod: _resolvePaymentMethod(paymentSubType),
     );
 
+    // Surface server-side errors (insufficient_stock from a concurrent
+    // device, FK / unique violations) BEFORE the receipt prints. flushSale
+    // is a no-op when offline, when the queue row is absent (already
+    // drained by background push), or when the sale was enqueued under
+    // the legacy multi-row path. On permanent failure we compensate
+    // locally — cancel the order, refund the inventory cache — so the
+    // device's view stays consistent with the cloud's "this sale never
+    // happened".
+    if (_syncService != null && _syncService.isOnline.value) {
+      try {
+        await _syncService.flushSale(orderId);
+      } on SaleSyncException catch (e) {
+        debugPrint('[OrderService] Sale rejected by server: $e');
+        await _compensateRejectedSale(orderId, items);
+        rethrow;
+      } catch (e) {
+        // Transient error — the queue row stays pending and the
+        // background drain will retry. Don't block the receipt.
+        debugPrint('[OrderService] flushSale transient: $e');
+      }
+    }
+
     return orderNumber;
+  }
+
+  /// Reverses the local writes performed by `OrdersDao.createOrder` when
+  /// the server's `pos_record_sale` RPC permanently rejected the sale
+  /// (e.g. insufficient_stock from a concurrent device). The cloud never
+  /// saw any of this — the RPC rolled back its own transaction — so the
+  /// compensation is purely local: we don't enqueue it. The original
+  /// `domain:pos_record_sale` queue row was already marked failed by
+  /// SyncService.
+  Future<void> _compensateRejectedSale(
+    String orderId,
+    List<OrderItemsCompanion> items,
+  ) async {
+    await _db.transaction(() async {
+      // 1. Mark order cancelled.
+      await (_db.update(_db.orders)
+            ..where((t) => t.id.equals(orderId)))
+          .write(OrdersCompanion(
+        status: const Value('cancelled'),
+        cancellationReason: const Value('rejected_by_server'),
+        cancelledAt: Value(DateTime.now().toUtc()),
+        lastUpdatedAt: Value(DateTime.now()),
+      ));
+
+      // 2. Refund inventory cache. Each item's optimistic deduction is
+      // undone by adding the quantity back. The corresponding
+      // stock_transactions ledger rows are append-only — we leave them
+      // in place; they're orphaned but harmless because the cloud's
+      // ledger never received them either.
+      for (final item in items) {
+        final qty = item.quantity.value;
+        final productId = item.productId.value;
+        final whId = item.warehouseId.value;
+        await _db.customUpdate(
+          'UPDATE inventory SET quantity = quantity + ?, last_updated_at = ? '
+          'WHERE business_id = ? AND product_id = ? AND warehouse_id = ?',
+          variables: [
+            Variable<int>(qty),
+            Variable<DateTime>(DateTime.now()),
+            Variable<String>(_ordersDao.requireBusinessId()),
+            Variable<String>(productId),
+            Variable<String>(whId),
+          ],
+          updates: {_db.inventory},
+        );
+      }
+    });
   }
 
   String _resolvePaymentType({

--- a/lib/shared/services/wallet_service.dart
+++ b/lib/shared/services/wallet_service.dart
@@ -28,33 +28,37 @@ class WalletService {
 
     await _db.transaction(() async {
       final walletTxnId = UuidV7.generate();
+      final paymentTxnId = UuidV7.generate();
 
       // 1. Insert WalletTransactions row
-      await _db.into(_db.walletTransactions).insert(
-        WalletTransactionsCompanion.insert(
-          id: Value(walletTxnId),
-          businessId: businessId,
-          walletId: wallet.id,
-          customerId: customerId,
-          type: 'credit',
-          amountKobo: amountKobo,
-          signedAmountKobo: amountKobo,
-          referenceType: method == 'cash' ? 'topup_cash' : 'topup_transfer',
-          performedBy: Value(staffId),
-        ),
+      final walletComp = WalletTransactionsCompanion.insert(
+        id: Value(walletTxnId),
+        businessId: businessId,
+        walletId: wallet.id,
+        customerId: customerId,
+        type: 'credit',
+        amountKobo: amountKobo,
+        signedAmountKobo: amountKobo,
+        referenceType: method == 'cash' ? 'topup_cash' : 'topup_transfer',
+        performedBy: Value(staffId),
+        lastUpdatedAt: Value(DateTime.now()),
       );
+      await _db.into(_db.walletTransactions).insert(walletComp);
+      await _db.syncDao.enqueueUpsert('wallet_transactions', walletComp);
 
       // 2. Insert PaymentTransactions row
-      await _db.into(_db.paymentTransactions).insert(
-        PaymentTransactionsCompanion.insert(
-          businessId: businessId,
-          amountKobo: amountKobo,
-          method: method,
-          type: 'wallet_topup',
-          walletTxnId: Value(walletTxnId),
-          performedBy: Value(staffId),
-        ),
+      final paymentComp = PaymentTransactionsCompanion.insert(
+        id: Value(paymentTxnId),
+        businessId: businessId,
+        amountKobo: amountKobo,
+        method: method,
+        type: 'wallet_topup',
+        walletTxnId: Value(walletTxnId),
+        performedBy: Value(staffId),
+        lastUpdatedAt: Value(DateTime.now()),
       );
+      await _db.into(_db.paymentTransactions).insert(paymentComp);
+      await _db.syncDao.enqueueUpsert('payment_transactions', paymentComp);
     });
   }
 
@@ -80,19 +84,22 @@ class WalletService {
 
     if (originalDebit == null) return;
 
-    await _db.into(_db.walletTransactions).insert(
-      WalletTransactionsCompanion.insert(
-        businessId: businessId,
-        walletId: originalDebit.walletId,
-        customerId: originalDebit.customerId,
-        type: 'credit',
-        amountKobo: originalDebit.amountKobo,
-        signedAmountKobo: originalDebit.amountKobo,
-        referenceType: 'refund',
-        orderId: Value(orderId),
-        performedBy: Value(staffId),
-      ),
+    final refundId = UuidV7.generate();
+    final refundComp = WalletTransactionsCompanion.insert(
+      id: Value(refundId),
+      businessId: businessId,
+      walletId: originalDebit.walletId,
+      customerId: originalDebit.customerId,
+      type: 'credit',
+      amountKobo: originalDebit.amountKobo,
+      signedAmountKobo: originalDebit.amountKobo,
+      referenceType: 'refund',
+      orderId: Value(orderId),
+      performedBy: Value(staffId),
+      lastUpdatedAt: Value(DateTime.now()),
     );
+    await _db.into(_db.walletTransactions).insert(refundComp);
+    await _db.syncDao.enqueueUpsert('wallet_transactions', refundComp);
   }
 
   /// Calculates the current balance for a customer.

--- a/supabase/migrations/0006_domain_rpcs.sql
+++ b/supabase/migrations/0006_domain_rpcs.sql
@@ -1,0 +1,562 @@
+-- =============================================================================
+-- 0006_domain_rpcs.sql — Atomic domain RPCs that collapse multi-table sync
+-- traffic into one server-side transaction per business action.
+--
+-- Background: the client outbox (sync_queue) currently emits one row per
+-- table touched by a single business action. A 3-item cash sale produces
+-- ~11 outbox rows (1 order + 3 items + 3 inventory + 3 stock_transactions +
+-- 1 payment_transaction + optional 1 wallet_transaction), each pushed
+-- separately via PostgREST. The new RPCs let the client enqueue ONE
+-- domain envelope (action_type 'domain:pos_record_sale' etc.) which is
+-- pushed via _supabase.rpc(...) and applied atomically.
+--
+-- Why server-side atomic for inventory: with client-LWW on absolute
+-- quantity, two devices selling the same product simultaneously each
+-- compute (qty - units_sold) locally and the cloud upsert keeps the later
+-- write — silently overwriting one of the decrements. The new RPC sends
+-- the *delta* and the server runs UPDATE inventory SET quantity =
+-- quantity + delta WHERE quantity + delta >= 0 RETURNING. Postgres takes
+-- a row-level lock on the matched row so concurrent calls serialize; the
+-- second one either succeeds with a smaller-but-correct quantity or
+-- raises P0001 'insufficient_stock' and the whole RPC rolls back.
+--
+-- Idempotency under retry: every row carries a client-generated UUIDv7,
+-- and every INSERT uses ON CONFLICT (id) DO NOTHING. Append-only ledger
+-- triggers (0001_initial.sql:876-903) fire only on UPDATE/DELETE so DO
+-- NOTHING is safe. The orders insert uses ON CONFLICT (id) DO NOTHING
+-- inside a CTE so a retry after a network blip is detected as "order
+-- already exists" and the function returns existing state without
+-- reapplying the inventory deltas.
+--
+-- SECURITY DEFINER + manual tenant guard: matches the pattern of
+-- pos_pull_snapshot in 0005_sync_rpcs.sql. Functions run as the function
+-- owner and bypass RLS; the explicit business_id() check is what
+-- enforces tenant isolation.
+-- =============================================================================
+
+
+-- -----------------------------------------------------------------------------
+-- 1. pos_record_sale — single-transaction checkout.
+-- -----------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.pos_record_sale(
+  p_business_id     uuid,
+  p_order           jsonb,
+  p_items           jsonb,            -- JSON array of order_items rows
+  p_stock_movements jsonb,            -- JSON array: {id, product_id, location_id, quantity_delta (negative), order_id?, performed_by?}
+  p_payment         jsonb DEFAULT NULL,  -- single payment_transactions row, optional
+  p_wallet_tx       jsonb DEFAULT NULL   -- single wallet_transactions row, optional
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+DECLARE
+  v_caller_business uuid;
+  v_order_id        uuid;
+  v_is_new_sale     boolean := false;
+  v_order_lua       timestamptz;
+  v_mv              jsonb;
+  v_new_qty         int;
+  v_inv_after       jsonb := '[]'::jsonb;
+  v_stx_ids         jsonb := '[]'::jsonb;
+  v_payment_id      uuid;
+  v_wallet_tx_id    uuid;
+BEGIN
+  -- Tenant guard
+  v_caller_business := public.business_id();
+  IF v_caller_business IS NULL THEN
+    RAISE EXCEPTION 'no_business_for_caller' USING ERRCODE = 'insufficient_privilege';
+  END IF;
+  IF v_caller_business <> p_business_id THEN
+    RAISE EXCEPTION 'tenant_mismatch' USING ERRCODE = 'insufficient_privilege';
+  END IF;
+  IF (p_order->>'business_id')::uuid <> p_business_id THEN
+    RAISE EXCEPTION 'order_business_id_mismatch' USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  v_order_id := (p_order->>'id')::uuid;
+  IF v_order_id IS NULL THEN
+    RAISE EXCEPTION 'order_id_required' USING ERRCODE = 'invalid_parameter_value';
+  END IF;
+
+  -- Idempotent order insert. ON CONFLICT DO NOTHING + CTE detects whether
+  -- this is a fresh sale or a retry of a previously-applied one.
+  WITH ins AS (
+    INSERT INTO public.orders
+    SELECT (jsonb_populate_record(NULL::public.orders, p_order)).*
+    ON CONFLICT (id) DO NOTHING
+    RETURNING id
+  )
+  SELECT COUNT(*) > 0 INTO v_is_new_sale FROM ins;
+
+  IF NOT v_is_new_sale THEN
+    -- Retry of an already-applied sale. Compose response from existing state
+    -- and return without re-running the inventory deltas.
+    SELECT last_updated_at INTO v_order_lua FROM public.orders WHERE id = v_order_id;
+
+    SELECT COALESCE(jsonb_agg(jsonb_build_object(
+             'product_id',      i.product_id,
+             'warehouse_id',    i.warehouse_id,
+             'quantity',        i.quantity,
+             'last_updated_at', i.last_updated_at)), '[]'::jsonb)
+      INTO v_inv_after
+      FROM public.inventory i
+      JOIN jsonb_array_elements(p_stock_movements) AS m ON
+           i.product_id   = (m->>'product_id')::uuid
+       AND i.warehouse_id = (m->>'location_id')::uuid
+     WHERE i.business_id = p_business_id;
+
+    RETURN jsonb_build_object(
+      'order_id',              v_order_id,
+      'order_last_updated_at', v_order_lua,
+      'inventory_after',       v_inv_after,
+      'stock_transaction_ids', v_stx_ids,
+      'payment_transaction_id', NULL,
+      'wallet_transaction_id',  NULL,
+      'replayed',              true
+    );
+  END IF;
+
+  -- Items (append-only from the client's perspective)
+  INSERT INTO public.order_items
+  SELECT (jsonb_populate_record(NULL::public.order_items, item)).*
+    FROM jsonb_array_elements(p_items) AS item
+  ON CONFLICT (id) DO NOTHING;
+
+  -- Atomic inventory deltas. Per movement: row-locked UPDATE that fails if
+  -- the resulting quantity would go negative.
+  FOR v_mv IN SELECT * FROM jsonb_array_elements(p_stock_movements) LOOP
+    IF (v_mv->>'business_id') IS NOT NULL
+       AND (v_mv->>'business_id')::uuid <> p_business_id THEN
+      RAISE EXCEPTION 'movement_business_id_mismatch' USING ERRCODE = 'insufficient_privilege';
+    END IF;
+    IF (v_mv->>'quantity_delta')::int >= 0 THEN
+      RAISE EXCEPTION 'sale_movement_must_be_negative_delta'
+        USING ERRCODE = 'invalid_parameter_value';
+    END IF;
+
+    UPDATE public.inventory
+       SET quantity = quantity + (v_mv->>'quantity_delta')::int
+     WHERE business_id  = p_business_id
+       AND product_id   = (v_mv->>'product_id')::uuid
+       AND warehouse_id = (v_mv->>'location_id')::uuid
+       AND quantity + (v_mv->>'quantity_delta')::int >= 0
+    RETURNING quantity INTO v_new_qty;
+
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'insufficient_stock'
+        USING ERRCODE = 'P0001',
+              DETAIL  = format('product_id=%s warehouse_id=%s requested_delta=%s',
+                               v_mv->>'product_id',
+                               v_mv->>'location_id',
+                               v_mv->>'quantity_delta'),
+              HINT    = jsonb_build_object(
+                          'product_id',   v_mv->>'product_id',
+                          'warehouse_id', v_mv->>'location_id',
+                          'requested_delta', (v_mv->>'quantity_delta')::int
+                        )::text;
+    END IF;
+
+    v_inv_after := v_inv_after || jsonb_build_object(
+      'product_id',      (v_mv->>'product_id')::uuid,
+      'warehouse_id',    (v_mv->>'location_id')::uuid,
+      'quantity',        v_new_qty,
+      'last_updated_at', now()
+    );
+  END LOOP;
+
+  -- Stock transaction ledger rows (append-only; trigger forbids UPDATE on
+  -- non-void columns but we never UPDATE these).
+  INSERT INTO public.stock_transactions
+  SELECT (jsonb_populate_record(NULL::public.stock_transactions,
+            mv || jsonb_build_object('order_id', v_order_id))).*
+    FROM jsonb_array_elements(p_stock_movements) AS mv
+  ON CONFLICT (id) DO NOTHING;
+
+  SELECT COALESCE(jsonb_agg((mv->>'id')::uuid), '[]'::jsonb)
+    INTO v_stx_ids
+    FROM jsonb_array_elements(p_stock_movements) AS mv;
+
+  -- Payment transaction (optional)
+  IF p_payment IS NOT NULL THEN
+    IF (p_payment->>'business_id')::uuid <> p_business_id THEN
+      RAISE EXCEPTION 'payment_business_id_mismatch' USING ERRCODE = 'insufficient_privilege';
+    END IF;
+    INSERT INTO public.payment_transactions
+    SELECT (jsonb_populate_record(NULL::public.payment_transactions, p_payment)).*
+    ON CONFLICT (id) DO NOTHING;
+    v_payment_id := (p_payment->>'id')::uuid;
+  END IF;
+
+  -- Wallet transaction (optional)
+  IF p_wallet_tx IS NOT NULL THEN
+    IF (p_wallet_tx->>'business_id')::uuid <> p_business_id THEN
+      RAISE EXCEPTION 'wallet_tx_business_id_mismatch' USING ERRCODE = 'insufficient_privilege';
+    END IF;
+    INSERT INTO public.wallet_transactions
+    SELECT (jsonb_populate_record(NULL::public.wallet_transactions, p_wallet_tx)).*
+    ON CONFLICT (id) DO NOTHING;
+    v_wallet_tx_id := (p_wallet_tx->>'id')::uuid;
+  END IF;
+
+  SELECT last_updated_at INTO v_order_lua FROM public.orders WHERE id = v_order_id;
+
+  RETURN jsonb_build_object(
+    'order_id',              v_order_id,
+    'order_last_updated_at', v_order_lua,
+    'inventory_after',       v_inv_after,
+    'stock_transaction_ids', v_stx_ids,
+    'payment_transaction_id', v_payment_id,
+    'wallet_transaction_id',  v_wallet_tx_id,
+    'replayed',              false
+  );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.pos_record_sale(uuid, jsonb, jsonb, jsonb, jsonb, jsonb) FROM public;
+GRANT EXECUTE ON FUNCTION public.pos_record_sale(uuid, jsonb, jsonb, jsonb, jsonb, jsonb)
+  TO authenticated, service_role;
+
+
+-- -----------------------------------------------------------------------------
+-- 2. pos_inventory_delta — batch atomic deltas for non-sale movements.
+-- -----------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.pos_inventory_delta(
+  p_business_id uuid,
+  p_movements   jsonb       -- JSON array: {id, product_id, warehouse_id, quantity_delta, movement_type, ref_type, ref_id?, performed_by?}
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+DECLARE
+  v_caller_business uuid;
+  v_mv              jsonb;
+  v_new_qty         int;
+  v_inv_after       jsonb := '[]'::jsonb;
+  v_stx_ids         jsonb := '[]'::jsonb;
+  v_movement_type   text;
+  v_ref_type        text;
+  v_ref_id          uuid;
+BEGIN
+  v_caller_business := public.business_id();
+  IF v_caller_business IS NULL THEN
+    RAISE EXCEPTION 'no_business_for_caller' USING ERRCODE = 'insufficient_privilege';
+  END IF;
+  IF v_caller_business <> p_business_id THEN
+    RAISE EXCEPTION 'tenant_mismatch' USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  FOR v_mv IN SELECT * FROM jsonb_array_elements(p_movements) LOOP
+    v_movement_type := v_mv->>'movement_type';
+    v_ref_type      := v_mv->>'ref_type';
+    v_ref_id        := NULLIF(v_mv->>'ref_id', '')::uuid;
+
+    -- Sales must go through pos_record_sale; that path applies the order
+    -- write atomically with the deltas. Allowing a 'sale' here would skip
+    -- the order/items/payment writes.
+    IF v_movement_type = 'sale' THEN
+      RAISE EXCEPTION 'sale_must_use_pos_record_sale'
+        USING ERRCODE = 'invalid_parameter_value';
+    END IF;
+    IF v_movement_type NOT IN ('return','damage','transfer_out','transfer_in','purchase_received','adjustment') THEN
+      RAISE EXCEPTION 'invalid_movement_type: %', v_movement_type
+        USING ERRCODE = 'invalid_parameter_value';
+    END IF;
+
+    -- Apply delta. Negative deltas use the locked-update guard. Non-negative
+    -- deltas upsert (the row may not yet exist for first-time stock-in).
+    IF (v_mv->>'quantity_delta')::int < 0 THEN
+      UPDATE public.inventory
+         SET quantity = quantity + (v_mv->>'quantity_delta')::int
+       WHERE business_id  = p_business_id
+         AND product_id   = (v_mv->>'product_id')::uuid
+         AND warehouse_id = (v_mv->>'warehouse_id')::uuid
+         AND quantity + (v_mv->>'quantity_delta')::int >= 0
+      RETURNING quantity INTO v_new_qty;
+
+      IF NOT FOUND THEN
+        RAISE EXCEPTION 'insufficient_stock'
+          USING ERRCODE = 'P0001',
+                HINT = jsonb_build_object(
+                  'product_id',      v_mv->>'product_id',
+                  'warehouse_id',    v_mv->>'warehouse_id',
+                  'requested_delta', (v_mv->>'quantity_delta')::int
+                )::text;
+      END IF;
+    ELSE
+      INSERT INTO public.inventory (id, business_id, product_id, warehouse_id, quantity)
+      VALUES (
+        gen_random_uuid(),
+        p_business_id,
+        (v_mv->>'product_id')::uuid,
+        (v_mv->>'warehouse_id')::uuid,
+        (v_mv->>'quantity_delta')::int
+      )
+      ON CONFLICT (business_id, product_id, warehouse_id)
+        DO UPDATE SET quantity = public.inventory.quantity + EXCLUDED.quantity
+      RETURNING quantity INTO v_new_qty;
+    END IF;
+
+    -- Insert ledger row. The CHECK at 0001_initial.sql:529-534 requires
+    -- exactly one parent FK; route ref_id by ref_type.
+    INSERT INTO public.stock_transactions (
+      id, business_id, product_id, location_id, quantity_delta, movement_type,
+      order_id, transfer_id, adjustment_id, purchase_id,
+      performed_by, created_at, last_updated_at
+    )
+    VALUES (
+      COALESCE((v_mv->>'id')::uuid, gen_random_uuid()),
+      p_business_id,
+      (v_mv->>'product_id')::uuid,
+      (v_mv->>'warehouse_id')::uuid,
+      (v_mv->>'quantity_delta')::int,
+      v_movement_type,
+      CASE WHEN v_ref_type = 'order'      THEN v_ref_id END,
+      CASE WHEN v_ref_type = 'transfer'   THEN v_ref_id END,
+      CASE WHEN v_ref_type = 'adjustment' THEN v_ref_id END,
+      CASE WHEN v_ref_type = 'purchase'   THEN v_ref_id END,
+      NULLIF(v_mv->>'performed_by','')::uuid,
+      now(), now()
+    )
+    ON CONFLICT (id) DO NOTHING;
+
+    v_stx_ids := v_stx_ids || jsonb_build_array(COALESCE((v_mv->>'id')::uuid, NULL));
+    v_inv_after := v_inv_after || jsonb_build_object(
+      'product_id',      (v_mv->>'product_id')::uuid,
+      'warehouse_id',    (v_mv->>'warehouse_id')::uuid,
+      'quantity',        v_new_qty,
+      'last_updated_at', now()
+    );
+  END LOOP;
+
+  RETURN jsonb_build_object(
+    'inventory_after',       v_inv_after,
+    'stock_transaction_ids', v_stx_ids
+  );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.pos_inventory_delta(uuid, jsonb) FROM public;
+GRANT EXECUTE ON FUNCTION public.pos_inventory_delta(uuid, jsonb)
+  TO authenticated, service_role;
+
+
+-- -----------------------------------------------------------------------------
+-- 3. pos_create_product — product + optional initial stock in one txn.
+-- -----------------------------------------------------------------------------
+--
+-- The stock_transactions CHECK (0001_initial.sql:529-534) requires exactly
+-- one of (order_id, transfer_id, adjustment_id, purchase_id) to be non-null
+-- on every row. There is no slot for "product-creation initial stock", so
+-- we anchor the ledger row to a stock_adjustments row with reason
+-- 'initial_stock' — same trick used by InventoryDao.adjustStock locally.
+
+CREATE OR REPLACE FUNCTION public.pos_create_product(
+  p_business_id   uuid,
+  p_product       jsonb,
+  p_initial_stock jsonb DEFAULT NULL   -- {warehouse_id, quantity, performed_by?}
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+DECLARE
+  v_caller_business uuid;
+  v_product_id      uuid;
+  v_product_lua     timestamptz;
+  v_qty             int;
+  v_warehouse_id    uuid;
+  v_adjustment_id   uuid;
+  v_stx_id          uuid;
+  v_inventory_id    uuid;
+  v_new_qty         int;
+BEGIN
+  v_caller_business := public.business_id();
+  IF v_caller_business IS NULL THEN
+    RAISE EXCEPTION 'no_business_for_caller' USING ERRCODE = 'insufficient_privilege';
+  END IF;
+  IF v_caller_business <> p_business_id THEN
+    RAISE EXCEPTION 'tenant_mismatch' USING ERRCODE = 'insufficient_privilege';
+  END IF;
+  IF (p_product->>'business_id')::uuid <> p_business_id THEN
+    RAISE EXCEPTION 'product_business_id_mismatch' USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  v_product_id := (p_product->>'id')::uuid;
+  IF v_product_id IS NULL THEN
+    RAISE EXCEPTION 'product_id_required' USING ERRCODE = 'invalid_parameter_value';
+  END IF;
+
+  -- Idempotent product insert. On UPDATE we trust the client's payload —
+  -- this is a domain RPC, the client is sending a complete row.
+  INSERT INTO public.products
+  SELECT (jsonb_populate_record(NULL::public.products, p_product)).*
+  ON CONFLICT (id) DO UPDATE SET
+    name                = EXCLUDED.name,
+    subtitle            = EXCLUDED.subtitle,
+    sku                 = EXCLUDED.sku,
+    size                = EXCLUDED.size,
+    unit                = EXCLUDED.unit,
+    retail_price_kobo   = EXCLUDED.retail_price_kobo,
+    selling_price_kobo  = EXCLUDED.selling_price_kobo,
+    buying_price_kobo   = EXCLUDED.buying_price_kobo,
+    category_id         = EXCLUDED.category_id,
+    crate_group_id      = EXCLUDED.crate_group_id,
+    manufacturer_id     = EXCLUDED.manufacturer_id,
+    supplier_id         = EXCLUDED.supplier_id,
+    is_available        = EXCLUDED.is_available,
+    is_deleted          = EXCLUDED.is_deleted,
+    low_stock_threshold = EXCLUDED.low_stock_threshold,
+    track_empties       = EXCLUDED.track_empties,
+    image_path          = EXCLUDED.image_path,
+    last_updated_at     = now();
+
+  SELECT last_updated_at INTO v_product_lua FROM public.products WHERE id = v_product_id;
+
+  IF p_initial_stock IS NOT NULL THEN
+    v_qty          := COALESCE((p_initial_stock->>'quantity')::int, 0);
+    v_warehouse_id := (p_initial_stock->>'warehouse_id')::uuid;
+
+    IF v_qty > 0 AND v_warehouse_id IS NOT NULL THEN
+      -- Anchor for the stock_transactions row.
+      INSERT INTO public.stock_adjustments (
+        id, business_id, product_id, warehouse_id, quantity_diff, reason, performed_by
+      ) VALUES (
+        gen_random_uuid(),
+        p_business_id,
+        v_product_id,
+        v_warehouse_id,
+        v_qty,
+        'initial_stock',
+        NULLIF(p_initial_stock->>'performed_by','')::uuid
+      )
+      RETURNING id INTO v_adjustment_id;
+
+      INSERT INTO public.inventory (id, business_id, product_id, warehouse_id, quantity)
+      VALUES (gen_random_uuid(), p_business_id, v_product_id, v_warehouse_id, v_qty)
+      ON CONFLICT (business_id, product_id, warehouse_id)
+        DO UPDATE SET quantity = public.inventory.quantity + EXCLUDED.quantity
+      RETURNING id, quantity INTO v_inventory_id, v_new_qty;
+
+      INSERT INTO public.stock_transactions (
+        id, business_id, product_id, location_id, quantity_delta, movement_type,
+        adjustment_id, performed_by
+      ) VALUES (
+        gen_random_uuid(),
+        p_business_id,
+        v_product_id,
+        v_warehouse_id,
+        v_qty,
+        'adjustment',
+        v_adjustment_id,
+        NULLIF(p_initial_stock->>'performed_by','')::uuid
+      )
+      RETURNING id INTO v_stx_id;
+    END IF;
+  END IF;
+
+  RETURN jsonb_build_object(
+    'product_id',             v_product_id,
+    'product_last_updated_at', v_product_lua,
+    'inventory_id',           v_inventory_id,
+    'inventory_quantity',     v_new_qty,
+    'stock_adjustment_id',    v_adjustment_id,
+    'stock_transaction_id',   v_stx_id
+  );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.pos_create_product(uuid, jsonb, jsonb) FROM public;
+GRANT EXECUTE ON FUNCTION public.pos_create_product(uuid, jsonb, jsonb)
+  TO authenticated, service_role;
+
+
+-- -----------------------------------------------------------------------------
+-- 4. Realtime publication membership check.
+--    The client subscribes to a wildcard 'public:*' channel filtered by
+--    business_id. The wildcard only delivers events for tables that are
+--    members of supabase_realtime; missing tables silently never fire.
+--    Add every synced tenant table to the publication.
+-- -----------------------------------------------------------------------------
+
+DO $$
+DECLARE
+  t text;
+  synced_tables text[] := ARRAY[
+    'businesses','profiles','users','sessions','invites',
+    'warehouses','manufacturers','crate_groups','categories','suppliers',
+    'products','price_lists',
+    'customers','customer_wallets','wallet_transactions',
+    'customer_crate_balances','manufacturer_crate_balances','crate_ledger',
+    'inventory','crates','stock_transfers','stock_adjustments','stock_transactions',
+    'orders','order_items','purchases','purchase_items',
+    'drivers','delivery_receipts','saved_carts','pending_crate_returns',
+    'payment_transactions',
+    'expense_categories','expenses','activity_logs','notifications',
+    'settings','system_config'
+  ];
+  v_in_pub boolean;
+BEGIN
+  -- The publication may not exist on a fresh non-Supabase database
+  -- (self-hosted Postgres without realtime). Skip silently in that case.
+  IF NOT EXISTS (SELECT 1 FROM pg_publication WHERE pubname = 'supabase_realtime') THEN
+    RAISE NOTICE 'supabase_realtime publication absent; skipping realtime membership step';
+    RETURN;
+  END IF;
+
+  FOREACH t IN ARRAY synced_tables LOOP
+    SELECT EXISTS (
+      SELECT 1 FROM pg_publication_tables
+       WHERE pubname = 'supabase_realtime'
+         AND schemaname = 'public'
+         AND tablename = t
+    ) INTO v_in_pub;
+    IF NOT v_in_pub THEN
+      EXECUTE format('ALTER PUBLICATION supabase_realtime ADD TABLE public.%I', t);
+      RAISE NOTICE 'Added % to supabase_realtime', t;
+    END IF;
+  END LOOP;
+END $$;
+
+
+-- -----------------------------------------------------------------------------
+-- 5. Defensive last_updated_at backfill.
+--    The schema declares NOT NULL DEFAULT now() (0001_initial.sql:12) and
+--    a BEFORE UPDATE trigger keeps it fresh, so this should be a no-op.
+--    Cheap insurance against historic rows from before triggers attached.
+-- -----------------------------------------------------------------------------
+
+DO $$
+DECLARE
+  t text;
+  synced_tables text[] := ARRAY[
+    'businesses','profiles','users','sessions','invites',
+    'warehouses','manufacturers','crate_groups','categories','suppliers',
+    'products','price_lists',
+    'customers','customer_wallets','wallet_transactions',
+    'customer_crate_balances','manufacturer_crate_balances','crate_ledger',
+    'inventory','crates','stock_transfers','stock_adjustments','stock_transactions',
+    'orders','order_items','purchases','purchase_items',
+    'drivers','delivery_receipts','saved_carts','pending_crate_returns',
+    'payment_transactions',
+    'expense_categories','expenses','activity_logs','notifications',
+    'settings','system_config'
+  ];
+BEGIN
+  FOREACH t IN ARRAY synced_tables LOOP
+    EXECUTE format(
+      'UPDATE public.%I SET last_updated_at = COALESCE(last_updated_at, created_at, now()) WHERE last_updated_at IS NULL',
+      t
+    );
+  END LOOP;
+END $$;
+
+-- =============================================================================
+-- End of 0006_domain_rpcs.sql.
+-- =============================================================================


### PR DESCRIPTION
Collapses the 9–12 outbox rows per checkout/adjust/product-create down to one domain envelope and fixes the silent ledger leaks that were keeping wallet topups, payment transactions, and crate-return approvals out of the cloud.

Why: the local-first sync queue was spiking to ~12 rows per business action because (a) one checkout fans out to 6 tables, each enqueued separately; (b) several screens wrote directly to Drift without calling enqueueUpsert; (c) duplicates only deduped at push time. Multi-device stock concurrency was also LWW — two simultaneous sales silently overwrote each other's quantity.

Server: new 0006_domain_rpcs.sql adds pos_record_sale, pos_inventory_delta, pos_create_product (SECURITY DEFINER, manual business_id() guard, ON CONFLICT DO NOTHING for retry idempotency, row-locked UPDATE inventory ... WHERE quantity + delta >= 0 RETURNING for stock concurrency, P0001 'insufficient_stock' on overdraw). Plus a publication-membership self-heal (wildcard channel silently drops events for tables not in supabase_realtime) and a defensive last_updated_at backfill.

Client:
- schemaVersion 4: partial unique index on sync_queue (action_type, payload->id) WHERE status='pending', preceded by collapse of any pre-existing duplicates.
- pushPending detects 'domain:' prefix and dispatches via rpc(), reconciles inventory_after / order_last_updated_at / product_ last_updated_at back to the local cache without re-enqueueing, and maps P0001 / 23xxx to permanent-fail.
- SyncDao.enqueueUpsert / enqueueDelete coalesce against the new unique index; deletes also clear pending upserts for the same row.
- OrdersDao.createOrder, InventoryDao.adjustStock, and the new CatalogDao.insertProductWithInitialStock each emit one domain envelope when their feature flag is on (system_config keys feature.domain_rpcs.{sales,inventory,product_create}); legacy multi-row enqueue path is the rollback.
- OrderService awaits SupabaseSyncService.flushSale(orderId) when online so insufficient_stock surfaces before the receipt prints; on SaleSyncException the local order is auto-cancelled and the inventory cache refunded (cloud never saw the sale).
- Backfill is now one-shot, gated by a SharedPreferences version flag — no more per-launch scan.

Leaky writes plugged: WalletService.topup / refundOrderWalletDebit (was silently dropping every wallet+payment ledger row), CrateReturnApprovalService.approve/reject (status update + crate_ledger row + balance cache), staff_screen edit, warehouse_screen add/edit/delete, add_product_sheet and update_product_sheet cosmetic fields. Auth/onboarding direct writes are documented in CLAUDE.md §5 as legitimate exceptions (online-first via direct Supabase writes).

UI streams: new allCategoriesProvider, allManufacturersProvider, warehouseByIdProvider; inventory list, POS controller, checkout receipt header now subscribe to streams so remote edits propagate without a manual refresh.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added real-time streaming updates for categories, manufacturers, and warehouses
  * Implemented atomic sales, inventory, and product creation operations for improved reliability
  * Introduced soft-delete for warehouses to prevent accidental data loss

* **Bug Fixes**
  * Improved sync queue deduplication to reduce redundant cloud updates

* **Chores**
  * Updated database schema for enhanced synchronization operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->