### PR TITLE
feat(lock): manual app lock + offline-tolerant PIN unlock

### DIFF
--- a/lib/core/settings/settings_screen.dart
+++ b/lib/core/settings/settings_screen.dart
@@ -15,7 +15,7 @@ class SettingsScreen extends ConsumerStatefulWidget {
 }
 
 class _SettingsScreenState extends ConsumerState<SettingsScreen> {
-  int _autoLockSeconds = 1800; // default 30m
+  int _autoLockSeconds = 0; // default Never — auto-lock is opt-in
   bool _biometricsEnabled = false;
   bool _isLoading = true;
 
@@ -32,7 +32,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
 
     if (mounted) {
       setState(() {
-        _autoLockSeconds = int.tryParse(intervalStr ?? '') ?? 1800;
+        _autoLockSeconds = int.tryParse(intervalStr ?? '') ?? 0;
         _biometricsEnabled = bioStr == 'true';
         _isLoading = false;
       });

--- a/lib/features/auth/screens/login_screen.dart
+++ b/lib/features/auth/screens/login_screen.dart
@@ -13,6 +13,7 @@ import 'package:local_auth/local_auth.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:reebaplus_pos/features/auth/widgets/auth_background.dart';
 import 'package:reebaplus_pos/features/staff/screens/staff_constants.dart';
+import 'package:reebaplus_pos/shared/services/auth_service.dart';
 
 import 'package:reebaplus_pos/core/theme/app_decorations.dart';
 
@@ -340,36 +341,42 @@ class _LoginScreenState extends ConsumerState<LoginScreen>
     final auth = ref.read(authProvider);
 
     // PIN matched a local row, but RLS + sync push need a Supabase JWT too.
-    // If the SDK has no current session (refresh token gave up, signed out
-    // by another path, SDK storage wiped), bounce the user through OTP to
-    // re-establish the JWT before mounting MainLayout. Without this guard
-    // every cloud write piles up in the queue with `pushPending` skipping
-    // on "no auth session", and the Sync Issues screen reports
-    // "no profiles row for current auth.uid()" / "no active Supabase
-    // session" with no path to recovery.
+    // If the SDK has no current session, try a silent refresh first — most
+    // of the time the access token has just expired while the refresh token
+    // is still valid, and the user shouldn't be bounced to OTP over that.
+    // Only fall back to OTP when the refresh genuinely fails on an online
+    // device (refresh token rejected / signed out elsewhere). Offline gets
+    // a pass: the SDK auto-retries on reconnect, sync push self-gates on
+    // auth, so cloud writes safely queue until the JWT comes back.
     if (!auth.hasSupabaseSession && (user.email ?? '').isNotEmpty) {
-      setState(() {
-        _checking = false;
-        _loginSuccess = false;
-      });
-      _pinNotifier.value = '';
-      AppNotification.showError(
-        context,
-        'Your session expired. Please verify your email to continue.',
-      );
-      final error = await auth.sendOtp(user.email!);
+      final refreshResult = await auth.tryRefreshSupabaseSession();
       if (!mounted) return;
-      if (error != null) {
-        AppNotification.showError(context, error);
+
+      if (refreshResult == SessionRefreshResult.failedAuth) {
+        setState(() {
+          _checking = false;
+          _loginSuccess = false;
+        });
+        _pinNotifier.value = '';
+        AppNotification.showError(
+          context,
+          'Your session expired. Please verify your email to continue.',
+        );
+        final error = await auth.sendOtp(user.email!);
+        if (!mounted) return;
+        if (error != null) {
+          AppNotification.showError(context, error);
+          return;
+        }
+        Navigator.of(context).pushReplacement(
+          MaterialPageRoute(
+            builder: (_) =>
+                OtpVerificationScreen(user: user, email: user.email!),
+          ),
+        );
         return;
       }
-      Navigator.of(context).pushReplacement(
-        MaterialPageRoute(
-          builder: (_) =>
-              OtpVerificationScreen(user: user, email: user.email!),
-        ),
-      );
-      return;
+      // refreshed | alreadyValid | offline → continue into the app.
     }
 
     // Brief pause so the user sees all 6 dots filled before the overlay swap.

--- a/lib/features/pos/controllers/pos_controller.dart
+++ b/lib/features/pos/controllers/pos_controller.dart
@@ -79,6 +79,14 @@ class PosController extends ChangeNotifier {
   void _subscribeToProducts() {
     _productsSub?.cancel();
 
+    // The lockedWarehouseId listener fires during lockApp/logout. If the
+    // ordering ever regresses (or another teardown path nulls businessId
+    // before clearing the warehouse), bail rather than throw. Mirrors the
+    // currentUser==null guard in auto_lock_wrapper.dart.
+    if (_database.currentBusinessId == null) {
+      return;
+    }
+
     final warehouseId = _navigationService.lockedWarehouseId.value;
 
     final minLoading = Future.delayed(const Duration(seconds: 2));

--- a/lib/shared/services/auth_service.dart
+++ b/lib/shared/services/auth_service.dart
@@ -737,6 +737,11 @@ class AuthService extends ValueNotifier<UserData?> {
       });
       currentSessionId = null;
     }
+    // Clear nav state BEFORE nulling value. lockedWarehouseId listeners
+    // (e.g. PosController._subscribeToProducts) fire synchronously; if
+    // value is already null, requireBusinessId throws.
+    _nav.clearWarehouseLock();
+    _nav.resetNavigation();
     _supabase.auth
         .signOut(scope: SignOutScope.local)
         .catchError(
@@ -745,8 +750,6 @@ class AuthService extends ValueNotifier<UserData?> {
     value = null;
     _activeMember = null;
     bypassNextBiometric = true;
-    _nav.clearWarehouseLock();
-    _nav.resetNavigation();
   }
 
   /// UI-only lock: drops the in-memory user so the PIN screen takes over,
@@ -755,11 +758,12 @@ class AuthService extends ValueNotifier<UserData?> {
   /// avoids verifyLocalSessionStillActive treating us as a remote kick
   /// on the next resume (it early-returns when value == null).
   void lockApp() {
+    // See logout() — same ordering rule.
+    _nav.clearWarehouseLock();
+    _nav.resetNavigation();
     value = null;
     _activeMember = null;
     bypassNextBiometric = true;
-    _nav.clearWarehouseLock();
-    _nav.resetNavigation();
   }
 
   /// Completely wipes the session, reverting the device to a fresh state.
@@ -798,10 +802,12 @@ class AuthService extends ValueNotifier<UserData?> {
 
     // 4. Clear local state — triggers the ValueListenableBuilder to rebuild.
     //    At this point _hasDeviceUser is already false → routes to EmailEntryScreen.
-    value = null;
-    _activeMember = null;
+    //    Order matters: clear nav first so warehouse-listeners fire while
+    //    the businessId resolver still returns a valid id (see logout()).
     _nav.clearWarehouseLock();
     _nav.resetNavigation();
+    value = null;
+    _activeMember = null;
   }
 
   /// Returns true if [pin] belongs to at least one user whose

--- a/lib/shared/services/auth_service.dart
+++ b/lib/shared/services/auth_service.dart
@@ -15,6 +15,14 @@ import 'package:reebaplus_pos/shared/services/pin_hasher.dart';
 /// Route to show after login instead of the default MainLayout.
 enum PostLoginRoute { none, successDashboard, accessGranted }
 
+/// Outcome of a silent JWT refresh attempt.
+///
+/// Callers use this to decide whether to proceed (refreshed/alreadyValid/
+/// offline) or fall back to OTP (failedAuth). Offline is deliberately
+/// tolerated — the SDK auto-retries on reconnect and sync push already
+/// gates on auth, so cloud writes queue safely until the JWT is back.
+enum SessionRefreshResult { refreshed, alreadyValid, offline, failedAuth }
+
 /// Holds the currently logged-in user.
 /// `value` is null when nobody is logged in.
 class AuthService extends ValueNotifier<UserData?> {
@@ -413,6 +421,43 @@ class AuthService extends ValueNotifier<UserData?> {
     }
   }
 
+  /// Attempts a one-shot JWT refresh without bouncing the user to OTP.
+  ///
+  /// Used by PIN unlock to recover an expired access token silently when
+  /// the refresh token is still valid (typical case: device was idle long
+  /// enough for the access token to expire but the refresh token hasn't).
+  Future<SessionRefreshResult> tryRefreshSupabaseSession() async {
+    if (_supabase.auth.currentSession != null) {
+      return SessionRefreshResult.alreadyValid;
+    }
+    try {
+      final response = await _supabase.auth
+          .refreshSession()
+          .timeout(const Duration(seconds: 8));
+      return response.session != null
+          ? SessionRefreshResult.refreshed
+          : SessionRefreshResult.failedAuth;
+    } on AuthRetryableFetchException catch (e) {
+      debugPrint('[AuthService] refreshSession offline: $e');
+      return SessionRefreshResult.offline;
+    } on TimeoutException catch (_) {
+      return SessionRefreshResult.offline;
+    } on AuthException catch (e) {
+      // "No current session" / refresh-token rejected — genuine auth fail.
+      debugPrint('[AuthService] refreshSession auth failure: $e');
+      return SessionRefreshResult.failedAuth;
+    } catch (e) {
+      final msg = e.toString().toLowerCase();
+      if (msg.contains('socketexception') ||
+          msg.contains('failed host lookup') ||
+          msg.contains('clientexception')) {
+        return SessionRefreshResult.offline;
+      }
+      debugPrint('[AuthService] refreshSession unknown error: $e');
+      return SessionRefreshResult.failedAuth;
+    }
+  }
+
   /// Verifies the [otp] code for [email].
   /// Returns null on success, or an error string on failure.
   Future<String?> verifyOtp(String email, String otp) async {
@@ -697,6 +742,19 @@ class AuthService extends ValueNotifier<UserData?> {
         .catchError(
           (e) => debugPrint('[AuthService] Supabase signOut(local) error: $e'),
         );
+    value = null;
+    _activeMember = null;
+    bypassNextBiometric = true;
+    _nav.clearWarehouseLock();
+    _nav.resetNavigation();
+  }
+
+  /// UI-only lock: drops the in-memory user so the PIN screen takes over,
+  /// but does NOT revoke the sessions row or sign out of Supabase. The
+  /// same device session continues across the lock — keeps RLS happy and
+  /// avoids verifyLocalSessionStillActive treating us as a remote kick
+  /// on the next resume (it early-returns when value == null).
+  void lockApp() {
     value = null;
     _activeMember = null;
     bypassNextBiometric = true;

--- a/lib/shared/widgets/app_drawer.dart
+++ b/lib/shared/widgets/app_drawer.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:reebaplus_pos/core/theme/theme_settings_screen.dart';
 import 'package:reebaplus_pos/core/settings/settings_screen.dart';
@@ -59,38 +60,64 @@ class AppDrawer extends ConsumerWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Material(
-            color: Colors.transparent,
-            child: InkWell(
-              borderRadius: BorderRadius.circular(14),
-              onTap: () {
-                Navigator.pop(context);
-                Navigator.of(context).push(
-                  MaterialPageRoute(builder: (_) => const ProfileScreen()),
-                );
-              },
-              child: Container(
-                width: context.getRSize(56),
-                height: context.getRSize(56),
-                decoration: BoxDecoration(
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              Material(
+                color: Colors.transparent,
+                child: InkWell(
                   borderRadius: BorderRadius.circular(14),
-                  boxShadow: [
-                    BoxShadow(
-                      color: primary.withValues(alpha: 0.4),
-                      blurRadius: 16,
-                      spreadRadius: 2,
+                  onTap: () {
+                    Navigator.pop(context);
+                    Navigator.of(context).push(
+                      MaterialPageRoute(builder: (_) => const ProfileScreen()),
+                    );
+                  },
+                  child: Container(
+                    width: context.getRSize(56),
+                    height: context.getRSize(56),
+                    decoration: BoxDecoration(
+                      borderRadius: BorderRadius.circular(14),
+                      boxShadow: [
+                        BoxShadow(
+                          color: primary.withValues(alpha: 0.4),
+                          blurRadius: 16,
+                          spreadRadius: 2,
+                        ),
+                      ],
                     ),
-                  ],
-                ),
-                child: ClipRRect(
-                  borderRadius: BorderRadius.circular(14),
-                  child: SvgPicture.asset(
-                    'assets/images/logo.svg',
-                    fit: BoxFit.contain,
+                    child: ClipRRect(
+                      borderRadius: BorderRadius.circular(14),
+                      child: SvgPicture.asset(
+                        'assets/images/logo.svg',
+                        fit: BoxFit.contain,
+                      ),
+                    ),
                   ),
                 ),
               ),
-            ),
+              if (user != null)
+                IconButton(
+                  icon: const FaIcon(FontAwesomeIcons.lock, size: 18),
+                  tooltip: 'Lock app',
+                  color: Theme.of(
+                    context,
+                  ).colorScheme.onSurface.withValues(alpha: 0.85),
+                  onPressed: () async {
+                    // Pop the drawer first — mirrors the Log Out pattern below
+                    // so the watched currentUser flipping to null doesn't trip
+                    // tenant-scoped widgets while the drawer is still painting.
+                    Navigator.pop(context);
+                    // Drop any stale paused-time marker so a rapid
+                    // background→resume right after lock doesn't double-fire
+                    // the auto-lock branch.
+                    final prefs = await SharedPreferences.getInstance();
+                    await prefs.remove('app_paused_time');
+                    ref.read(authProvider).lockApp();
+                  },
+                ),
+            ],
           ),
           SizedBox(height: context.getRSize(16)),
           // Sync status indicator. Three signals nested so the badge reflects

--- a/lib/shared/widgets/auto_lock_wrapper.dart
+++ b/lib/shared/widgets/auto_lock_wrapper.dart
@@ -94,11 +94,16 @@ class _AutoLockWrapperState extends ConsumerState<AutoLockWrapper>
         } else {
           final intervalStr =
               await _db.settingsDao.get('auto_lock_interval_seconds');
-          final autoLockSeconds = int.tryParse(intervalStr ?? '') ?? 1800;
+          // Default 0 = Never. Auto-lock is opt-in; an inactivity logout
+          // mid-shift is more disruptive than a stale session.
+          final autoLockSeconds = int.tryParse(intervalStr ?? '') ?? 0;
 
           if (autoLockSeconds > 0 && difference.inSeconds >= autoLockSeconds) {
             if (_auth.currentUser != null) {
-              _auth.logout();
+              // lockApp (not logout) so the sessions row isn't revoked —
+              // otherwise verifyLocalSessionStillActive on the next resume
+              // would falsely trip the remote-kick path. See AuthService.
+              _auth.lockApp();
             }
           }
         }


### PR DESCRIPTION
## Summary

- **Manual `lockApp()`** — UI-only lock that drops the in-memory user without revoking the local `sessions` row or signing out of Supabase. Avoids the false remote-kick that a real `logout()` would trip on the next `verifyLocalSessionStillActive` pass.
- **Drawer lock button** beside the logo (clears stale `app_paused_time` before invoking `lockApp` so a rapid background→resume doesn't double-fire auto-lock).
- **Auto-lock is now opt-in.** Default `auto_lock_interval_seconds` flipped from `1800` to `0` (Never). Settings tile still visible. When opt-in is on, the inactivity branch now calls `lockApp()` instead of `logout()` — same revoke-row fix.
- **Offline-tolerant silent JWT refresh.** New `SessionRefreshResult { refreshed, alreadyValid, offline, failedAuth }` + `tryRefreshSupabaseSession()`. `_enterApp` (login screen) attempts silent refresh before the OTP fallback — only `failedAuth` re-prompts; `refreshed`/`alreadyValid`/`offline` proceed into MainLayout. PIN unlock no longer dies mid-shift on a stale-JWT "no active session".
- **Teardown ordering fix** in `lockApp` / `logout` / `fullLogout`: call `_nav.clearWarehouseLock()` + `_nav.resetNavigation()` **before** nulling `value`. Otherwise `lockedWarehouseId` listeners (e.g. `PosController._subscribeToProducts`) fire synchronously while `businessIdResolver` already returns null and `requireBusinessId` throws.
- **Defensive guard** in `PosController._subscribeToProducts` — early-return when `_database.currentBusinessId == null`, mirroring the existing `currentUser==null` guard in `auto_lock_wrapper.dart`.

## Test plan

- [x] Drawer lock → PIN unlock — no `requireBusinessId` crash; no false "session ended remotely" snackbar on next resume.
- [x] Auto-lock opt-in: default "Never" confirmed; setting a short interval and backgrounding past it routes to PIN; unlock continues.
- [x] Stale-JWT mid-shift: PIN unlock proceeds into MainLayout via silent refresh, no OTP fallback.
- [x] Offline unlock: airplane mode + PIN proceeds; SyncBanner reflects offline state.
- [x] 12h shift expiration still routes to EmailEntryScreen via `fullLogout`.
- [x] Trunk sanity: SyncBanner pending/failed counts and non-blocking sign-in still work post-rebase.
- [x] `flutter analyze` — no issues.

## Notes

- Lock-scope design decision was resolved as "keep current — full reset" (safer default for shared devices). Solo-user context-preservation can be revisited as a follow-up if staff flag the lock→unlock context loss.
- Rebased onto current `main` (`76934ea`) — no conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)