### PR TITLE
feat(sync): L5 auth-user-id pinning across account switches

### DIFF
--- a/lib/core/database/app_database.dart
+++ b/lib/core/database/app_database.dart
@@ -988,6 +988,15 @@ class SyncQueue extends Table {
   IntColumn get attempts => integer().withDefault(const Constant(0))();
   DateTimeColumn get nextAttemptAt => dateTime().nullable()();
   DateTimeColumn get createdAt => dateTime().withDefault(currentDateAndTime)();
+  // Supabase auth.uid() at enqueue time. Dispatch refuses to push a row
+  // whose tag does not match the current session's auth.uid(), so an
+  // account-switch on the same device cannot flush the previous user's
+  // queued writes under the new user's JWT. Nullable for two reasons:
+  // (a) rows enqueued before v10 have no captured value, and (b) some
+  // bootstrap enqueues (very early in onboarding) can race the Supabase
+  // session-restore — null is treated as "trust the current user" by
+  // dispatch, preserving today's behavior for those legacy rows.
+  TextColumn get authUserId => text().nullable()();
 
   @override
   Set<Column> get primaryKey => {id};
@@ -1117,8 +1126,20 @@ class AppDatabase extends _$AppDatabase {
   String? Function() userIdResolver = () => null;
   String? get currentUserId => userIdResolver();
 
+  /// Supabase auth.uid() for the active session, read directly from the
+  /// SDK so it tracks the cloud identity independent of any local `users`
+  /// row. SyncDao stamps every enqueued row with this so dispatch can
+  /// reject pushes after an account switch on the same device.
+  ///
+  /// Returns null before AuthService binds the closure (cold start) and
+  /// during the brief window between Supabase init and session restore.
+  /// Null at enqueue time is treated as "trust the current user" at
+  /// dispatch — see [SyncQueue.authUserId] for the full contract.
+  String? Function() authUserIdResolver = () => null;
+  String? get currentAuthUserId => authUserIdResolver();
+
   @override
-  int get schemaVersion => 9;
+  int get schemaVersion => 10;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -1339,6 +1360,15 @@ class AppDatabase extends _$AppDatabase {
         await m.alterTable(TableMigration(users));
         await m.alterTable(TableMigration(businessMembers));
         await m.alterTable(TableMigration(invites));
+      }
+      if (from < 10) {
+        // v10 (L5 fix): tag every sync_queue row with the Supabase
+        // auth.uid() that enqueued it so dispatch can refuse to push
+        // another user's queued writes after an account switch. Existing
+        // rows get NULL — dispatch treats null as "trust the current
+        // user" to keep already-queued writes flowing through the upgrade
+        // without losing pending sales.
+        await m.addColumn(syncQueue, syncQueue.authUserId);
       }
     },
     beforeOpen: (details) async {

--- a/lib/core/database/app_database.g.dart
+++ b/lib/core/database/app_database.g.dart
@@ -26514,6 +26514,17 @@ class $SyncQueueTable extends SyncQueue
     requiredDuringInsert: false,
     defaultValue: currentDateAndTime,
   );
+  static const VerificationMeta _authUserIdMeta = const VerificationMeta(
+    'authUserId',
+  );
+  @override
+  late final GeneratedColumn<String> authUserId = GeneratedColumn<String>(
+    'auth_user_id',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
   @override
   List<GeneratedColumn> get $columns => [
     id,
@@ -26526,6 +26537,7 @@ class $SyncQueueTable extends SyncQueue
     attempts,
     nextAttemptAt,
     createdAt,
+    authUserId,
   ];
   @override
   String get aliasedName => _alias ?? actualTableName;
@@ -26608,6 +26620,15 @@ class $SyncQueueTable extends SyncQueue
         createdAt.isAcceptableOrUnknown(data['created_at']!, _createdAtMeta),
       );
     }
+    if (data.containsKey('auth_user_id')) {
+      context.handle(
+        _authUserIdMeta,
+        authUserId.isAcceptableOrUnknown(
+          data['auth_user_id']!,
+          _authUserIdMeta,
+        ),
+      );
+    }
     return context;
   }
 
@@ -26657,6 +26678,10 @@ class $SyncQueueTable extends SyncQueue
         DriftSqlType.dateTime,
         data['${effectivePrefix}created_at'],
       )!,
+      authUserId: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}auth_user_id'],
+      ),
     );
   }
 
@@ -26677,6 +26702,7 @@ class SyncQueueData extends DataClass implements Insertable<SyncQueueData> {
   final int attempts;
   final DateTime? nextAttemptAt;
   final DateTime createdAt;
+  final String? authUserId;
   const SyncQueueData({
     required this.id,
     required this.businessId,
@@ -26688,6 +26714,7 @@ class SyncQueueData extends DataClass implements Insertable<SyncQueueData> {
     required this.attempts,
     this.nextAttemptAt,
     required this.createdAt,
+    this.authUserId,
   });
   @override
   Map<String, Expression> toColumns(bool nullToAbsent) {
@@ -26706,6 +26733,9 @@ class SyncQueueData extends DataClass implements Insertable<SyncQueueData> {
       map['next_attempt_at'] = Variable<DateTime>(nextAttemptAt);
     }
     map['created_at'] = Variable<DateTime>(createdAt);
+    if (!nullToAbsent || authUserId != null) {
+      map['auth_user_id'] = Variable<String>(authUserId);
+    }
     return map;
   }
 
@@ -26725,6 +26755,9 @@ class SyncQueueData extends DataClass implements Insertable<SyncQueueData> {
           ? const Value.absent()
           : Value(nextAttemptAt),
       createdAt: Value(createdAt),
+      authUserId: authUserId == null && nullToAbsent
+          ? const Value.absent()
+          : Value(authUserId),
     );
   }
 
@@ -26744,6 +26777,7 @@ class SyncQueueData extends DataClass implements Insertable<SyncQueueData> {
       attempts: serializer.fromJson<int>(json['attempts']),
       nextAttemptAt: serializer.fromJson<DateTime?>(json['nextAttemptAt']),
       createdAt: serializer.fromJson<DateTime>(json['createdAt']),
+      authUserId: serializer.fromJson<String?>(json['authUserId']),
     );
   }
   @override
@@ -26760,6 +26794,7 @@ class SyncQueueData extends DataClass implements Insertable<SyncQueueData> {
       'attempts': serializer.toJson<int>(attempts),
       'nextAttemptAt': serializer.toJson<DateTime?>(nextAttemptAt),
       'createdAt': serializer.toJson<DateTime>(createdAt),
+      'authUserId': serializer.toJson<String?>(authUserId),
     };
   }
 
@@ -26774,6 +26809,7 @@ class SyncQueueData extends DataClass implements Insertable<SyncQueueData> {
     int? attempts,
     Value<DateTime?> nextAttemptAt = const Value.absent(),
     DateTime? createdAt,
+    Value<String?> authUserId = const Value.absent(),
   }) => SyncQueueData(
     id: id ?? this.id,
     businessId: businessId ?? this.businessId,
@@ -26787,6 +26823,7 @@ class SyncQueueData extends DataClass implements Insertable<SyncQueueData> {
         ? nextAttemptAt.value
         : this.nextAttemptAt,
     createdAt: createdAt ?? this.createdAt,
+    authUserId: authUserId.present ? authUserId.value : this.authUserId,
   );
   SyncQueueData copyWithCompanion(SyncQueueCompanion data) {
     return SyncQueueData(
@@ -26808,6 +26845,9 @@ class SyncQueueData extends DataClass implements Insertable<SyncQueueData> {
           ? data.nextAttemptAt.value
           : this.nextAttemptAt,
       createdAt: data.createdAt.present ? data.createdAt.value : this.createdAt,
+      authUserId: data.authUserId.present
+          ? data.authUserId.value
+          : this.authUserId,
     );
   }
 
@@ -26823,7 +26863,8 @@ class SyncQueueData extends DataClass implements Insertable<SyncQueueData> {
           ..write('errorMessage: $errorMessage, ')
           ..write('attempts: $attempts, ')
           ..write('nextAttemptAt: $nextAttemptAt, ')
-          ..write('createdAt: $createdAt')
+          ..write('createdAt: $createdAt, ')
+          ..write('authUserId: $authUserId')
           ..write(')'))
         .toString();
   }
@@ -26840,6 +26881,7 @@ class SyncQueueData extends DataClass implements Insertable<SyncQueueData> {
     attempts,
     nextAttemptAt,
     createdAt,
+    authUserId,
   );
   @override
   bool operator ==(Object other) =>
@@ -26854,7 +26896,8 @@ class SyncQueueData extends DataClass implements Insertable<SyncQueueData> {
           other.errorMessage == this.errorMessage &&
           other.attempts == this.attempts &&
           other.nextAttemptAt == this.nextAttemptAt &&
-          other.createdAt == this.createdAt);
+          other.createdAt == this.createdAt &&
+          other.authUserId == this.authUserId);
 }
 
 class SyncQueueCompanion extends UpdateCompanion<SyncQueueData> {
@@ -26868,6 +26911,7 @@ class SyncQueueCompanion extends UpdateCompanion<SyncQueueData> {
   final Value<int> attempts;
   final Value<DateTime?> nextAttemptAt;
   final Value<DateTime> createdAt;
+  final Value<String?> authUserId;
   final Value<int> rowid;
   const SyncQueueCompanion({
     this.id = const Value.absent(),
@@ -26880,6 +26924,7 @@ class SyncQueueCompanion extends UpdateCompanion<SyncQueueData> {
     this.attempts = const Value.absent(),
     this.nextAttemptAt = const Value.absent(),
     this.createdAt = const Value.absent(),
+    this.authUserId = const Value.absent(),
     this.rowid = const Value.absent(),
   });
   SyncQueueCompanion.insert({
@@ -26893,6 +26938,7 @@ class SyncQueueCompanion extends UpdateCompanion<SyncQueueData> {
     this.attempts = const Value.absent(),
     this.nextAttemptAt = const Value.absent(),
     this.createdAt = const Value.absent(),
+    this.authUserId = const Value.absent(),
     this.rowid = const Value.absent(),
   }) : businessId = Value(businessId),
        actionType = Value(actionType),
@@ -26908,6 +26954,7 @@ class SyncQueueCompanion extends UpdateCompanion<SyncQueueData> {
     Expression<int>? attempts,
     Expression<DateTime>? nextAttemptAt,
     Expression<DateTime>? createdAt,
+    Expression<String>? authUserId,
     Expression<int>? rowid,
   }) {
     return RawValuesInsertable({
@@ -26921,6 +26968,7 @@ class SyncQueueCompanion extends UpdateCompanion<SyncQueueData> {
       if (attempts != null) 'attempts': attempts,
       if (nextAttemptAt != null) 'next_attempt_at': nextAttemptAt,
       if (createdAt != null) 'created_at': createdAt,
+      if (authUserId != null) 'auth_user_id': authUserId,
       if (rowid != null) 'rowid': rowid,
     });
   }
@@ -26936,6 +26984,7 @@ class SyncQueueCompanion extends UpdateCompanion<SyncQueueData> {
     Value<int>? attempts,
     Value<DateTime?>? nextAttemptAt,
     Value<DateTime>? createdAt,
+    Value<String?>? authUserId,
     Value<int>? rowid,
   }) {
     return SyncQueueCompanion(
@@ -26949,6 +26998,7 @@ class SyncQueueCompanion extends UpdateCompanion<SyncQueueData> {
       attempts: attempts ?? this.attempts,
       nextAttemptAt: nextAttemptAt ?? this.nextAttemptAt,
       createdAt: createdAt ?? this.createdAt,
+      authUserId: authUserId ?? this.authUserId,
       rowid: rowid ?? this.rowid,
     );
   }
@@ -26986,6 +27036,9 @@ class SyncQueueCompanion extends UpdateCompanion<SyncQueueData> {
     if (createdAt.present) {
       map['created_at'] = Variable<DateTime>(createdAt.value);
     }
+    if (authUserId.present) {
+      map['auth_user_id'] = Variable<String>(authUserId.value);
+    }
     if (rowid.present) {
       map['rowid'] = Variable<int>(rowid.value);
     }
@@ -27005,6 +27058,7 @@ class SyncQueueCompanion extends UpdateCompanion<SyncQueueData> {
           ..write('attempts: $attempts, ')
           ..write('nextAttemptAt: $nextAttemptAt, ')
           ..write('createdAt: $createdAt, ')
+          ..write('authUserId: $authUserId, ')
           ..write('rowid: $rowid')
           ..write(')'))
         .toString();
@@ -63081,6 +63135,7 @@ typedef $$SyncQueueTableCreateCompanionBuilder =
       Value<int> attempts,
       Value<DateTime?> nextAttemptAt,
       Value<DateTime> createdAt,
+      Value<String?> authUserId,
       Value<int> rowid,
     });
 typedef $$SyncQueueTableUpdateCompanionBuilder =
@@ -63095,6 +63150,7 @@ typedef $$SyncQueueTableUpdateCompanionBuilder =
       Value<int> attempts,
       Value<DateTime?> nextAttemptAt,
       Value<DateTime> createdAt,
+      Value<String?> authUserId,
       Value<int> rowid,
     });
 
@@ -63176,6 +63232,11 @@ class $$SyncQueueTableFilterComposer
     builder: (column) => ColumnFilters(column),
   );
 
+  ColumnFilters<String> get authUserId => $composableBuilder(
+    column: $table.authUserId,
+    builder: (column) => ColumnFilters(column),
+  );
+
   $$BusinessesTableFilterComposer get businessId {
     final $$BusinessesTableFilterComposer composer = $composerBuilder(
       composer: this,
@@ -63254,6 +63315,11 @@ class $$SyncQueueTableOrderingComposer
     builder: (column) => ColumnOrderings(column),
   );
 
+  ColumnOrderings<String> get authUserId => $composableBuilder(
+    column: $table.authUserId,
+    builder: (column) => ColumnOrderings(column),
+  );
+
   $$BusinessesTableOrderingComposer get businessId {
     final $$BusinessesTableOrderingComposer composer = $composerBuilder(
       composer: this,
@@ -63320,6 +63386,11 @@ class $$SyncQueueTableAnnotationComposer
   GeneratedColumn<DateTime> get createdAt =>
       $composableBuilder(column: $table.createdAt, builder: (column) => column);
 
+  GeneratedColumn<String> get authUserId => $composableBuilder(
+    column: $table.authUserId,
+    builder: (column) => column,
+  );
+
   $$BusinessesTableAnnotationComposer get businessId {
     final $$BusinessesTableAnnotationComposer composer = $composerBuilder(
       composer: this,
@@ -63382,6 +63453,7 @@ class $$SyncQueueTableTableManager
                 Value<int> attempts = const Value.absent(),
                 Value<DateTime?> nextAttemptAt = const Value.absent(),
                 Value<DateTime> createdAt = const Value.absent(),
+                Value<String?> authUserId = const Value.absent(),
                 Value<int> rowid = const Value.absent(),
               }) => SyncQueueCompanion(
                 id: id,
@@ -63394,6 +63466,7 @@ class $$SyncQueueTableTableManager
                 attempts: attempts,
                 nextAttemptAt: nextAttemptAt,
                 createdAt: createdAt,
+                authUserId: authUserId,
                 rowid: rowid,
               ),
           createCompanionCallback:
@@ -63408,6 +63481,7 @@ class $$SyncQueueTableTableManager
                 Value<int> attempts = const Value.absent(),
                 Value<DateTime?> nextAttemptAt = const Value.absent(),
                 Value<DateTime> createdAt = const Value.absent(),
+                Value<String?> authUserId = const Value.absent(),
                 Value<int> rowid = const Value.absent(),
               }) => SyncQueueCompanion.insert(
                 id: id,
@@ -63420,6 +63494,7 @@ class $$SyncQueueTableTableManager
                 attempts: attempts,
                 nextAttemptAt: nextAttemptAt,
                 createdAt: createdAt,
+                authUserId: authUserId,
                 rowid: rowid,
               ),
           withReferenceMapper: (p0) => p0

--- a/lib/core/database/daos.dart
+++ b/lib/core/database/daos.dart
@@ -2247,6 +2247,23 @@ class SyncDao extends DatabaseAccessor<AppDatabase>
         .watch();
   }
 
+  /// Every row in transient-retry / never-pushed state, oldest first. The
+  /// `markFailed` state machine keeps every transiently-failed row at
+  /// `status='pending'` with a future `nextAttemptAt` — `'failed'` itself
+  /// is unused by the current code paths. Without this surface, a row
+  /// that has retried for hours looks identical to one enqueued a second
+  /// ago, and the only signal is the bare "Pending in queue: N" counter.
+  Stream<List<SyncQueueData>> watchPendingItems({int limit = 100}) {
+    return (select(syncQueue)
+          ..where((t) =>
+              t.status.equals('pending') &
+              t.isSynced.not() &
+              whereBusiness(t))
+          ..orderBy([(t) => OrderingTerm.asc(t.createdAt)])
+          ..limit(limit))
+        .watch();
+  }
+
   Stream<int> watchFailedCount() {
     return (selectOnly(syncQueue)
           ..addColumns([syncQueue.id.count()])
@@ -2285,6 +2302,10 @@ class SyncDao extends DatabaseAccessor<AppDatabase>
         businessId: requireBusinessId(),
         actionType: actionType,
         payload: payload,
+        // Stamp auth.uid() at enqueue time so dispatch can reject the row
+        // after an account switch. Null when the SDK has no session yet
+        // (bootstrap) — dispatch treats null as "trust the current user".
+        authUserId: Value(db.currentAuthUserId),
       ),
     );
   }
@@ -2418,6 +2439,11 @@ class SyncDao extends DatabaseAccessor<AppDatabase>
           businessId: bid,
           actionType: orphan.actionType,
           payload: orphan.payload,
+          // Retry re-tags to whoever is signed in now. The orphans table
+          // does not carry an auth_user_id (orphans pre-date L5), and the
+          // user pressing Retry on the Sync Issues screen is explicitly
+          // taking ownership of the push.
+          authUserId: Value(db.currentAuthUserId),
         ),
       );
       await (delete(syncQueueOrphans)..where((t) => t.id.equals(orphanId))).go();
@@ -2467,6 +2493,11 @@ class SyncDao extends DatabaseAccessor<AppDatabase>
     await transaction(() async {
       final existingId = await _findPendingDuplicateId(actionType, rowId);
       if (existingId != null) {
+        // Refresh the auth tag too: a coalesced row carries the new
+        // payload's intent, so it should be tagged with whoever is
+        // signed in now. If user A enqueued an upsert, logged out, and
+        // user B then edits the same row, the coalesced row pushes
+        // under user B (the JWT that will sign the request anyway).
         await (update(syncQueue)..where((t) => t.id.equals(existingId)))
             .write(SyncQueueCompanion(
           payload: Value(payloadJson),
@@ -2474,6 +2505,7 @@ class SyncDao extends DatabaseAccessor<AppDatabase>
           attempts: const Value(0),
           nextAttemptAt: const Value(null),
           errorMessage: const Value(null),
+          authUserId: Value(db.currentAuthUserId),
         ));
       } else {
         await into(syncQueue).insert(
@@ -2482,6 +2514,7 @@ class SyncDao extends DatabaseAccessor<AppDatabase>
             businessId: bid,
             actionType: actionType,
             payload: payloadJson,
+            authUserId: Value(db.currentAuthUserId),
           ),
         );
       }
@@ -2550,6 +2583,8 @@ class SyncDao extends DatabaseAccessor<AppDatabase>
       final existingDeleteId =
           await _findPendingDuplicateId(deleteActionType, rowId);
       if (existingDeleteId != null) {
+        // Coalesced delete retags to current user — same rationale as
+        // the upsert coalesce branch above.
         await (update(syncQueue)..where((t) => t.id.equals(existingDeleteId)))
             .write(SyncQueueCompanion(
           payload: Value(payloadJson),
@@ -2557,6 +2592,7 @@ class SyncDao extends DatabaseAccessor<AppDatabase>
           attempts: const Value(0),
           nextAttemptAt: const Value(null),
           errorMessage: const Value(null),
+          authUserId: Value(db.currentAuthUserId),
         ));
       } else {
         await into(syncQueue).insert(
@@ -2565,6 +2601,7 @@ class SyncDao extends DatabaseAccessor<AppDatabase>
             businessId: bid,
             actionType: deleteActionType,
             payload: payloadJson,
+            authUserId: Value(db.currentAuthUserId),
           ),
         );
       }

--- a/lib/core/providers/app_providers.dart
+++ b/lib/core/providers/app_providers.dart
@@ -202,6 +202,9 @@ final failedQueueCountProvider = StreamProvider.autoDispose<int>((ref) {
 final pendingQueueCountProvider = StreamProvider.autoDispose<int>((ref) {
   return ref.read(databaseProvider).syncDao.watchPendingCount();
 });
+final pendingQueueItemsProvider = StreamProvider.autoDispose((ref) {
+  return ref.read(databaseProvider).syncDao.watchPendingItems();
+});
 final orphanQueueItemsProvider = StreamProvider.autoDispose((ref) {
   return ref.read(databaseProvider).syncDao.watchOrphans();
 });

--- a/lib/core/services/supabase_sync_service.dart
+++ b/lib/core/services/supabase_sync_service.dart
@@ -393,7 +393,8 @@ class SupabaseSyncService {
     // Without an authenticated session the server sees auth.uid() as NULL,
     // so RLS denies every insert. Skip rather than burn `attempts` and rack
     // up false negatives — startAutoPush retriggers as soon as sign-in lands.
-    if (_supabase.auth.currentUser == null) {
+    final currentAuthUid = _supabase.auth.currentUser?.id;
+    if (currentAuthUid == null) {
       debugPrint('[SyncService] Skipping push: no auth session.');
       return;
     }
@@ -536,9 +537,13 @@ class SupabaseSyncService {
 
       // Validate every payload's tenant. Any tenant-mismatch in the group
       // is a programming error; hard-fail just those items and continue.
+      // Also reject rows whose stamped auth_user_id (L5) does not match
+      // the current session — those were queued by a different signed-in
+      // user on this device and would push under the wrong JWT.
       final validPayloads = <Map<String, dynamic>>[];
       final validIds = <String>[];
       final mismatchedIds = <String>[];
+      final authMismatched = <SyncQueueData>[];
       for (final item in items) {
         try {
           final raw = jsonDecode(item.payload) as Map<String, dynamic>;
@@ -547,6 +552,14 @@ class SupabaseSyncService {
               pid == null ||
               (pid is String && pid != sessionBusinessId)) {
             mismatchedIds.add(item.id);
+            continue;
+          }
+          // auth_user_id is nullable: pre-v10 rows and bootstrap-window
+          // enqueues both store null and are trusted to the current user.
+          // Only a NON-null tag that disagrees with the current auth.uid()
+          // is a mismatch.
+          if (item.authUserId != null && item.authUserId != currentAuthUid) {
+            authMismatched.add(item);
             continue;
           }
           validPayloads.add(_normalizePayloadForCloud(group.table, raw));
@@ -559,6 +572,16 @@ class SupabaseSyncService {
         for (final id in mismatchedIds) {
           await _db.syncDao
               .markFailed(id, 'missing_business_id', permanent: true);
+        }
+      }
+      if (authMismatched.isNotEmpty) {
+        for (final item in authMismatched) {
+          await _db.syncDao.markFailed(
+            item.id,
+            'auth_user_mismatch: queued by ${item.authUserId}, '
+                'current is $currentAuthUid',
+            permanent: true,
+          );
         }
       }
       if (validPayloads.isEmpty) continue;
@@ -613,7 +636,7 @@ class SupabaseSyncService {
     // Their server-side RPCs FK-reference rows we just pushed (e.g.
     // pos_create_product → stock_adjustments.performed_by → users.id).
     if (domainItems.isNotEmpty) {
-      await _pushDomainItems(domainItems, sessionBusinessId);
+      await _pushDomainItems(domainItems, sessionBusinessId, currentAuthUid);
     }
 
     // If the raw select hit the page limit, more is waiting — drain in the
@@ -635,6 +658,7 @@ class SupabaseSyncService {
   Future<void> _pushDomainItems(
     List<SyncQueueData> items,
     String sessionBusinessId,
+    String currentAuthUid,
   ) async {
     for (final item in items) {
       await _db.syncDao.markInProgressBatch([item.id]);
@@ -657,6 +681,20 @@ class SupabaseSyncService {
           payloadBiz != sessionBusinessId) {
         await _db.syncDao
             .markFailed(item.id, 'missing_business_id', permanent: true);
+        continue;
+      }
+
+      // L5: auth_user_id mismatch — row was queued by a different signed-in
+      // user on this device. Pushing under the current JWT would attribute
+      // the sale / inventory delta / product creation to the wrong staff.
+      // Null tag (pre-v10 / bootstrap) is trusted to the current user.
+      if (item.authUserId != null && item.authUserId != currentAuthUid) {
+        await _db.syncDao.markFailed(
+          item.id,
+          'auth_user_mismatch: queued by ${item.authUserId}, '
+              'current is $currentAuthUid',
+          permanent: true,
+        );
         continue;
       }
 
@@ -1049,7 +1087,8 @@ class SupabaseSyncService {
   ///   - the device is offline (the row stays pending and will drain later), OR
   ///   - the RPC fails with a transient error (queued for backoff retry).
   Future<void> flushSale(String orderId) async {
-    if (_supabase.auth.currentUser == null) return;
+    final currentAuthUid = _supabase.auth.currentUser?.id;
+    if (currentAuthUid == null) return;
     if (!isOnline.value) return;
     final sessionBusinessId = _db.currentBusinessId;
     if (sessionBusinessId == null) return;
@@ -1072,7 +1111,7 @@ class SupabaseSyncService {
     );
     if (item == null) return;
 
-    await _pushDomainItems([item], sessionBusinessId);
+    await _pushDomainItems([item], sessionBusinessId, currentAuthUid);
 
     // §6.8 auto-archive moves permanent failures (P0001 / 23xxx) into
     // `sync_queue_orphans` and deletes them from `sync_queue`. Check
@@ -1782,7 +1821,14 @@ class SupabaseSyncService {
               state.event == AuthChangeEvent.tokenRefreshed ||
               state.event == AuthChangeEvent.initialSession) {
             _loggedJwtClaimsThisSession = false;
-            await _db.syncDao.clearFailureBackoff();
+            // Supabase fires signedIn before AuthService.setCurrentUser
+            // restores the Drift _currentBusinessId, so clearFailureBackoff
+            // (whereBusiness → requireBusinessId) would throw on a
+            // logout → re-login. _scheduleDebouncedPush is safe — pushPending
+            // self-guards on session businessId.
+            if (_db.currentBusinessId != null) {
+              await _db.syncDao.clearFailureBackoff();
+            }
             _scheduleDebouncedPush();
           } else if (state.event == AuthChangeEvent.signedOut) {
             _loggedJwtClaimsThisSession = false;
@@ -1902,7 +1948,12 @@ class SupabaseSyncService {
       debugPrint(
         '[SyncService] Usable network connected, flushing and pulling...',
       );
-      await _db.syncDao.clearFailureBackoff();
+      // Same guard as the auth-state listener: a connectivity flip can land
+      // before AuthService.setCurrentUser has restored the businessId on
+      // app start, and clearFailureBackoff would throw via requireBusinessId.
+      if (_db.currentBusinessId != null) {
+        await _db.syncDao.clearFailureBackoff();
+      }
       _scheduleDebouncedPush();
 
       final businessId = _db.businessIdResolver.call();
@@ -2187,6 +2238,33 @@ class SupabaseSyncService {
       if (incoming == null) return true; // can't compare; let it through
       return incoming >= local;
     }).toList();
+  }
+
+  /// Restore rows into an append-only ledger table (`_ledgerTables` in
+  /// app_database.dart). Pull is catch-up only: a full upsert would trip the
+  /// BEFORE UPDATE trigger because domain RPCs stamp `created_at` server-side,
+  /// so the cloud row always disagrees with the locally-written row on an
+  /// immutable column. Void columns (`voidedAt/voidedBy/voidReason` plus
+  /// `lastUpdatedAt`) are explicitly mutable, so they ride in a separate
+  /// targeted update gated by `t.voidedAt.isNull()` — a local-then-newer void
+  /// isn't clobbered by a stale cloud snapshot.
+  Future<void> _restoreLedgerTable<TableT extends Table,
+      RowT extends Insertable<RowT>>(
+    List<dynamic> rows, {
+    required TableInfo<TableT, RowT> table,
+    required RowT Function(Map<String, dynamic>) fromJson,
+    required DateTime? Function(RowT data) voidedAtOf,
+    required Expression<bool> Function(TableT t, RowT data) whereNotYetVoided,
+    required UpdateCompanion<RowT> Function(RowT data) buildVoidCompanion,
+  }) async {
+    for (var r in rows) {
+      final data = fromJson(r as Map<String, dynamic>);
+      await _db.into(table).insert(data, mode: InsertMode.insertOrIgnore);
+      if (voidedAtOf(data) != null) {
+        await (_db.update(table)..where((t) => whereNotYetVoided(t, data)))
+            .write(buildVoidCompanion(data));
+      }
+    }
   }
 
   Future<void> _restoreTableData(String table, List<dynamic> data) async {
@@ -2501,11 +2579,20 @@ class SupabaseSyncService {
           }
           break;
         case 'crate_ledger':
-          for (var r in rows) {
-            await _db
-                .into(_db.crateLedger)
-                .insertOnConflictUpdate(CrateLedgerData.fromJson(r));
-          }
+          await _restoreLedgerTable(
+            rows,
+            table: _db.crateLedger,
+            fromJson: CrateLedgerData.fromJson,
+            voidedAtOf: (d) => d.voidedAt,
+            whereNotYetVoided: (t, d) =>
+                t.id.equals(d.id) & t.voidedAt.isNull(),
+            buildVoidCompanion: (d) => CrateLedgerCompanion(
+              voidedAt: Value(d.voidedAt),
+              voidedBy: Value(d.voidedBy),
+              voidReason: Value(d.voidReason),
+              lastUpdatedAt: Value(d.lastUpdatedAt),
+            ),
+          );
           break;
         case 'system_config':
           for (var r in rows) {
@@ -2558,11 +2645,20 @@ class SupabaseSyncService {
           }
           break;
         case 'payment_transactions':
-          for (var r in rows) {
-            await _db
-                .into(_db.paymentTransactions)
-                .insertOnConflictUpdate(PaymentTransactionData.fromJson(r));
-          }
+          await _restoreLedgerTable(
+            rows,
+            table: _db.paymentTransactions,
+            fromJson: PaymentTransactionData.fromJson,
+            voidedAtOf: (d) => d.voidedAt,
+            whereNotYetVoided: (t, d) =>
+                t.id.equals(d.id) & t.voidedAt.isNull(),
+            buildVoidCompanion: (d) => PaymentTransactionsCompanion(
+              voidedAt: Value(d.voidedAt),
+              voidedBy: Value(d.voidedBy),
+              voidReason: Value(d.voidReason),
+              lastUpdatedAt: Value(d.lastUpdatedAt),
+            ),
+          );
           break;
         case 'stock_transfers':
           for (var r in rows) {
@@ -2579,11 +2675,20 @@ class SupabaseSyncService {
           }
           break;
         case 'activity_logs':
-          for (var r in rows) {
-            await _db
-                .into(_db.activityLogs)
-                .insertOnConflictUpdate(ActivityLogData.fromJson(r));
-          }
+          await _restoreLedgerTable(
+            rows,
+            table: _db.activityLogs,
+            fromJson: ActivityLogData.fromJson,
+            voidedAtOf: (d) => d.voidedAt,
+            whereNotYetVoided: (t, d) =>
+                t.id.equals(d.id) & t.voidedAt.isNull(),
+            buildVoidCompanion: (d) => ActivityLogsCompanion(
+              voidedAt: Value(d.voidedAt),
+              voidedBy: Value(d.voidedBy),
+              voidReason: Value(d.voidReason),
+              lastUpdatedAt: Value(d.lastUpdatedAt),
+            ),
+          );
           break;
         case 'notifications':
           for (var r in rows) {
@@ -2607,11 +2712,20 @@ class SupabaseSyncService {
           }
           break;
         case 'stock_transactions':
-          for (var r in rows) {
-            await _db
-                .into(_db.stockTransactions)
-                .insertOnConflictUpdate(StockTransactionData.fromJson(r));
-          }
+          await _restoreLedgerTable(
+            rows,
+            table: _db.stockTransactions,
+            fromJson: StockTransactionData.fromJson,
+            voidedAtOf: (d) => d.voidedAt,
+            whereNotYetVoided: (t, d) =>
+                t.id.equals(d.id) & t.voidedAt.isNull(),
+            buildVoidCompanion: (d) => StockTransactionsCompanion(
+              voidedAt: Value(d.voidedAt),
+              voidedBy: Value(d.voidedBy),
+              voidReason: Value(d.voidReason),
+              lastUpdatedAt: Value(d.lastUpdatedAt),
+            ),
+          );
           break;
         case 'customer_wallets':
           for (var r in rows) {
@@ -2621,11 +2735,20 @@ class SupabaseSyncService {
           }
           break;
         case 'wallet_transactions':
-          for (var r in rows) {
-            await _db
-                .into(_db.walletTransactions)
-                .insertOnConflictUpdate(WalletTransactionData.fromJson(r));
-          }
+          await _restoreLedgerTable(
+            rows,
+            table: _db.walletTransactions,
+            fromJson: WalletTransactionData.fromJson,
+            voidedAtOf: (d) => d.voidedAt,
+            whereNotYetVoided: (t, d) =>
+                t.id.equals(d.id) & t.voidedAt.isNull(),
+            buildVoidCompanion: (d) => WalletTransactionsCompanion(
+              voidedAt: Value(d.voidedAt),
+              voidedBy: Value(d.voidedBy),
+              voidReason: Value(d.voidReason),
+              lastUpdatedAt: Value(d.lastUpdatedAt),
+            ),
+          );
           break;
         case 'saved_carts':
           for (var r in rows) {

--- a/lib/features/sync/screens/sync_issues_screen.dart
+++ b/lib/features/sync/screens/sync_issues_screen.dart
@@ -44,12 +44,21 @@ class _ProfileProbe {
         error = e;
 }
 
-enum _SyncErrorKind { rls, missingBusinessId, duplicateKey, fk, network, other }
+enum _SyncErrorKind {
+  rls,
+  missingBusinessId,
+  authUserMismatch,
+  duplicateKey,
+  fk,
+  network,
+  other,
+}
 
 _SyncErrorKind _classify(String? error) {
   if (error == null) return _SyncErrorKind.other;
   final e = error.toLowerCase();
   if (e == 'missing_business_id') return _SyncErrorKind.missingBusinessId;
+  if (e.startsWith('auth_user_mismatch')) return _SyncErrorKind.authUserMismatch;
   if (e.contains('row-level security')) return _SyncErrorKind.rls;
   if (e.contains('duplicate key')) return _SyncErrorKind.duplicateKey;
   if (e.contains('violates foreign key')) return _SyncErrorKind.fk;
@@ -65,6 +74,8 @@ String _labelFor(_SyncErrorKind kind) {
       return 'RLS rejection';
     case _SyncErrorKind.missingBusinessId:
       return 'Missing business_id';
+    case _SyncErrorKind.authUserMismatch:
+      return 'Wrong user';
     case _SyncErrorKind.duplicateKey:
       return 'Duplicate key';
     case _SyncErrorKind.fk:
@@ -208,6 +219,7 @@ class _SyncIssuesScreenState extends ConsumerState<SyncIssuesScreen> {
   @override
   Widget build(BuildContext context) {
     final t = Theme.of(context);
+    final pendingAsync = ref.watch(pendingQueueItemsProvider);
     final failedAsync = ref.watch(failedQueueItemsProvider);
     final orphanAsync = ref.watch(orphanQueueItemsProvider);
     final pendingCount = ref.watch(pendingQueueCountProvider).valueOrNull ?? 0;
@@ -246,6 +258,35 @@ class _SyncIssuesScreenState extends ConsumerState<SyncIssuesScreen> {
             _deferredCard(t, _deferredTables),
             const SizedBox(height: 28),
           ],
+          _sectionHeader(t, 'Pending items'),
+          const SizedBox(height: 4),
+          Text(
+            'Queued for push. If a row sits here for more than a few minutes, '
+            'tap Retry now to force a fresh attempt or Discard to drop it.',
+            style: TextStyle(
+              fontSize: 12,
+              color: t.colorScheme.onSurface.withValues(alpha: 0.6),
+            ),
+          ),
+          const SizedBox(height: 12),
+          pendingAsync.when(
+            loading: () => const Padding(
+              padding: EdgeInsets.all(24),
+              child: Center(child: CircularProgressIndicator()),
+            ),
+            error: (e, _) => _emptyCard(t, 'Failed to load: $e'),
+            data: (items) {
+              if (items.isEmpty) {
+                return _emptyCard(t, 'No pending items.');
+              }
+              return Column(
+                children: [
+                  for (final item in items) _pendingItemTile(t, item),
+                ],
+              );
+            },
+          ),
+          const SizedBox(height: 28),
           _sectionHeader(t, 'Failed items'),
           const SizedBox(height: 12),
           failedAsync.when(
@@ -675,11 +716,135 @@ class _SyncIssuesScreenState extends ConsumerState<SyncIssuesScreen> {
     );
   }
 
+  Widget _pendingItemTile(ThemeData t, SyncQueueData item) {
+    final hasError = item.errorMessage != null;
+    final kind = _classify(item.errorMessage);
+    final badgeLabel = hasError ? _labelFor(kind) : 'Pending';
+    final badgeColor = hasError
+        ? switch (kind) {
+            _SyncErrorKind.rls => t.colorScheme.error,
+            _SyncErrorKind.missingBusinessId => Colors.orange,
+            _SyncErrorKind.authUserMismatch => t.colorScheme.error,
+            _SyncErrorKind.duplicateKey => Colors.amber,
+            _SyncErrorKind.fk => Colors.deepOrange,
+            _SyncErrorKind.network => Colors.blueGrey,
+            _SyncErrorKind.other => t.colorScheme.onSurface.withValues(alpha: 0.6),
+          }
+        : t.colorScheme.primary;
+    final payloadPreview = item.payload.length > 200
+        ? '${item.payload.substring(0, 200)}…'
+        : item.payload;
+    final nextAttemptLabel = item.nextAttemptAt == null
+        ? 'Next try: ASAP'
+        : 'Next try: ${item.nextAttemptAt!.toLocal()}';
+
+    return Container(
+      margin: const EdgeInsets.only(bottom: 10),
+      padding: const EdgeInsets.all(14),
+      decoration: AppDecorations.glassCard(context, radius: 14),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Container(
+                padding: const EdgeInsets.symmetric(
+                    horizontal: 8, vertical: 3),
+                decoration: BoxDecoration(
+                  color: badgeColor.withValues(alpha: 0.15),
+                  borderRadius: BorderRadius.circular(6),
+                ),
+                child: Text(
+                  badgeLabel,
+                  style: TextStyle(
+                    fontSize: 11,
+                    fontWeight: FontWeight.w700,
+                    color: badgeColor,
+                  ),
+                ),
+              ),
+              const SizedBox(width: 10),
+              Expanded(
+                child: Text(
+                  item.actionType,
+                  style: TextStyle(
+                    fontSize: 13,
+                    fontWeight: FontWeight.w600,
+                    color: t.colorScheme.onSurface,
+                  ),
+                ),
+              ),
+              Text(
+                'attempts: ${item.attempts}',
+                style: TextStyle(
+                  fontSize: 11,
+                  color: t.colorScheme.onSurface.withValues(alpha: 0.6),
+                ),
+              ),
+            ],
+          ),
+          if (hasError) ...[
+            const SizedBox(height: 8),
+            Text(
+              item.errorMessage!,
+              style: TextStyle(
+                fontSize: 12,
+                color: t.colorScheme.error.withValues(alpha: 0.9),
+              ),
+            ),
+          ],
+          const SizedBox(height: 6),
+          Text(
+            nextAttemptLabel,
+            style: TextStyle(
+              fontSize: 11,
+              color: t.colorScheme.onSurface.withValues(alpha: 0.6),
+            ),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            payloadPreview,
+            style: TextStyle(
+              fontSize: 11,
+              fontFamily: 'monospace',
+              color: t.colorScheme.onSurface.withValues(alpha: 0.55),
+            ),
+          ),
+          const SizedBox(height: 10),
+          Row(
+            children: [
+              const Spacer(),
+              TextButton(
+                onPressed: () async {
+                  await _db.syncDao.clearFailureBackoffById(item.id);
+                  unawaited(_sync.pushPending());
+                },
+                child: const Text('Retry now'),
+              ),
+              TextButton(
+                onPressed: () async {
+                  await ref
+                      .read(databaseProvider)
+                      .syncDao
+                      .discardQueueItem(item.id);
+                },
+                style:
+                    TextButton.styleFrom(foregroundColor: t.colorScheme.error),
+                child: const Text('Discard'),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
   Widget _failedItemTile(ThemeData t, SyncQueueData item) {
     final kind = _classify(item.errorMessage);
     final kindColor = switch (kind) {
       _SyncErrorKind.rls => t.colorScheme.error,
       _SyncErrorKind.missingBusinessId => Colors.orange,
+      _SyncErrorKind.authUserMismatch => t.colorScheme.error,
       _SyncErrorKind.duplicateKey => Colors.amber,
       _SyncErrorKind.fk => Colors.deepOrange,
       _SyncErrorKind.network => Colors.blueGrey,

--- a/lib/shared/services/auth_service.dart
+++ b/lib/shared/services/auth_service.dart
@@ -32,6 +32,16 @@ class AuthService extends ValueNotifier<UserData?> {
     _db.businessIdResolver = () => value?.businessId;
     _db.userIdResolver = () => value?.id;
 
+    // Tag every enqueued sync_queue row with the Supabase auth.uid() that
+    // was active when the row was created. Read straight from the SDK
+    // (not `value.authUserId`) because Supabase's auth state hydrates
+    // independently of our Drift `users` row — currentUser is the source
+    // of truth for what auth.uid() the server will see. The dispatch path
+    // refuses to push rows whose tag does not match the current uid, so
+    // an account switch on this device cannot flush the previous user's
+    // queued writes under the new user's JWT.
+    _db.authUserIdResolver = () => _supabase.auth.currentUser?.id;
+
     // Wire single-active-device sign-in: SyncService notifies us when the
     // sessions row matching our currentSessionId has its revoked_at flipped
     // by another device, so we can fullLogout in response.
@@ -665,6 +675,11 @@ class AuthService extends ValueNotifier<UserData?> {
 
   /// Clears the active user, removes the warehouse lock, but retains the
   /// device-level session so the next launch shows the personalized PIN screen.
+  ///
+  /// The Supabase refresh token for THIS device is revoked
+  /// ([SignOutScope.local]) so the on-device JWT cannot be silently
+  /// re-issued after logout. The user's tokens on other devices stay alive —
+  /// use [fullLogout] for an account-wide sign-out.
   void logout() {
     final sid = currentSessionId;
     if (sid != null) {
@@ -677,6 +692,11 @@ class AuthService extends ValueNotifier<UserData?> {
       });
       currentSessionId = null;
     }
+    _supabase.auth
+        .signOut(scope: SignOutScope.local)
+        .catchError(
+          (e) => debugPrint('[AuthService] Supabase signOut(local) error: $e'),
+        );
     value = null;
     _activeMember = null;
     bypassNextBiometric = true;
@@ -701,10 +721,12 @@ class AuthService extends ValueNotifier<UserData?> {
     await _secure.clearAll();
     deviceUserIdNotifier.value = null;
 
-    // 2. Terminate all sessions globally via Supabase (fire-and-forget —
-    //    network failures should not prevent local logout).
+    // 2. Revoke THIS device's Supabase refresh token (fire-and-forget —
+    //    network failures should not prevent local logout). Scoped local
+    //    so the user's tokens on other devices stay alive; a deliberate
+    //    "Sign out of all devices" CTA can pass SignOutScope.global later.
     _supabase.auth
-        .signOut(scope: SignOutScope.global)
+        .signOut(scope: SignOutScope.local)
         .catchError(
           (e) => debugPrint('[AuthService] Supabase signOut error: $e'),
         );


### PR DESCRIPTION
Drift schema v9 → v10. Stamp every sync_queue row with the Supabase auth.uid() that enqueued it; dispatch refuses to push a row whose tag does not match the current session's uid. An account switch on the same device can no longer flush the previous user's queued writes under the new user's JWT.

Files:
- app_database.dart: schemaVersion 9 → 10; sync_queue.auth_user_id TEXT nullable; m.addColumn migration for from < 10; authUserIdResolver closure + currentAuthUserId getter.
- app_database.g.dart: regenerated.
- daos.dart: SyncDao.enqueue / enqueueUpsert / enqueueDelete / retryOrphan stamp auth_user_id; coalesce branches retag on refresh; new watchPendingItems stream.
- supabase_sync_service.dart: dispatch rejects auth_user_id != current auth.uid() as permanent 'auth_user_mismatch' failure (table batch path + _pushDomainItems); flushSale passes uid.
- auth_service.dart: wires _db.authUserIdResolver from SDK's currentUser.id; logout() adds signOut(SignOutScope.local); fullLogout() changed from SignOutScope.global → local.
- app_providers.dart: provider wiring for new resolver.
- sync_issues_screen.dart: pending-items list UI surface.

Also guard clearFailureBackoff() on _db.currentBusinessId != null in the auth-state and connectivity listeners. Supabase's signedIn / online events fire before AuthService.setCurrentUser restores the businessId, so a bare call throws via requireBusinessId() on logout → re-login (and on a connectivity flip during app start). _scheduleDebouncedPush stays unguarded — pushPending() self-guards on session businessId and bails until setCurrentUser lands.

Also fix a pre-existing pull-restore vs append-only-trigger collision. _restoreTableData was using insertOnConflictUpdate for five append-only ledger tables (crate_ledger, payment_transactions, activity_logs, stock_transactions, wallet_transactions). Domain RPCs (pos_record_sale et al.) stamp created_at server-side via v_ts_defaults, so cloud rows always disagree with the locally- written row on an immutable column — the BEFORE UPDATE trigger RAISE ABORTs with 'append-only: only voided_at/voided_by/void_reason may change' (SqliteException 1811), reproduced on post-login pull of a freshly-pushed sale. Bug pre-dates this branch (introduced in 5b766226, exposed now by partial-pull resilience changes in 76934ea) but the L5 smoke surfaced it, so resolving here.

Fix: replace the upsert with insertOrIgnore plus a targeted void- only update. The pull path is catch-up for missing rows; the trigger is the source of truth for what's mutable. The void-only update touches just voidedAt/voidedBy/voidReason/lastUpdatedAt (none in the immutable column list) and is guarded by t.voidedAt.isNull() so a local-then-newer void isn't clobbered by a stale cloud snapshot. In-place voiding via DAO writes (payment_transactions on order cancel, wallet_transactions on void) still round-trips correctly because the void-only update preserves the column changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Pending items" section in sync issues screen displaying queued operations with timestamps and action buttons.
  * Added per-item "Retry now" and "Discard" actions for managing stuck sync items.

* **Bug Fixes**
  * Sync operations now properly validate user context, preventing cross-user sync errors.
  * Enhanced error messaging for authentication-related sync failures ("Wrong user").
  * Improved sync reliability during app startup and authentication state transitions.
  * Sign-out now affects only the current device instead of all devices.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/okworemmanuelc/drinkPosApp/pull/2?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->