### PR TITLE
Per-user permission override enforcement, live-revert fix (0090), and Restore defaults

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,16 @@ app.*.map.json
 .env.production
 .env.test
 .envrc
+# Keys / signing / service accounts (belt-and-suspenders; hooks also enforce these)
+*.jks
+*.keystore
+*.pem
+*.p12
+*.p8
+*.pfx
+google-services.json
+GoogleService-Info.plist
+service-account*.json
 Thumbs.db
 
 # Local properties (machine-specific)

--- a/BUILD_LOG.md
+++ b/BUILD_LOG.md
@@ -106,6 +106,574 @@ Mark each item with `[x]` as it's completed. Add notes under any item if needed.
 
 ---
 
+## Session 86 — 2026-06-04 — Optional reason when rejecting a stock approval (§16.6.1)
+
+**What the user asked for:**
+- "When approval rejected, log it and notify the user that created that adjustment that their request was approved or rejected."
+
+**What was already there (so it wasn't rebuilt):**
+- Both `approveRequest` and `rejectRequest` already logged to `activity_logs` and notified the requesting stock keeper on each outcome. (The user just couldn't see it until the Session 84 sync fix made the approver's card populate.) Confirmed end-to-end before changing anything.
+
+**Built today (the add-on the user chose):**
+- Rejecting now asks the approver for an **optional reason**. The reason is shown to the stock keeper in their rejection notification and recorded in the activity-log entry. Empty reason still rejects (the reason is simply omitted).
+- The Reject button opens a small dialog (optional text field + Cancel / Reject) before the rejection runs; Cancel leaves the request pending. The dialog owns and disposes its own text controller (the controller-lifecycle rule from the earlier crash fix).
+- Reworded the requester-facing notifications so they read as clearly theirs: "Your stock request was approved & applied — …" / "Your stock request was rejected — (reason)".
+- No schema/migration/cloud change — the reason rides the existing notification + activity-log (the durable audit); nothing displays rejected request rows, so no column was added.
+
+**Files touched:**
+- lib/core/database/daos.dart (`rejectRequest` gains `reason`; approve/reject notification wording)
+- lib/features/dashboard/screens/stock_approvals_screen.dart (`_decide` reject branch + new `_RejectReasonDialog`)
+- reebaplus_master_plan.md (§16.6.1 reject-reason line), BUILD_LOG.md
+
+**Database changes:**
+- None.
+
+**Master plan sections covered:**
+- §16.6.1 (optional reject reason).
+
+**Plan updates made during session:**
+- §16.6.1 amended (optional reason on reject).
+
+**Tested:**
+- `flutter analyze lib` clean.
+- On-device pending: as CEO/Manager, Reports → Stock Approvals → Reject → type a reason → the stock keeper (other device, after sync) gets "Your stock request was rejected — (reason)" and the Activity Log shows "Rejected stock change: (summary) — Reason: (reason)". Empty reason still rejects.
+
+**Known issues / left open:**
+- None.
+
+---
+
+## Session 85 — 2026-06-04 — Repo hygiene: private repo + secret-push guard
+
+**Built today:**
+- Made the GitHub repo private (was public) to protect proprietary code. It had 0 forks / 0 stars, so nothing was lost in the switch.
+- Added a local git-hook guard so secrets/sensitive files can't be committed or pushed. Plain shell, no new dependency.
+  - `pre-commit` scans the staged change; `pre-push` re-scans the commits being pushed (backstop for `--no-verify`).
+  - Blocks sensitive *filenames* (`.env*`, `.envrc`, `*.jks`/`*.keystore`, `key.properties`, `*.pem/.p12/.p8/.pfx`, `google-services.json`, `GoogleService-Info.plist`, `service-account*.json`, `id_rsa*`) — even with `git add -f`.
+  - Blocks secret *content* pasted into any tracked file: private-key blocks, AWS keys, and Supabase **service-role** keys (decodes JWT payload to check `role=service_role`).
+  - Deliberately does NOT flag the Supabase **anon** key in `lib/main.dart` — anon keys are client-public by design (ship in every APK, gated by RLS). Verified it decodes to `role=anon` and passes.
+- Activated with `git config core.hooksPath tools/git-hooks` (one-time per clone — documented in the hooks README).
+
+**Files touched:**
+- tools/git-hooks/_scan.sh (new — shared scan logic)
+- tools/git-hooks/pre-commit (new)
+- tools/git-hooks/pre-push (new)
+- tools/git-hooks/README.md (new)
+- .gitignore (added key/keystore/service-account patterns at root)
+
+**Database changes:**
+- None.
+
+**Master plan sections covered:**
+- None — repo/devops hygiene, not an app feature.
+
+**Plan updates made during session:**
+- None.
+
+**Tested:**
+- 9 unit tests on the scan logic (each filename/content rule blocks; real anon key + ordinary code pass). All green.
+- 6 end-to-end tests in throwaway /tmp repos with real `git commit`/`git push`: clean commit passes; `.envrc` (even `add -f`) blocked; private-key content blocked; `--no-verify` bypass works; `pre-push` blocks the bypassed secret commit; clean repo pushes fine. All green.
+- Dry-ran the scanner over the current uncommitted working tree — no false positives; pending work will commit normally.
+
+**Known issues / left open:**
+- Local guard only; not enforced on GitHub's servers (server-side push protection needs the paid Secret Protection add-on, unavailable on personal private repos). Each machine must run the one-time `core.hooksPath` command.
+- The anon key + URL remain hardcoded in `lib/main.dart` and in git history (intentional — client-public). Not externalized.
+
+**Next session should:**
+- Resume normal feature work. If a second dev machine is set up, run the one-time hook activation there.
+
+---
+
+## Session 84 — 2026-06-04 — Fix: stock approval requests never reached the approver's device (§16.6.1)
+
+**What the user reported:**
+- "Stock keeper added stock and the request-for-approval notification was sent, but as CEO I did not see the approve-stock functionality when I went to the Stock Approvals card on Reports."
+
+**Root cause:**
+- The new synced table `stock_adjustment_requests` (Session 78) was wired into `_syncedTenantTables`, `_pullOrder`, and the cloud `pos_pull_snapshot` — but **not into `_restoreTableData`** in `supabase_sync_service.dart`. The push and the realtime subscription worked (so the notification — a separate already-wired table — arrived), but when the approver's device received the request row via pull/realtime, the per-table apply `switch` had no case for it and **silently dropped it**. So the approver's Stock Approvals card showed nothing. (Exactly the multi-site gap in the [new-synced-table apply-sites] note.)
+
+**Fix:**
+- Added the `case 'stock_adjustment_requests':` to `_restoreTableData` — an FK-resilient id-keyed `insertOnConflictUpdate` (clone of the `stock_adjustments` case). Upsert-only table (never `enqueueDelete`), so the hard-delete sites (`_deleteLocalRowById` / `_hardDeleteReconcileTables` / `_deleteLocalRowsNotIn`) are correctly N/A.
+
+**Files touched:**
+- lib/core/services/supabase_sync_service.dart (`_restoreTableData` apply case)
+
+**Database changes:**
+- None (cloud 0089 already deployed).
+
+**Tested:**
+- `flutter analyze lib` clean.
+- Needs both devices on the rebuilt app: submit a fresh request as stock keeper → it now appears on the CEO/Manager's Stock Approvals card with Approve/Reject. (An already-pending request from the broken build may need a full re-pull / re-login on the approver device to come down, since the incremental pull cursor moved past it.)
+
+**Known issues / left open:**
+- None for this fix.
+
+---
+
+## Session 84 — 2026-06-04 — Per-staff permission toggles now actually take effect (enforcement-leak fixes)
+
+**What the user asked for:**
+- "Review the permissions a CEO can use to override other permissions in the staff management screens. The on/off toggles don't work — toggling a permission off doesn't change anything. What's the cause? Should we remove role-based permissions and make them per-user with role defaults?"
+
+**The finding (and the answer to the design question):**
+- The per-user override system the user imagined **already exists**: each role has default grants (`role_permissions`), and a CEO can override any one staff member's access on their profile (`user_permission_overrides`), merged at runtime by `currentUserPermissionsProvider`. So there was nothing to rebuild — the user picked "fix enforcement only."
+- The toggles **save correctly**; the bug was that flipping one often changed nothing the staff member could do. A toggle only takes effect where the feature asks `hasPermission(ref, '<key>')` (the effective role-default ± override). Several features instead checked the **role name** (e.g. "is this a manager?"), checked **nothing**, or read the **raw role defaults** directly — all of which ignore a per-user override.
+- Audited all 29 toggle-able permissions (one checker per key + a second pass to refute false alarms): 22 were already correct, 1 suspected leak was a false alarm, **9 were real**.
+
+**Built today (the 9 fixes):**
+- **Home "Net Profit" card** — was CEO-only by role; now also shows for anyone the CEO grants `reports.see_profit`.
+- **Home "Customer Wallet" card + "Add Customer" button** — were shown by role; now follow the `customers.add` permission, so revoking it from a cashier hides both.
+- **Customer wallet Total In / Total Out tiles** — a Manager always saw them regardless of the toggle; now they follow `customers.wallet.totals.view` (Managers still see them by default, but the CEO can now turn them off per person).
+- **Add Funds to a wallet** — added a permission re-check at the moment money moves (the button was already hidden correctly).
+- **Supplier Accounts** — the Inventory "Suppliers" tab read raw role defaults (ignored overrides) and the Supplier Accounts screen had no entry guard, so it could be reached without permission; both now follow the effective `suppliers.manage`.
+- **Staff Management** — added a screen entry guard and a re-check before an invite code is generated, so revoking `staff.invite` actually blocks it (the menu item was already gated).
+- **"See buying prices in reports"** (`reports.see_cost_prices`) — was never checked anywhere. Now it gates the raw "Cost of goods" figure (and CSV column) in the Profit Report, on top of the existing profit gate — so a CEO can let someone see profit but withhold the raw cost. (Design note: this is the only place a raw buying-price number appears in reports; profit/net-profit numbers stay governed by `reports.see_profit`.)
+- **Two toggles that did nothing because the feature isn't built** — "Update customer details" (no edit-customer screen yet, §18) and "Manage incoming shipments" (no Track Shipments screen yet, §22) — are now **hidden** from both permission editors (like the existing hidden discount toggle), so the CEO isn't shown switches that can't work. Reversible: un-hide each the moment its feature ships.
+
+**New guardrail:**
+- Added `test/permissions/permission_enforcement_test.dart` — a source scan asserting every non-hidden permission key is actually checked somewhere via `hasPermission` / the effective-permission set. If a future key is added with no enforcement (or only a role-name check), this test goes red. Same idea as the existing sync-leak scanner. It passes now.
+
+**Files touched:**
+- `lib/features/dashboard/screens/home_screen.dart`
+- `lib/features/customers/screens/customers_screen.dart`
+- `lib/features/customers/screens/customer_detail_screen.dart`
+- `lib/features/inventory/screens/inventory_screen.dart`
+- `lib/features/payments/screens/payments_screen.dart`
+- `lib/features/staff/screens/staff_management_screen.dart`
+- `lib/features/staff/widgets/invite_staff_sheet.dart`
+- `lib/features/dashboard/screens/profit_report_screen.dart`
+- `lib/core/settings/role_permissions_detail_screen.dart` (hidden-keys set)
+- `test/permissions/permission_enforcement_test.dart` (new)
+
+**Database changes:**
+- None. No schema, no migration, no new sync registration — pure enforcement wiring on existing screens.
+
+**Master plan sections covered:**
+- §10.2.1 (per-user permission overrides — making them effective everywhere), hard rules #6/#7.
+
+**Plan updates made during session:**
+- None. The per-user override model was already documented (§10.2.1, Sessions 74/76).
+
+**Tested:**
+- `flutter analyze` clean on all 10 touched files. `test/permissions/` passes. `test/customers test/staff test/inventory` all pass.
+- Pre-existing failures, NOT from this work: `test/settings/role_permissions_detail_test.dart` (6) — still hard-codes the OLD permission labels and `Expected: <33>` switches (owned by the in-flight label-rename work). My hidden-keys change shifts the correct visible switch count from 32 → **30** (two more keys hidden), so whoever fixes that test should expect 30, not 33.
+
+**Known issues / left open:**
+- On-device pass pending: revoke `reports.see_profit` from a Manager and `customers.add` from a Cashier on one device, switch to that staff member (shared-PIN), and confirm the gated UI disappears. Repeat for `suppliers.manage` (grant to a cashier → Suppliers surfaces appear).
+- `customers.update` / `shipments.manage` toggles stay hidden until their features (§18 edit-customer, §22 shipments) are built.
+
+**Next session should:**
+- Run the on-device checks above, then continue with whatever is next on the permissions/inventory track.
+
+**Follow-up fix (same day): per-staff override turned OFF didn't revert on the other device.**
+- On-device report: as CEO, granting `activity_logs.view` / `settings.manage` / `sync.view` to a stock keeper propagated live, but turning them back OFF did not — the stock keeper kept the access.
+- Root cause was NOT per-permission and NOT enforcement — it was **one missing cloud property on the override table**. For a stock keeper (whose role default for those keys is OFF), turning a granted override OFF *clears* the row — a hard delete. Supabase Realtime authorizes a DELETE against the row's `business_id`-scoped RLS using only the columns in the table's REPLICA IDENTITY; `user_permission_overrides` was still on the default (primary-key only), so `business_id` was absent, the RLS check failed, and Realtime **dropped the DELETE**. The grant (delivered live as an INSERT, whose new record carries every column) stuck; the removal never arrived until the device next did a full snapshot reconcile (restart / re-login). This is the exact bug 0064 fixed for `role_permissions` / `saved_carts` / `notifications` — `user_permission_overrides` was added in 0088 *after* 0064 and missed.
+- **Fix:** migration `0090_user_permission_overrides_replica_identity_full.sql` → `ALTER TABLE public.user_permission_overrides REPLICA IDENTITY FULL;`. Server-side only — **no app rebuild needed**; takes effect immediately for future deletes. Deployed via `supabase db push`. The client already applied the realtime DELETE (`_deleteLocalRowById` case), so nothing in the app changed.
+- **Because this is a per-TABLE property, the fix covers ALL permission keys at once** — there is no per-permission variant of this bug. It also fixes the mirror case: re-enabling a *default-on* permission after force-revoking it (also a clear → delete).
+- **New guardrail:** `test/sync/replica_identity_full_test.dart` — asserts every table in `_hardDeleteReconcileTables` has an `ALTER TABLE … REPLICA IDENTITY FULL` migration. Would have caught this. Passes now (4/4 hard-delete tables covered). `flutter test test/sync` → 99 pass.
+- **Clearing the already-stuck override:** the stock keeper's device that missed the dropped DELETE still holds the stale row until its next snapshot reconcile (app restart / re-login) — or re-toggle the permission ON then OFF (the OFF now broadcasts correctly).
+
+**Follow-up feature (same day): "Restore defaults" button on the per-staff permission screen (§10.2.1).**
+- The CEO asked for a button to wipe a staff member's overrides back to the role defaults in one tap. Added at the bottom of the per-staff Permission access → Customize screen.
+- **Behaviour:** clears EVERY override for that staff member so all permissions inherit the role default again. Asks for confirmation first (a Cancel/Restore dialog, so a stray tap can't wipe overrides). Disabled with a helper line ("… is already on the … defaults.") when the person has no overrides; not shown for the CEO (who has none). Re-checks `settings.manage` before and after the dialog, and writes an `activity_logs` entry.
+- **Sync:** new `UserPermissionOverridesDao.clearAllForUser(userId)` hard-deletes each override row and `enqueueDelete`s it — so the restore propagates live to the staff member's device (relies on the 0090 replica-identity fix above; without it the clears wouldn't broadcast).
+- **Files:** `lib/features/staff/screens/staff_permissions_screen.dart` (button + confirm + handler), `lib/core/database/daos.dart` (`clearAllForUser`), `reebaplus_master_plan.md` §10.2.1 (documented the button), `test/permissions/user_permission_overrides_dao_test.dart` (new — verifies it clears only that user, returns the count, tombstones each). `flutter analyze` clean; `test/permissions` + `test/staff` pass.
+- **Plan update:** §10.2.1 gained one sentence describing the Restore defaults button (per CLAUDE.md — no UI ships unlisted).
+
+---
+
+## Session 83 — 2026-06-04 — FABs (and modal footers) clear the 3-button system nav bar
+
+**What the user asked for:**
+- "If your [overflow] fix worked, FABs will never go below the system nav buttons on devices with the three bottom system nav buttons. Review all FABs and ensure they don't go below the nav and stay responsive, including in modals."
+
+**Built today:**
+- Root cause: a Scaffold's `floatingActionButton` slot only lifts the FAB ~16px above the content bottom — it does NOT add the system-nav safe area on edge-to-edge (Android 15). On screens where MainLayout's bottom nav bar is HIDDEN (drawer-accessed + pushed screens) the screen reaches the physical bottom, so the FAB landed ~16px up — UNDER the ~48px 3-button nav. (On gesture nav the thin pill ≈ the 16px margin, so the gap was invisible — that's why it was missed.) On the visible-bar tab roots (POS, Stock) the bar already lifts the FAB, so those were already fine.
+- Fix (centralized in the design-system FAB): `AppFAB` now lifts itself above the system nav by default via a new `reserveBottomInset` flag (default true). It uses a new nav-ONLY inset, `context.deviceBottomPadding` (system nav, EXCLUDES the keyboard), so a form's Save FAB shown with the keyboard up doesn't double-lift.
+- Opted out the two visible-bar tab roots: POS "Go to Cart" and Stock "Add Product" pass `reserveBottomInset: false` (the bar already insets them; more would leave a gap above the bar).
+- Net: auto-fixes the FABs on Customers, Payments, Expenses, Stores, Deliveries, Staff Management, and Stock Count.
+- Modals: confirmed every bottom-anchored modal/sheet footer already uses `deviceBottomInset` (so they clear the nav). The only sheets without it are auth screens (run before MainLayout — already correct) and the centered PIN dialog (not bottom-anchored). No modal changes needed.
+- Updated CLAUDE.md's safe-area section: `floatingActionButton` is NOT a "don't-pad" Scaffold slot; documented the `AppFAB` / `reserveBottomInset` / `deviceBottomPadding` rule so it can't regress.
+
+**Files touched:**
+- lib/core/utils/responsive.dart (new `deviceBottomPadding`)
+- lib/core/widgets/app_fab.dart (`reserveBottomInset` + self-inset)
+- lib/features/inventory/screens/inventory_screen.dart (opt out)
+- lib/features/pos/screens/pos_home_screen.dart (opt out)
+- CLAUDE.md (safe-area FAB guidance)
+
+**Database changes:**
+- None.
+
+**Master plan sections covered:**
+- None — UI safe-area robustness. Extends the CLAUDE.md edge-to-edge inset convention to FABs.
+
+**Plan updates made during session:**
+- CLAUDE.md safe-area section updated (FAB inset rule). No master-plan feature change.
+
+**Tested:**
+- `flutter analyze` on the 4 code files — no issues. NOT yet visually confirmed on-device: needs a look on a 3-button-nav emulator — the Add buttons on Customers/Expenses/Payments/Stores/Deliveries/Staff and the Save FAB on Stock Count should sit fully above the nav bar, while the POS/Stock tab FABs should be unchanged (no new gap above the bar).
+
+**Known issues / left open:**
+- Pending the on-device visual confirmation above.
+
+**Next session should:**
+- Confirm FAB clearance on a 3-button-nav device; nothing else outstanding from this pass.
+
+---
+
+## Session 82 — 2026-06-04 — Period filters reversed to calendar periods + non-Manager cap
+
+**Built today:**
+- Reversed the date filters from the rolling set ("Last 24 hours / Last 7 days / Last 30 days / Last year / To date") back to **calendar periods**: **Today, This Week, This Month, This Year, To Date**. "This Week" starts on **Sunday**. "To Date" still means everything up to now. Because they're calendar-anchored, "Today" now means since local midnight (not a fixed 24-hour span).
+- Applied a **role cap**: Cashier and Stock keeper only see **Today / This Week / This Month** on every period selector they can reach (Home, Orders, a customer's wallet, and the Expenses / Supplier-Accounts totals). Manager and CEO see all five. The Reports hub and its sub-screens were already CEO/Manager-only, so they were left showing all five.
+- Added a shared helper `datePeriodLabelsForRole(managerUp:)` and a per-screen value "clamp" so a capped viewer's dropdown never shows a value it isn't allowed to pick (e.g. a Cashier opening a customer wallet, whose default was "To Date", now opens on "This Month").
+- The Expenses monthly budget bar now reflects the **current calendar month** (it previously used a rolling last-30-days window).
+
+**Files touched:**
+- lib/core/utils/date_period.dart
+- lib/features/dashboard/screens/home_screen.dart
+- lib/features/orders/screens/orders_screen.dart
+- lib/features/customers/screens/customer_detail_screen.dart
+- lib/features/expenses/screens/expenses_screen.dart
+- lib/features/payments/screens/payments_screen.dart
+- lib/features/inventory/screens/supplier_detail_screen.dart
+- test/utils/date_period_test.dart
+- reebaplus_master_plan.md, BUILD_LOG.md
+
+**Database changes:**
+- None.
+
+**Master plan sections covered:**
+- §30.11 — rewrote the canonical chip set to calendar periods + documented the non-Manager cap.
+- §11.2, §19.1/§19.2, §20.1, §25.1, §25.9, §30.6 — updated the scattered default-label references.
+
+**Plan updates made during session:**
+- §30.11 reversed from rolling windows back to calendar periods (user request, 2026-06-04); added the explicit non-Manager Today/This Week/This Month cap. Reconciled all "rolling" / "Last 24 hours" / "Last 30 days" references across the plan.
+
+**Tested:**
+- Rewrote test/utils/date_period_test.dart for calendar boundaries (Sunday-start week, month/year starts) + the role-cap helper — 25 cases, all green.
+- `flutter analyze` clean on all touched files.
+
+**Known issues / left open:**
+- On-device pass not yet done (emulator) — confirm a Cashier sees only the three chips on Home/Orders/wallet and that the customer wallet opens on "This Month" without crashing.
+
+**Next session should:**
+- Run the app on the emulator and spot-check the role cap + calendar filtering as above.
+
+---
+
+## Session 81 — 2026-06-04 — Permission-wiring audit + 9 enforcement-leak fixes; staff Permission-access card redesign
+
+**What the user asked for:**
+- "I turned on and turned off manage business settings but the ceo settings is still accessible to this same cashier… deploy workflow to ensure every permission is wired correctly in the permissions role, and while they are investigating, redesign the permissions tappable card in the staff's profile — right now the card is cluttered."
+
+**What I did:**
+- **Redesigned the "Permission access" card** on the staff profile (`staff_detail_screen.dart`). It was cluttered — a header row, a full sentence, AND a nested "Customize…" row with a second icon, subtext and chevron. Collapsed it to a single clean line matching the info rows above it: icon · "Permission access" · a state value (**Role default** / **N overrides** / **Full access** for CEO) · chevron. The value turns the accent colour when the staff member has overrides; CEO is non-tappable full-access. Behaviour and gating unchanged.
+- **Ran a multi-agent audit workflow** over all 33 permission keys (90 sub-agents: a finder per key + adversarial verifiers on each suspected leak + a synthesis). It found **9 confirmed enforcement leaks** and ~20 false suspicions it dismissed. Recurring root cause: an entry point gated on a **role slug or the wrong key** instead of the permission key, or the destination screen never re-checking.
+- **The reported `settings.manage` symptom is NOT a code bug.** The CEO-Settings vertical (drawer + screen body + all 7 sub-screens) is correctly gated. Most likely the test device was logged in as the **CEO** (always-on, non-overridable by design), or the revoke simply hadn't propagated/refreshed on the cashier's device. Told the user to confirm which role was logged in.
+- **Fixed all 9 confirmed leaks** (user approved "all 9"):
+  1. `products.edit_price` — long-press product editor was ungated; now gated on the key (entry + save re-check).
+  2. `stock.add` — the editor's "quantity to add" field added stock with no check; now gated, with stock-keeper adds routed through the §16.6.1 approval flow.
+  3. `stock.adjust` — Daily Stock Count was gated by role slug only; now also requires the permission (icon + fail-closed screen guard).
+  4. `reports.see_sales` — Home "Total Sales" card was role-only; now requires the key.
+  5. `reports.see_expenses` — Expenses drawer item gated the wrong key (`expenses.create`) and the screen never re-checked; fixed the drawer key, the Home card, and added a load-bearing screen-body guard.
+  6. `funds.view` — Daily Reconciliation exposed per-account balances (card + CSV) with no check; gated both (rest of the report stays Manager-visible per §25.3).
+  7. `funds.open_day` — Open-Day form/handler and the POS "opening cash" CTA were role-only; now gated on the key (form + handler re-check + POS tap).
+  8. `customers.add` — Cart "New customer" bypassed the only gate; added a re-check at the single save chokepoint and hid the Cart button.
+  9. `settings.manage` — standalone Stores tab body + Add/Edit/Delete + Stock Transfer were unguarded (only reachable via the gated drawer item); added a reactive body guard, gated the FAB/Stock-Transfer action, and write-boundary re-checks.
+- Also fixed the cosmetic hard-rule-#7 item: Home "Stock Value" card now respects `stock.view`.
+
+**Dead keys noted (gate nothing, left as-is):** `sales.discount.give` (intentional — uses the discount slider), `customers.update` (no edit-customer feature yet), `reports.see_cost_prices`, `shipments.manage` (§22 unbuilt). Not wired this session — the user chose the "all 9 confirmed leaks" scope, not the dead-key wiring.
+
+**Files touched:**
+- lib/features/staff/screens/staff_detail_screen.dart (card redesign)
+- lib/features/inventory/screens/inventory_screen.dart, lib/features/inventory/widgets/update_product_sheet.dart, lib/features/inventory/screens/stock_count_screen.dart (#1–3)
+- lib/features/dashboard/screens/home_screen.dart, lib/shared/widgets/app_drawer.dart, lib/features/expenses/screens/expenses_screen.dart (#4–5)
+- lib/features/dashboard/screens/daily_reconciliation_detail_screen.dart (#6)
+- lib/features/funds/screens/funds_register_screen.dart, lib/features/pos/screens/pos_home_screen.dart (#7)
+- lib/features/customers/widgets/add_customer_sheet.dart, lib/features/pos/screens/cart_screen.dart (#8)
+- lib/features/stores/screens/stores_screen.dart, lib/features/stores/screens/stock_transfer_screen.dart (#9)
+
+**Database changes:**
+- None — pure UI/permission-gating. No schema, no sync registration, no migration.
+
+**Master plan sections covered:**
+- No new features. Enforcement-only hardening of existing permission keys (hard rules #6/#7). No plan changes.
+
+**Tested:**
+- `flutter analyze` on all 14 touched files — no issues.
+- `flutter test test/sync test/database` — 157 pass. `test/settings/sidebar_role_visibility_test.dart` (exercises the #5 drawer change) — passes. `test/customers`, `test/staff`, `test/inventory`, `test/pos`, `test/expenses`, `test/funds` — pass.
+- **Pre-existing failures, NOT from this work:** `test/settings/role_permissions_detail_test.dart` (6) hard-codes the OLD permission labels ("Edit product prices", "View stock levels") and expects 33 switches; the in-flight label rename (migration 0087 + `app_database.dart` catalogue edits, already in git status) renamed them and hides `sales.discount.give` (→ 32). `test/utils/date_period_test.dart` references removed `DatePeriod` enum names. Both belong to other in-progress work — left untouched.
+
+**Known issues / left open:**
+- The 4 dead permission keys above remain unwired (out of chosen scope).
+- The `role_permissions_detail_test.dart` / `date_period_test.dart` failures should be updated by whoever owns the label-rename / date-period work.
+
+**Next session should:**
+- Confirm on-device: revoke a permission from a Cashier (e.g. `stock.adjust`, `reports.see_sales`) and verify the gated UI disappears for that cashier on a second device.
+
+---
+
+## Session 80 — 2026-06-04 — Keyboard & overflow hardening (scrollable modals, capped text scaling, Row fixes)
+
+**What the user asked for:**
+- "A lot of screens show 'bottom overflowed by xx pixels', especially when the keyboard comes up — what's causing it and the fix?" After the diagnosis, they approved a three-part fix to do "in that order": (a) make keyboard forms scroll, (b) cap OS text scaling, (c) audit Rows for sideways overflow and fix.
+
+**Built today:**
+- (a) Stopped the "BOTTOM OVERFLOWED BY … pixels" stripe on modals when the keyboard opens. Cause: every screen sits under MainLayout's Scaffold (resizeToAvoidBottomInset defaults on), so the keyboard shrinks the content area by ~⅓; a fixed, non-scrolling Column can't fit and overflows. Fix: the content now scrolls, so it slides instead of overflowing.
+  - Edit-item modal (POS cart line editor): wrapped in a scroll view.
+  - Invite-staff sheet: wrapped in a scroll view AND fixed a real bug — its keyboard padding used `MediaQuery.viewInsets.bottom`, which reads 0 under MainLayout (the trap documented in CLAUDE.md), so it was double/none-padding. Now uses `deviceBottomInset` only.
+  - Quick Sale dialog: wrapped its content in a scroll view.
+  - POS "Switch Store" picker grid: now scrolls when there are more stores than fit (it used to overflow — not a keyboard case).
+  - Verified four other input sheets (add-customer, add-payment, receive-delivery, crate-return) already scroll correctly — left untouched.
+- (b) Capped the phone's system font-size multiplier at 1.3× in main.dart's MaterialApp builder, so very large accessibility text can't blow out the dense POS layouts. Type still scales by screen width as before; this only bounds the extra OS multiplier on top. Easy to raise later.
+- (c) Fixed horizontal "RIGHT OVERFLOWED" risks where a long name/amount sat in a Row with no room to shrink — now they truncate with "…":
+  - On-screen receipt: per-manufacturer crate line.
+  - Cart: crate-deposit line label.
+  - Expenses: category-section header.
+  - Supplier detail: "Goods Received" header.
+
+**Files touched:**
+- lib/main.dart
+- lib/features/pos/widgets/edit_item_modal.dart
+- lib/features/pos/widgets/quick_sale_modal.dart
+- lib/features/staff/widgets/invite_staff_sheet.dart
+- lib/features/pos/screens/pos_home_screen.dart
+- lib/features/pos/screens/cart_screen.dart
+- lib/features/expenses/screens/expenses_screen.dart
+- lib/features/inventory/screens/supplier_detail_screen.dart
+- lib/shared/widgets/receipt_widget.dart
+- lib/features/inventory/screens/product_detail_screen.dart (follow-up, after editing done)
+- lib/features/funds/screens/funds_register_screen.dart (follow-up, after editing done)
+- lib/features/inventory/screens/inventory_screen.dart (follow-up, after editing done)
+
+**Database changes:**
+- None.
+
+**Master plan sections covered:**
+- None — cross-cutting UI robustness pass, no feature/plan changes. Follows the existing safe-area inset convention in CLAUDE.md.
+
+**Plan updates made during session:**
+- None.
+
+**Tested:**
+- `flutter analyze` on all 12 touched files — no issues. Did NOT run the full test suite: the working tree had other in-progress work (new migrations/screens) unrelated to this, and these are layout-only changes with no test coverage — analyze is the right check here.
+
+**Known issues / left open:**
+- The 1.3× text-scale cap is a judgment call — adjust in main.dart if larger text is wanted.
+- Three follow-ups that were initially deferred (those files were being edited live) were COMPLETED later the same session once editing finished: product_detail `_UpdateStockSheet` got the scroll wrap; the funds_register account rows (day-summary + close-day sheet) and the inventory "Update [manufacturer]" dialog title now wrap in Expanded + ellipsis.
+
+**Next session should:**
+- Nothing outstanding from this pass. Optionally extend the same Expanded+ellipsis treatment to the remaining LOW-confidence Row sites from the audit (static-label + amount rows) only if huge currency values ever overflow on the narrowest devices.
+
+---
+
+## Session 79 — 2026-06-04 — Reusable sync safeguard (can't silently fail to sync)
+
+**What the user asked for:**
+- "build a reusable sync safeguard so future features and existing features can't silently fail to sync." (And: create a new branch for the work first.)
+
+**Built today:**
+- A three-layer, automated guardrail that enforces the §5 sync invariant (every write to a synced table must reach the cloud via a DAO's enqueue), so the failure can't slip through code review:
+  - **Layer A — runtime guard.** `SyncDao.enqueueUpsert`/`enqueueDelete` now throw if asked to enqueue a table that isn't a real synced/cache/businesses table. A typo'd or unregistered table name fails immediately at the write, instead of quietly sticking in the outbox as a failed item. (Same idea as the existing ledger-delete guard.)
+  - **Layer B — registration check.** A test reads the live database shape and flags any table that *looks* syncable (has both a `business_id` and a `last_updated_at` column) but was never registered for sync. This is the big one: it makes "added a new table, forgot to wire up sync" turn the tests red instead of silently never syncing.
+  - **Layer C — leak scanner.** A test scans the app's source for a write to a synced table that has no matching enqueue anywhere in the same method — i.e. a screen or service that writes to the database without sending it to the cloud. The exact silent bug the user was worried about.
+- A small "exempt" marker convention so the handful of legitimate local-only writes (the sync engine itself, PIN columns, onboarding/staff-signup mirrors, rejected-sale reversal) declare themselves with a one-line comment instead of tripping the scanner.
+- The scanner found **zero** real leaks in the current app — only the already-documented legitimate exceptions — and it correctly caught a deliberately-planted bad write during testing, then went green again once removed.
+
+**Files touched:**
+- lib/core/database/app_database.dart (3 public constants: kSyncedTenantTables, kSyncCacheTables, kEnqueueableTables)
+- lib/core/database/daos.dart (Layer A guards in enqueueUpsert/enqueueDelete)
+- lib/core/services/supabase_sync_service.dart (sync-exempt-file marker)
+- lib/shared/services/order_service.dart, lib/shared/services/auth_service.dart, lib/features/auth/screens/staff_sign_up_screen.dart (sync-exempt markers on the legitimate §5 exceptions)
+- test/sync/sync_dao_enqueue_guard_test.dart, test/sync/sync_table_registration_test.dart, test/sync/sync_raw_write_leak_test.dart (new)
+- CLAUDE.md (§5 — documented the safeguard + marker convention)
+- Ran build_runner once to regenerate the stale Drift code for the in-progress stock_adjustment_requests feature (only the two .g.dart files changed) so the project would compile for testing.
+
+**Database changes:**
+- None. (Added public constant aliases only; no schema change.)
+
+**Master plan sections covered:**
+- None new — this enforces the existing CLAUDE.md §5 sync invariant; it is build tooling, not a product feature.
+
+**Plan updates made during session:**
+- None.
+
+**Tested:**
+- `flutter analyze` clean. `flutter test test/sync test/orders test/customers test/expenses test/inventory` → all 138+ passed (no regression from the Layer A guard). The three new sync tests pass; Layer C verified to catch a planted leak and go green after removal.
+
+**Known issues / left open:**
+- Out of scope by design: partial-row upserts (missing NOT NULL → cloud 23502; not silent, surfaces as failed), domain-envelope payload-key drift (covered by dispatch tests), and stream-provider registration for new synced tables (UI propagation, a possible future "Layer D").
+- Work is on branch `feat/sync-write-guardrails` (not yet merged/committed).
+
+**Next session should:**
+- Commit/merge `feat/sync-write-guardrails` if approved; consider a future "Layer D" that checks every synced table also has a stream provider.
+
+---
+
+## Session 78 — 2026-06-04 — Stock-keeper adjustments now need approval (§16.6.1)
+
+**What the user asked for:**
+- "Before updating inventory for stock keeper actions, send them to manager of the store and ceo for approval in reports tab. It should be a tappable card that when tapped, expands with details of what happened and seeks for approval. If manager or ceo has approved, then proceed."
+
+**Plan conflict flagged + resolved:**
+- The plan (line ~1413) said "there is no Pending Approvals card on Reports." The user confirmed (AskUserQuestion) they want the approval card **on the Reports tab** anyway (overriding that line), and that approval applies to **stock add/remove only** (not product create / shipments). Plan amended accordingly before coding.
+
+**Built today:**
+- A stock keeper's **Update Stock** (Add/Remove) no longer changes inventory directly. It now records a **pending request** and shows "Sent for approval." Inventory stays unchanged until a Manager/CEO approves.
+- The request notifies the **CEO + the affected store's Manager(s)** (CEO-only if no manager is tied to that store) — same audience as the old post-hoc notice, which this replaces.
+- New **Stock Approvals** card on the Reports hub (CEO + Manager) with a count badge. CEO sees every store's requests; a Manager only their assigned store(s). Each request is a **tappable card that expands** to who/store/reason/when with **Approve / Reject**.
+- **Approve** runs the real adjustment through the existing atomic `adjustStock` path (so the stock number changes only now; a Remove that no longer fits fails and stays pending). **Reject** discards it. Both notify the stock keeper who submitted.
+- Manager/CEO stock adjustments are unaffected — they still apply directly.
+
+**Files touched:**
+- `lib/core/database/app_database.dart` (new `StockAdjustmentRequests` table, schemaVersion 33→34, v34 migration block, `_syncedTenantTables`, @DriftDatabase registration)
+- `lib/core/database/daos.dart` (new `StockAdjustmentRequestsDao` — request / approve / reject / watchPending, reusing `adjustStock`)
+- `lib/core/services/supabase_sync_service.dart` (`_pullOrder`)
+- `lib/core/providers/stream_providers.dart` (`pendingStockRequestsProvider` + `viewerScopedPendingStockRequestsProvider`)
+- `lib/features/inventory/screens/product_detail_screen.dart` (onSave branches stock-keeper→request vs direct adjust; removed the now-dead post-hoc notify helper)
+- `lib/features/dashboard/screens/stock_approvals_screen.dart` (new — expandable approval cards)
+- `lib/features/dashboard/screens/reports_hub_screen.dart` (Stock Approvals card + badge)
+- `lib/shared/widgets/notifications_modal.dart` (icon/colour for the new notification types)
+- `supabase/migrations/0089_stock_adjustment_requests.sql` (new)
+- `reebaplus_master_plan.md` (§16.6 Stock Keeper save, new §16.6.1, §25.2 Stock Approvals card, §26.4 notifications), generated drift files, `BUILD_LOG.md`
+
+**Database changes:**
+- New synced table `stock_adjustment_requests`, local schema v33 → v34, cloud migration 0089 (table + RLS via `current_user_business_ids()` + bump trigger + realtime + `pos_pull_snapshot`). Additive only.
+
+**Master plan sections covered:**
+- §16.6 / §16.6.1 (new approval flow), §25.2 (Stock Approvals card), §26.4 (notifications).
+
+**Plan updates made during session:**
+- Amended §16.6 Stock Keeper save, added §16.6.1, amended the §25.2 "no approvals card on Reports" note (stock approvals are the one exception), amended §26.4 stock-keeper notification lines.
+
+**Tested:**
+- `flutter analyze` clean on all touched Dart files; `build_runner` regen succeeded.
+- On-device verification pending (emulator): submit as stock keeper → "Sent for approval", number unchanged; approve as CEO/Manager from Reports → number changes; reject → discarded; both notify the stock keeper.
+
+**Known issues / left open:**
+- Cloud migration 0089 must be deployed (`supabase db push`) before a v34 device pushes a request, or the upsert 42P01s.
+
+---
+
+## Session 77 — 2026-06-04 — Confirm before Close Day
+
+**What the user asked for:**
+- "Add a confirmation before close the day so as to avoid mistakenly closing the day."
+
+**Built today:**
+- The Close Day flow now asks "Close the day?" one more time before it actually closes. Tapping "Confirm Close Day" on the count-cash sheet pops up a dialog explaining that closing locks that day's sales and a new day must be opened to continue. Cancel backs out and changes nothing; "Close Day" goes ahead. Stops an accidental tap from closing the day.
+- The dialog shows the date in a friendly format (e.g. "Thu, 4 Jun 2026") instead of the raw "2026-06-04", matching the Daily Reconciliation screens.
+
+**Files touched:**
+- lib/features/funds/screens/funds_register_screen.dart
+
+**Database changes:**
+- None.
+
+**Master plan sections covered:**
+- §23.6 (Close Day flow) — no plan change, just a safety confirmation.
+
+**Plan updates made during session:**
+- None.
+
+**Tested:**
+- `flutter analyze` on the changed file — no issues.
+
+**Known issues / left open:**
+- None.
+
+---
+
+## Session 76 — 2026-06-04 — Per-staff permission overrides built for real (User scope) (§10.2.1)
+
+**What the user asked for:**
+- After the earlier session that scaffolded Business → Store → User scopes with Store/User as placeholders, the user asked "what's the way forward — build multi-store now?" The honest answer: full multi-store is Phase 2 and a multi-session epic, BUT the part they cared about — the CEO opening a staff member's profile and changing that one person's access — is the **User** scope, which is **independent of multi-store**. They chose to build per-user overrides now. (Store overrides stay a placeholder, still blocked on multi-store.)
+
+**Built today:**
+- **New synced tenant table `user_permission_overrides`** (`business_id`, `user_id`, `permission_key`, `is_granted`). A row forces a permission on (`is_granted` true) or off (false) for one staff member; no row = inherit the role default. Local Drift table (schema v33) + DAO (`UserPermissionOverridesDao.setOverride` / `watchForUser`) that routes writes through `enqueueUpsert`/`enqueueDelete` (§5 sync contract). Added to `_syncedTenantTables`, registered on `AppDatabase`, with a `userPermissionOverridesProvider` stream provider.
+- **Runtime resolver merge:** `currentUserPermissionsProvider` now computes effective = role grants ± the user's overrides (grant adds, revoke removes). The CEO is skipped entirely — always all-on, never overridable.
+- **Per-user override editor** (`StaffPermissionsScreen`): reached from Staff Management → tap a staff member → **Permission access → Customize**. Mirrors the per-role screen (toggles grouped by category, hidden keys excluded, dependency gating + cascade-revoke, activity logging). Each toggle shows the **effective** value; flipping away from the role default stores an override, flipping back clears it (subtitle shows "Overridden — role default is on/off"). The staff-profile card went from a disabled placeholder to a live entry showing the override count.
+- **Cloud migration 0088:** creates `user_permission_overrides` with RLS via `current_user_business_ids()` (the fixed profiles-based pattern, from the start — no follow-up fix migration needed), FK to `permissions(key)`, the `_bump_last_updated_at` trigger, realtime publication, and the table appended to `pos_pull_snapshot`. Deployed via `supabase db push` (only 0088 was pending; no divergence).
+
+**Files touched:**
+- `reebaplus_master_plan.md` (§10.2.1 User scope promoted to "BUILT (Phase 1)"; §2.4 table added)
+- `lib/core/database/app_database.dart` (table, schemaVersion 32→33, v33 migration block, `_syncedTenantTables`, @DriftDatabase registration)
+- `lib/core/database/daos.dart` (`UserPermissionOverridesDao`)
+- `lib/core/providers/stream_providers.dart` (`userPermissionOverridesProvider` + resolver merge)
+- `lib/features/staff/screens/staff_permissions_screen.dart` (new)
+- `lib/features/staff/screens/staff_detail_screen.dart` (Permission access card now navigates)
+- `supabase/migrations/0088_user_permission_overrides.sql` (new)
+- generated drift files (build_runner), `BUILD_LOG.md`
+
+**Database changes:**
+- New synced table `user_permission_overrides`, local schema v32 → v33, cloud migration 0088. Additive only.
+
+**Master plan sections covered:**
+- §10.2.1 — User scope is now BUILT (Phase 1). Store scope remains a placeholder pending multi-store (Phase 2, §2.2).
+
+**Plan updates made during session:**
+- §10.2.1 rewritten: User scope promoted from placeholder to built, with storage/resolution documented. §2.4 gained the `user_permission_overrides` table. Approved by the user (chose "Per-user overrides now").
+
+**Follow-up fix (same day): overrides weren't reaching the second device.** First on-device test: CEO overrode a Cashier's permission, logged in as that staff on a SECOND device — nothing changed. Root cause was NOT the resolver (that was correct) — it was the **client-side sync apply path**. `user_permission_overrides` was added to the cloud pull (`pos_pull_snapshot`, 0088) and `_syncedTenantTables`, but NOT to the sync service's per-table sites: it was missing from `_pullOrder` (which drives both the pull-restore loop AND the realtime subscription loop), had no `_restoreTableData` case (so pulled/realtime rows were silently dropped), and no hard-delete handling. Fixed by wiring it exactly like `role_permissions` (its twin: random id, logical key `(business_id, user_id, permission_key)`, grant=upsert, clear=hard-delete) at all five sites in `supabase_sync_service.dart`: `_pullOrder`, `_restoreTableData` (with logical-key dedup), `_deleteLocalRowById`, `_hardDeleteReconcileTables`, `_deleteLocalRowsNotIn`. Lesson: a new synced table needs the §5 DAO/enqueue contract PLUS registration at every per-table switch in `supabase_sync_service.dart`, not just the pull RPC. **Both devices must run the rebuilt app to pick this up.**
+
+**Status:** `flutter analyze` clean (only pre-existing `avoid_print` infos in a test report file). `flutter test test/database test/sync` → all pass (157 after the sync-wiring fix; the v33 migration's idempotency guard verified by the revert-then-re-upgrade suite). Cloud migration deployed. On-device cross-device confirmation pending after rebuilding both devices.
+
+**Tested:**
+- Full `flutter analyze`; database + sync test suites; `build_runner` codegen; `supabase db push`.
+
+**Known issues / left open:**
+- Store-scope overrides still a placeholder (needs the multi-store epic — Phase 2).
+- On-device pass pending: open a staff member → Permission access → Customize; flip a toggle (creates an override, effective set updates, count shows on the card); flip back (clears it); verify the override syncs to a second device and the affected staff member's gated UI reflects it. CEO target shows the static "full access" note (no editor).
+- Resolver applies overrides as a flat add/remove; if a later ROLE change orphaned an overridden child whose parent went off at role level, the editor's gating still shows it correctly but the resolver wouldn't re-cascade. Acceptable edge case (mirrors how role grants are already trusted to be dependency-consistent); revisit if it ever bites.
+
+**Next session should:**
+- Get the on-device confirmation above, then decide whether to start the Phase 2 multi-store groundwork (current-store context + `StoreScopedDao`) that the Store scope depends on.
+
+---
+
+## Session 75 — 2026-06-04 — Stock-update crash fix + accurate view-only banner + inventory store confinement + store-scoped stock notification (§16.6/§16.7/§26.4)
+
+**What the user asked for:**
+- A crash ("A TextEditingController was used after being disposed") that happened when a Stock keeper updated stock from the Product Details screen.
+- When a product is view-only for a staff member, show a clear "VIEW ONLY" tag and the real reason — not always "this product is not in your store".
+- Notify the CEO and store manager whenever a Stock keeper adds or removes stock (with the reason). During planning the user also clarified: roles below Manager should only see items in their assigned store, and the notification should go to the affected store's Manager(s), not every Manager.
+
+**Built today:**
+- **Fixed the crash.** The Update Stock bottom sheet used to create its text boxes in the caller and throw them away right after the sheet closed, which collided with the closing animation. Moved the sheet into its own widget that owns and cleans up its own text boxes at the right time (the same pattern every other sheet in the app already uses). No behaviour changed — same Add/Remove modes, store picker, reason, validation, and permission re-checks.
+- **Accurate view-only message.** A Cashier opening a product now sees a clear "VIEW ONLY" tag instead of the misleading "not in your store".
+- **Store confinement in Inventory.** Cashiers and Stock keepers are now locked to their assigned store in the Inventory store picker (no "All Stores", and the product list only shows their store) — matching how the Home screen already behaves. The CEO, and a Manager the CEO granted all-stores, are unchanged.
+- **Store-scoped stock notification.** A Stock keeper's add/remove now notifies the CEO plus the Manager(s) assigned to the store where the stock moved, instead of every Manager. If no Manager is tied to that store, only the CEO is notified.
+
+**Files touched:**
+- lib/features/inventory/screens/product_detail_screen.dart
+- lib/features/inventory/screens/inventory_screen.dart
+- lib/core/database/daos.dart
+- reebaplus_master_plan.md
+- BUILD_LOG.md
+
+**Database changes:**
+- None. Added one read-only DAO query (`UserStoresDao.getUserIdsForStore`) — no new tables, columns, or migrations.
+
+**Master plan sections covered:**
+- §16.6 / §16.7 — product detail view-only state and inventory store access.
+- §26.4 — stock-keeper stock-movement notification.
+
+**Plan updates made during session:**
+- §26.4 amended: the Stock keeper add/removed-stock notification now fires to the CEO and the **affected store's** Manager(s) (was "all Managers"), with an all-Managers fallback when none are assigned to that store. Noted inline in the plan with today's date.
+
+**Tested:**
+- `flutter analyze` clean on all touched files (only pre-existing `avoid_print` infos remain in an unrelated test file).
+- On-device emulator verification still pending (see below).
+
+**Known issues / left open:**
+- Needs an on-device pass: confirm the crash is gone with the keyboard up (Add and Remove), the Cashier banner reads correctly, a locked Cashier/Stock keeper sees only their store, and only the CEO + that store's Manager(s) get the notification.
+- A Manager without the all-stores grant and without any assigned store falls back to the "My Store" chip (mirrors Home) — acceptable, but worth revisiting if managers should always be store-assigned.
+
+**Next session should:**
+- Run the on-device checks above, then continue with whatever is next on the inventory/permissions track.
+
 ## Session 74 — 2026-06-04 — Permission scopes: Business → Store → User (Business real, Store/User placeholders) (§10.2.1)
 
 **What the user asked for:**

--- a/BUILD_LOG.md
+++ b/BUILD_LOG.md
@@ -106,6 +106,47 @@ Mark each item with `[x]` as it's completed. Add notes under any item if needed.
 
 ---
 
+## Session 74 — 2026-06-04 — Permission scopes: Business → Store → User (Business real, Store/User placeholders) (§10.2.1)
+
+**What the user asked for:**
+- Permission settings shouldn't be managed only per role. They should layer by scope: per **business** first (default for all stores), then per **store** (default for all users in that store), then per **user** (overrides the rest). Since multi-store isn't fully built, add placeholders where the store/user layers will go. The user clarified the "user" layer means: the CEO opens an individual staff member's profile and changes that one person's permission access.
+
+**Plan-conflict flagged first (per CLAUDE.md):** the master plan had permissions as strictly role-based and business-wide — no per-store or per-user override anywhere, and multi-store UI is Phase 2 (§2.2). This was a new feature, so the master plan was updated before any code (user approved "Business real + placeholders").
+
+**Built today:**
+- **Master plan §10.2.1 (new):** documents the three permission scopes and the resolution order (most-specific wins: **User > Store > Business**). Business is the existing per-role behaviour; Store (on the role page) and User (on the staff profile) are visible Phase-1 placeholders, disabled and labelled "coming with multi-store." Added a forward-only schema note naming the future Phase-2 tables (`store_role_permissions`, `user_permission_overrides`) — not built.
+- **Role detail screen:** added a Business / Store scope selector (lightweight glass-pill segmented control) at the top. Business = the full toggle list exactly as before. Store = a centred "Per-store permissions — coming with multi-store" placeholder. A muted helper line explains the hierarchy and points to the staff profile for per-person overrides.
+- **Staff detail screen:** added a "Permission access" card (only for a `settings.manage` holder, never on the own/read-only card) showing the member uses their role's permissions, plus a disabled "Customize this staff's permissions — coming with multi-store" row.
+
+**Files touched:**
+- `reebaplus_master_plan.md`
+- `lib/core/settings/role_permissions_detail_screen.dart`
+- `lib/features/staff/screens/staff_detail_screen.dart`
+- `BUILD_LOG.md`
+
+**Database changes:**
+- None. No new tables, columns, migrations, DAOs, providers, or sync changes. The placeholders are pure UI and write nothing — effective permissions stay role-based business-wide, correct for Phase 1.
+
+**Master plan sections covered:**
+- §10.2.1 (new) — permission scopes Business → Store → User. References §2.2 (multi-store is Phase 2) and §20.6 (the business→store fallback pattern the future tables will follow).
+
+**Plan updates made during session:**
+- Added §10.2.1 as above. This is a deliberate plan extension, approved by the user, because the original plan had no per-store/per-user permission concept.
+
+**Status:** `flutter analyze` clean on both changed files. On-device confirmation pending.
+
+**Tested:**
+- `flutter analyze` on the two changed files — no issues.
+
+**Known issues / left open:**
+- Store and User scopes are placeholders only — no override storage or runtime resolver yet. The real Phase-2 work (the two new synced tables + a resolver merging User > Store > Business) is described in §10.2.1 but not started.
+- On-device pass still pending (scope selector switches cleanly; Store placeholder shows; Permission access card appears for CEO and is hidden on self / for non-managers; no rows hit the sync queue from opening these screens).
+
+**Next session should:**
+- Get an on-device confirmation of the two placeholders, then continue with whatever multi-store groundwork the user prioritises.
+
+---
+
 ## Session 73 — 2026-06-04 — Cart: "Select Customer" picker rebuilt as a smooth fixed-height sheet
 
 **What the user asked for:**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,6 +102,21 @@ If you find a raw write outside the six exceptions above, it is a sync leak — 
 
 **As we build new tables for the Reebaplus master plan** (roles, permissions, stores, invite_codes, activity_logs, funds_accounts, shipments, etc.), every new synced table follows the same contract. Add it to `_syncedTenantTables`, route writes through a DAO that calls `enqueueUpsert` / `enqueueDelete`, and add a stream provider in `stream_providers.dart`.
 
+### Automated sync safeguard (don't rely on review alone)
+
+The contract above is enforced by three automated layers so a write can't *silently* fail to sync. They all read one co-located source of truth in [app_database.dart](lib/core/database/app_database.dart) — `kSyncedTenantTables` (public alias of `_syncedTenantTables`), `kSyncCacheTables` (the 3 Phase D caches), `kEnqueueableTables` (the union a DAO may enqueue: synced ∪ caches ∪ `businesses`) — so they cannot drift apart. Run them with `flutter test test/sync/`.
+
+- **Layer A — runtime enqueue guard** (`SyncDao.enqueueUpsert` / `enqueueDelete` in [daos.dart](lib/core/database/daos.dart)). Throws `StateError` on a table name outside the legitimate set, so a typo/unregistered target fails fast at the write boundary instead of sticking forever as a `failed` queue row. Mirrors the existing `_ledgerTables` guard. Test: `test/sync/sync_dao_enqueue_guard_test.dart`.
+- **Layer B — registration completeness** (`test/sync/sync_table_registration_test.dart`). Reflects over the live schema; any table carrying the sync fingerprint (**both** a `business_id` and a `last_updated_at` column) must be in `kSyncedTenantTables` or `kSyncCacheTables`. Adding a new tenant table and forgetting to register it turns this red. This is the keystone: it makes the most common omission impossible to merge.
+- **Layer C — raw-write leak scanner** (`test/sync/sync_raw_write_leak_test.dart`). Source-scans `daos.dart` + `lib/shared` + `lib/features` + `lib/core/services` for a raw Drift write to a synced table whose **enclosing method** contains no enqueue (any `enqueue…(` call, incl. helpers and `domain:` envelopes). Catches the truly silent case — a new screen/service that writes the DB without enqueuing.
+
+**`sync-exempt` marker convention** (the reusable contract for the legitimate §5 exceptions):
+
+- `// sync-exempt: <reason>` inside a method exempts that method from Layer C. The 7 §5 exceptions carry it.
+- `// sync-exempt-file: <reason>` at the top of a file exempts the whole file. Only the sync engine ([supabase_sync_service.dart](lib/core/services/supabase_sync_service.dart)) has it — it restores cloud-authoritative state.
+
+When you add a new synced table: add it to `_syncedTenantTables`, route writes through a DAO that enqueues, add the stream provider — then `flutter test test/sync/` is green. If a write is a genuinely new §5 exception, add a `// sync-exempt:` marker **and** propose adding it to the §5 exception list before merging.
+
 ## 6. Cautious with Dependencies
 
 Adding a package has a cost beyond installing it: bundle size, security surface, maintenance burden, licensing risk.
@@ -174,6 +189,7 @@ This convention does not change. New screens, modals, and bottom sheets must fol
 
 - **YES → use `context.deviceBottomInset`.** Covers: anything inside `showModalBottomSheet` / `showDialog` / `DraggableScrollableSheet` (modals always hide the bar); pushed detail screens (footers, scrollable bottoms); and drawer-accessed tab roots where the bottom nav bar is hidden — Customers, Payments, Expenses, Stores, Deliveries, Activity Log, Funds Register.
 - **NO → leave it (0 is correct).** This is **only** the body of the five bottom-nav tab roots rendered above the visible bar — **Home, POS, Inventory, Orders (list), Cart**. The bar already insets them; adding `deviceBottomInset` makes a **gap above the bar**. Their existing `context.bottomInset` reads 0 there, which is correct — do **not** convert it. (But modals opened *from* these files still use `deviceBottomInset`.)
+- **Floating action buttons (`AppFAB`):** same YES/NO split — but the Scaffold's `floatingActionButton` slot does **not** add the system-nav inset on edge-to-edge (only a ~16px margin), so on a **3-button nav** the bar paints over the FAB (the gap is ~invisible on gesture nav, which is why this was missed at first). `AppFAB` lifts itself via `reserveBottomInset` (default **true**, using nav-only `context.deviceBottomPadding` so the keyboard isn't double-counted when a form FAB shows with the keyboard up). Set `reserveBottomInset: false` only on the visible-bar tab roots (POS, Stock), exactly like the NO rule above. Never wrap an `AppFAB` in your own bottom inset.
 - **Auth / onboarding screens** (`lib/features/auth/**`) run **before** `MainLayout`, so their `padding.bottom` / `context.bottomInset` already works — leave them.
 
 **`showModalBottomSheet` — the `useSafeArea` trap (also a real bug):** `useSafeArea: true` wraps the sheet in `SafeArea(bottom: false)` — it protects top/left/right only and **does NOT inset the bottom**. Combined with the trap above (even a nested `SafeArea(bottom)` reads 0 under `MainLayout`), the bottom is **always** your job — put `context.deviceBottomInset` on the footer padding.
@@ -183,7 +199,7 @@ This convention does not change. New screens, modals, and bottom sheets must fol
 - Use `MediaQuery.padding.bottom`, `context.bottomInset`, or a bottom `SafeArea` for bottom-anchored content under `MainLayout` — they read **0**. Use `context.deviceBottomInset`.
 - Add `deviceBottomInset` to the **body** of one of the five bottom-nav tab roots (Home / POS / Inventory / Orders / Cart) — it creates a gap above the bar. (Their modals are fine.)
 - Assume `showModalBottomSheet(useSafeArea: true)` insets the bottom — it doesn't (`SafeArea(bottom: false)`).
-- Double-pad: don't add an inset to content already in a Scaffold's `bottomNavigationBar` / `persistentFooterButtons` / `floatingActionButton` / `bottomSheet` slot, and don't stack `deviceBottomInset` with a separate `viewInsets.bottom` on the same edge (`deviceBottomInset` already includes the keyboard).
+- Double-pad: don't add an inset to content already in a Scaffold's `bottomNavigationBar` / `persistentFooterButtons` / `bottomSheet` slot, and don't stack `deviceBottomInset` with a separate `viewInsets.bottom` on the same edge (`deviceBottomInset` already includes the keyboard). (`floatingActionButton` is deliberately NOT in this list — the Scaffold does not inset it for the system nav on edge-to-edge; `AppFAB` owns that inset itself via `reserveBottomInset`, see the decision rule above.)
 - Run the raw inset through the size scaler (`getRSize(deviceBottomInset + …)`). Apply the raw inset and scale only the fixed gap: `context.deviceBottomInset + context.getRSize(16)`.
 
 ---

--- a/lib/core/database/app_database.dart
+++ b/lib/core/database/app_database.dart
@@ -706,6 +706,43 @@ class StockTransactions extends Table {
   ];
 }
 
+// Approval queue for stock-keeper stock adjustments (master plan §16.6.1).
+// A stock keeper's Add/Remove does NOT touch inventory directly — it lands here
+// as a `pending` request. The affected store's Manager(s) and the CEO approve in
+// the Reports hub; on approval the real adjustment runs via `adjustStock` (so
+// the atomic pos_inventory_delta_v2 envelope still applies the inventory +
+// ledger). `reason` is the note carried into the eventual adjustment; `summary`
+// is a denormalised human headline (like notifications.message) so the approval
+// card renders without cross-table joins. Direct Manager/CEO adjustments never
+// pass through here.
+@DataClassName('StockAdjustmentRequestData')
+class StockAdjustmentRequests extends Table {
+  TextColumn get id => text().clientDefault(() => UuidV7.generate())();
+  TextColumn get businessId => text().references(Businesses, #id)();
+  TextColumn get productId => text().references(Products, #id)();
+  TextColumn get storeId => text().references(Stores, #id)();
+  // Signed: positive = add, negative = remove.
+  IntColumn get quantityDiff => integer()();
+  TextColumn get reason => text()();
+  // Denormalised headline ("Akin added 5 bottle(s) of Star (Main Store)").
+  TextColumn get summary => text()();
+  TextColumn get requestedBy => text().nullable().references(Users, #id)();
+  TextColumn get status => text().withDefault(const Constant('pending'))();
+  TextColumn get approvedBy => text().nullable().references(Users, #id)();
+  DateTimeColumn get approvedAt => dateTime().nullable()();
+  DateTimeColumn get createdAt => dateTime().withDefault(currentDateAndTime)();
+  DateTimeColumn get lastUpdatedAt =>
+      dateTime().withDefault(currentDateAndTime)();
+
+  @override
+  Set<Column> get primaryKey => {id};
+
+  @override
+  List<String> get customConstraints => [
+    "CHECK (status IN ('pending','approved','rejected'))",
+  ];
+}
+
 @DataClassName('OrderData')
 class Orders extends Table {
   TextColumn get id => text().clientDefault(() => UuidV7.generate())();
@@ -1195,6 +1232,32 @@ class RolePermissions extends Table {
   ];
 }
 
+/// Per-staff permission override (master plan §10.2.1). A row means this user's
+/// effective permission for `permissionKey` is forced: `isGranted` true =
+/// force-grant, false = force-revoke. No row = inherit the role default. The
+/// runtime resolver applies these on top of the role's grants (CEO is skipped —
+/// always all-on). Scoped per business so a multi-business user's overrides
+/// don't leak across businesses.
+@DataClassName('UserPermissionOverrideData')
+class UserPermissionOverrides extends Table {
+  TextColumn get id => text().clientDefault(() => UuidV7.generate())();
+  TextColumn get businessId => text().references(Businesses, #id)();
+  TextColumn get userId => text().references(Users, #id)();
+  TextColumn get permissionKey => text()();
+  BoolColumn get isGranted => boolean()();
+  DateTimeColumn get createdAt => dateTime().withDefault(currentDateAndTime)();
+  DateTimeColumn get lastUpdatedAt =>
+      dateTime().withDefault(currentDateAndTime)();
+
+  @override
+  Set<Column> get primaryKey => {id};
+
+  @override
+  List<String> get customConstraints => [
+    'UNIQUE (business_id, user_id, permission_key)',
+  ];
+}
+
 @DataClassName('RoleSettingData')
 class RoleSettings extends Table {
   TextColumn get id => text().clientDefault(() => UuidV7.generate())();
@@ -1384,6 +1447,7 @@ class MigrationEvents extends Table {
     StockTransfers,
     StockAdjustments,
     StockTransactions,
+    StockAdjustmentRequests,
     Orders,
     OrderItems,
     Shipments,
@@ -1408,6 +1472,7 @@ class MigrationEvents extends Table {
     Permissions,
     Roles,
     RolePermissions,
+    UserPermissionOverrides,
     RoleSettings,
     UserBusinesses,
     InviteCodes,
@@ -1431,6 +1496,7 @@ class MigrationEvents extends Table {
     StoresDao,
     StockLedgerDao,
     StockTransferDao,
+    StockAdjustmentRequestsDao,
     PendingCrateReturnsDao,
     SessionsDao,
     WalletTransactionsDao,
@@ -1450,6 +1516,7 @@ class MigrationEvents extends Table {
     PermissionsDao,
     RolesDao,
     RolePermissionsDao,
+    UserPermissionOverridesDao,
     RoleSettingsDao,
     UserBusinessesDao,
     InviteCodesDao,
@@ -1488,7 +1555,7 @@ class AppDatabase extends _$AppDatabase {
   String? get currentAuthUserId => authUserIdResolver();
 
   @override
-  int get schemaVersion => 32;
+  int get schemaVersion => 34;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -2874,6 +2941,67 @@ class AppDatabase extends _$AppDatabase {
           "WHERE key = 'stock.view'",
         );
       }
+      if (from < 33) {
+        // v33 (master plan §10.2.1): per-staff permission overrides. One new
+        // synced tenant table. Mirrors
+        // supabase/migrations/0088_user_permission_overrides.sql. The
+        // (business_id, last_updated_at) sync index and the bump trigger match
+        // the generic `_postCreateStatements` loops so a fresh install
+        // (onCreate) and an upgrade end up identical.
+        //
+        // Idempotency guard (like the v27/v30 blocks): a DB stepped back to
+        // < 33 by the revert-then-re-upgrade tests may still carry the table;
+        // a blind createTable would throw "table already exists".
+        final exists = await customSelect(
+          "SELECT 1 FROM sqlite_master WHERE type='table' "
+          "AND name='user_permission_overrides'",
+        ).get();
+        if (exists.isEmpty) {
+          await m.createTable(userPermissionOverrides);
+          await customStatement(
+            'CREATE INDEX idx_user_permission_overrides_business_lua '
+            'ON user_permission_overrides (business_id, last_updated_at)',
+          );
+          await customStatement(
+            'CREATE TRIGGER bump_user_permission_overrides_last_updated_at '
+            'AFTER UPDATE ON user_permission_overrides '
+            'FOR EACH ROW '
+            'WHEN OLD.last_updated_at IS NEW.last_updated_at '
+            'BEGIN '
+            "UPDATE user_permission_overrides SET last_updated_at = CAST(strftime('%s', 'now') AS INTEGER) WHERE id = OLD.id; "
+            'END',
+          );
+        }
+      }
+      if (from < 34) {
+        // v34 (master plan §16.6.1): stock-keeper adjustment approval queue.
+        // One new synced tenant table. Mirrors
+        // supabase/migrations/0089_stock_adjustment_requests.sql. The
+        // (business_id, last_updated_at) sync index and the bump trigger match
+        // the generic `_postCreateStatements` loops so a fresh install
+        // (onCreate) and an upgrade end up identical. Idempotency guard (like
+        // v33) for a DB stepped back to < 34 by the revert-then-re-upgrade tests.
+        final exists = await customSelect(
+          "SELECT 1 FROM sqlite_master WHERE type='table' "
+          "AND name='stock_adjustment_requests'",
+        ).get();
+        if (exists.isEmpty) {
+          await m.createTable(stockAdjustmentRequests);
+          await customStatement(
+            'CREATE INDEX idx_stock_adjustment_requests_business_lua '
+            'ON stock_adjustment_requests (business_id, last_updated_at)',
+          );
+          await customStatement(
+            'CREATE TRIGGER bump_stock_adjustment_requests_last_updated_at '
+            'AFTER UPDATE ON stock_adjustment_requests '
+            'FOR EACH ROW '
+            'WHEN OLD.last_updated_at IS NEW.last_updated_at '
+            'BEGIN '
+            "UPDATE stock_adjustment_requests SET last_updated_at = CAST(strftime('%s', 'now') AS INTEGER) WHERE id = OLD.id; "
+            'END',
+          );
+        }
+      }
     },
     beforeOpen: (details) async {
       await customStatement('PRAGMA foreign_keys = ON');
@@ -2981,6 +3109,8 @@ const List<String> _syncedTenantTables = [
   'stock_transfers',
   'stock_adjustments',
   'stock_transactions',
+  // v34 (master plan §16.6.1) — stock-keeper adjustment approval queue.
+  'stock_adjustment_requests',
   'orders',
   'order_items',
   'shipments',
@@ -3010,10 +3140,41 @@ const List<String> _syncedTenantTables = [
   // by migration on both client and cloud.
   'roles',
   'role_permissions',
+  // v33 (master plan §10.2.1) — per-staff permission overrides.
+  'user_permission_overrides',
   'role_settings',
   'user_businesses',
   'invite_codes',
   'user_stores',
+];
+
+// ---------------------------------------------------------------------------
+// Sync safeguard constants (CLAUDE.md §5). Public, derived from the single
+// source of truth above so the three guardrail layers — the SyncDao enqueue
+// guard, the registration-completeness test, and the raw-write leak scanner —
+// cannot drift apart.
+// ---------------------------------------------------------------------------
+
+/// Public, read-only view of the synced-tenant-table set, for the sync
+/// guardrails (SyncDao enqueue guard + the registration/leak tests).
+const List<String> kSyncedTenantTables = _syncedTenantTables;
+
+/// Phase D §6.3 caches: enqueued + pushed, but deliberately NOT in
+/// `_syncedTenantTables` (no cursor index / bump trigger). They carry the
+/// sync fingerprint (`business_id` + `last_updated_at`), so the registration
+/// test exempts them explicitly.
+const List<String> kSyncCacheTables = [
+  'inventory',
+  'customer_crate_balances',
+  'manufacturer_crate_balances',
+];
+
+/// Every table name a DAO may legitimately enqueue. `businesses` syncs via
+/// its own realtime channel and has no `business_id`, so it is listed by name.
+const List<String> kEnqueueableTables = [
+  ..._syncedTenantTables,
+  ...kSyncCacheTables,
+  'businesses',
 ];
 
 // Subset of `_syncedTenantTables` introduced in schema v13. Used by

--- a/lib/core/database/app_database.g.dart
+++ b/lib/core/database/app_database.g.dart
@@ -15936,6 +15936,793 @@ class StockTransactionsCompanion extends UpdateCompanion<StockTransactionData> {
   }
 }
 
+class $StockAdjustmentRequestsTable extends StockAdjustmentRequests
+    with TableInfo<$StockAdjustmentRequestsTable, StockAdjustmentRequestData> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $StockAdjustmentRequestsTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _idMeta = const VerificationMeta('id');
+  @override
+  late final GeneratedColumn<String> id = GeneratedColumn<String>(
+    'id',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+    clientDefault: () => UuidV7.generate(),
+  );
+  static const VerificationMeta _businessIdMeta = const VerificationMeta(
+    'businessId',
+  );
+  @override
+  late final GeneratedColumn<String> businessId = GeneratedColumn<String>(
+    'business_id',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'REFERENCES businesses (id)',
+    ),
+  );
+  static const VerificationMeta _productIdMeta = const VerificationMeta(
+    'productId',
+  );
+  @override
+  late final GeneratedColumn<String> productId = GeneratedColumn<String>(
+    'product_id',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'REFERENCES products (id)',
+    ),
+  );
+  static const VerificationMeta _storeIdMeta = const VerificationMeta(
+    'storeId',
+  );
+  @override
+  late final GeneratedColumn<String> storeId = GeneratedColumn<String>(
+    'store_id',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'REFERENCES stores (id)',
+    ),
+  );
+  static const VerificationMeta _quantityDiffMeta = const VerificationMeta(
+    'quantityDiff',
+  );
+  @override
+  late final GeneratedColumn<int> quantityDiff = GeneratedColumn<int>(
+    'quantity_diff',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _reasonMeta = const VerificationMeta('reason');
+  @override
+  late final GeneratedColumn<String> reason = GeneratedColumn<String>(
+    'reason',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _summaryMeta = const VerificationMeta(
+    'summary',
+  );
+  @override
+  late final GeneratedColumn<String> summary = GeneratedColumn<String>(
+    'summary',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _requestedByMeta = const VerificationMeta(
+    'requestedBy',
+  );
+  @override
+  late final GeneratedColumn<String> requestedBy = GeneratedColumn<String>(
+    'requested_by',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'REFERENCES users (id)',
+    ),
+  );
+  static const VerificationMeta _statusMeta = const VerificationMeta('status');
+  @override
+  late final GeneratedColumn<String> status = GeneratedColumn<String>(
+    'status',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+    defaultValue: const Constant('pending'),
+  );
+  static const VerificationMeta _approvedByMeta = const VerificationMeta(
+    'approvedBy',
+  );
+  @override
+  late final GeneratedColumn<String> approvedBy = GeneratedColumn<String>(
+    'approved_by',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'REFERENCES users (id)',
+    ),
+  );
+  static const VerificationMeta _approvedAtMeta = const VerificationMeta(
+    'approvedAt',
+  );
+  @override
+  late final GeneratedColumn<DateTime> approvedAt = GeneratedColumn<DateTime>(
+    'approved_at',
+    aliasedName,
+    true,
+    type: DriftSqlType.dateTime,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _createdAtMeta = const VerificationMeta(
+    'createdAt',
+  );
+  @override
+  late final GeneratedColumn<DateTime> createdAt = GeneratedColumn<DateTime>(
+    'created_at',
+    aliasedName,
+    false,
+    type: DriftSqlType.dateTime,
+    requiredDuringInsert: false,
+    defaultValue: currentDateAndTime,
+  );
+  static const VerificationMeta _lastUpdatedAtMeta = const VerificationMeta(
+    'lastUpdatedAt',
+  );
+  @override
+  late final GeneratedColumn<DateTime> lastUpdatedAt =
+      GeneratedColumn<DateTime>(
+        'last_updated_at',
+        aliasedName,
+        false,
+        type: DriftSqlType.dateTime,
+        requiredDuringInsert: false,
+        defaultValue: currentDateAndTime,
+      );
+  @override
+  List<GeneratedColumn> get $columns => [
+    id,
+    businessId,
+    productId,
+    storeId,
+    quantityDiff,
+    reason,
+    summary,
+    requestedBy,
+    status,
+    approvedBy,
+    approvedAt,
+    createdAt,
+    lastUpdatedAt,
+  ];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'stock_adjustment_requests';
+  @override
+  VerificationContext validateIntegrity(
+    Insertable<StockAdjustmentRequestData> instance, {
+    bool isInserting = false,
+  }) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('id')) {
+      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    }
+    if (data.containsKey('business_id')) {
+      context.handle(
+        _businessIdMeta,
+        businessId.isAcceptableOrUnknown(data['business_id']!, _businessIdMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_businessIdMeta);
+    }
+    if (data.containsKey('product_id')) {
+      context.handle(
+        _productIdMeta,
+        productId.isAcceptableOrUnknown(data['product_id']!, _productIdMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_productIdMeta);
+    }
+    if (data.containsKey('store_id')) {
+      context.handle(
+        _storeIdMeta,
+        storeId.isAcceptableOrUnknown(data['store_id']!, _storeIdMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_storeIdMeta);
+    }
+    if (data.containsKey('quantity_diff')) {
+      context.handle(
+        _quantityDiffMeta,
+        quantityDiff.isAcceptableOrUnknown(
+          data['quantity_diff']!,
+          _quantityDiffMeta,
+        ),
+      );
+    } else if (isInserting) {
+      context.missing(_quantityDiffMeta);
+    }
+    if (data.containsKey('reason')) {
+      context.handle(
+        _reasonMeta,
+        reason.isAcceptableOrUnknown(data['reason']!, _reasonMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_reasonMeta);
+    }
+    if (data.containsKey('summary')) {
+      context.handle(
+        _summaryMeta,
+        summary.isAcceptableOrUnknown(data['summary']!, _summaryMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_summaryMeta);
+    }
+    if (data.containsKey('requested_by')) {
+      context.handle(
+        _requestedByMeta,
+        requestedBy.isAcceptableOrUnknown(
+          data['requested_by']!,
+          _requestedByMeta,
+        ),
+      );
+    }
+    if (data.containsKey('status')) {
+      context.handle(
+        _statusMeta,
+        status.isAcceptableOrUnknown(data['status']!, _statusMeta),
+      );
+    }
+    if (data.containsKey('approved_by')) {
+      context.handle(
+        _approvedByMeta,
+        approvedBy.isAcceptableOrUnknown(data['approved_by']!, _approvedByMeta),
+      );
+    }
+    if (data.containsKey('approved_at')) {
+      context.handle(
+        _approvedAtMeta,
+        approvedAt.isAcceptableOrUnknown(data['approved_at']!, _approvedAtMeta),
+      );
+    }
+    if (data.containsKey('created_at')) {
+      context.handle(
+        _createdAtMeta,
+        createdAt.isAcceptableOrUnknown(data['created_at']!, _createdAtMeta),
+      );
+    }
+    if (data.containsKey('last_updated_at')) {
+      context.handle(
+        _lastUpdatedAtMeta,
+        lastUpdatedAt.isAcceptableOrUnknown(
+          data['last_updated_at']!,
+          _lastUpdatedAtMeta,
+        ),
+      );
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {id};
+  @override
+  StockAdjustmentRequestData map(
+    Map<String, dynamic> data, {
+    String? tablePrefix,
+  }) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return StockAdjustmentRequestData(
+      id: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}id'],
+      )!,
+      businessId: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}business_id'],
+      )!,
+      productId: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}product_id'],
+      )!,
+      storeId: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}store_id'],
+      )!,
+      quantityDiff: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}quantity_diff'],
+      )!,
+      reason: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}reason'],
+      )!,
+      summary: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}summary'],
+      )!,
+      requestedBy: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}requested_by'],
+      ),
+      status: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}status'],
+      )!,
+      approvedBy: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}approved_by'],
+      ),
+      approvedAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.dateTime,
+        data['${effectivePrefix}approved_at'],
+      ),
+      createdAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.dateTime,
+        data['${effectivePrefix}created_at'],
+      )!,
+      lastUpdatedAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.dateTime,
+        data['${effectivePrefix}last_updated_at'],
+      )!,
+    );
+  }
+
+  @override
+  $StockAdjustmentRequestsTable createAlias(String alias) {
+    return $StockAdjustmentRequestsTable(attachedDatabase, alias);
+  }
+}
+
+class StockAdjustmentRequestData extends DataClass
+    implements Insertable<StockAdjustmentRequestData> {
+  final String id;
+  final String businessId;
+  final String productId;
+  final String storeId;
+  final int quantityDiff;
+  final String reason;
+  final String summary;
+  final String? requestedBy;
+  final String status;
+  final String? approvedBy;
+  final DateTime? approvedAt;
+  final DateTime createdAt;
+  final DateTime lastUpdatedAt;
+  const StockAdjustmentRequestData({
+    required this.id,
+    required this.businessId,
+    required this.productId,
+    required this.storeId,
+    required this.quantityDiff,
+    required this.reason,
+    required this.summary,
+    this.requestedBy,
+    required this.status,
+    this.approvedBy,
+    this.approvedAt,
+    required this.createdAt,
+    required this.lastUpdatedAt,
+  });
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['id'] = Variable<String>(id);
+    map['business_id'] = Variable<String>(businessId);
+    map['product_id'] = Variable<String>(productId);
+    map['store_id'] = Variable<String>(storeId);
+    map['quantity_diff'] = Variable<int>(quantityDiff);
+    map['reason'] = Variable<String>(reason);
+    map['summary'] = Variable<String>(summary);
+    if (!nullToAbsent || requestedBy != null) {
+      map['requested_by'] = Variable<String>(requestedBy);
+    }
+    map['status'] = Variable<String>(status);
+    if (!nullToAbsent || approvedBy != null) {
+      map['approved_by'] = Variable<String>(approvedBy);
+    }
+    if (!nullToAbsent || approvedAt != null) {
+      map['approved_at'] = Variable<DateTime>(approvedAt);
+    }
+    map['created_at'] = Variable<DateTime>(createdAt);
+    map['last_updated_at'] = Variable<DateTime>(lastUpdatedAt);
+    return map;
+  }
+
+  StockAdjustmentRequestsCompanion toCompanion(bool nullToAbsent) {
+    return StockAdjustmentRequestsCompanion(
+      id: Value(id),
+      businessId: Value(businessId),
+      productId: Value(productId),
+      storeId: Value(storeId),
+      quantityDiff: Value(quantityDiff),
+      reason: Value(reason),
+      summary: Value(summary),
+      requestedBy: requestedBy == null && nullToAbsent
+          ? const Value.absent()
+          : Value(requestedBy),
+      status: Value(status),
+      approvedBy: approvedBy == null && nullToAbsent
+          ? const Value.absent()
+          : Value(approvedBy),
+      approvedAt: approvedAt == null && nullToAbsent
+          ? const Value.absent()
+          : Value(approvedAt),
+      createdAt: Value(createdAt),
+      lastUpdatedAt: Value(lastUpdatedAt),
+    );
+  }
+
+  factory StockAdjustmentRequestData.fromJson(
+    Map<String, dynamic> json, {
+    ValueSerializer? serializer,
+  }) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return StockAdjustmentRequestData(
+      id: serializer.fromJson<String>(json['id']),
+      businessId: serializer.fromJson<String>(json['businessId']),
+      productId: serializer.fromJson<String>(json['productId']),
+      storeId: serializer.fromJson<String>(json['storeId']),
+      quantityDiff: serializer.fromJson<int>(json['quantityDiff']),
+      reason: serializer.fromJson<String>(json['reason']),
+      summary: serializer.fromJson<String>(json['summary']),
+      requestedBy: serializer.fromJson<String?>(json['requestedBy']),
+      status: serializer.fromJson<String>(json['status']),
+      approvedBy: serializer.fromJson<String?>(json['approvedBy']),
+      approvedAt: serializer.fromJson<DateTime?>(json['approvedAt']),
+      createdAt: serializer.fromJson<DateTime>(json['createdAt']),
+      lastUpdatedAt: serializer.fromJson<DateTime>(json['lastUpdatedAt']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'id': serializer.toJson<String>(id),
+      'businessId': serializer.toJson<String>(businessId),
+      'productId': serializer.toJson<String>(productId),
+      'storeId': serializer.toJson<String>(storeId),
+      'quantityDiff': serializer.toJson<int>(quantityDiff),
+      'reason': serializer.toJson<String>(reason),
+      'summary': serializer.toJson<String>(summary),
+      'requestedBy': serializer.toJson<String?>(requestedBy),
+      'status': serializer.toJson<String>(status),
+      'approvedBy': serializer.toJson<String?>(approvedBy),
+      'approvedAt': serializer.toJson<DateTime?>(approvedAt),
+      'createdAt': serializer.toJson<DateTime>(createdAt),
+      'lastUpdatedAt': serializer.toJson<DateTime>(lastUpdatedAt),
+    };
+  }
+
+  StockAdjustmentRequestData copyWith({
+    String? id,
+    String? businessId,
+    String? productId,
+    String? storeId,
+    int? quantityDiff,
+    String? reason,
+    String? summary,
+    Value<String?> requestedBy = const Value.absent(),
+    String? status,
+    Value<String?> approvedBy = const Value.absent(),
+    Value<DateTime?> approvedAt = const Value.absent(),
+    DateTime? createdAt,
+    DateTime? lastUpdatedAt,
+  }) => StockAdjustmentRequestData(
+    id: id ?? this.id,
+    businessId: businessId ?? this.businessId,
+    productId: productId ?? this.productId,
+    storeId: storeId ?? this.storeId,
+    quantityDiff: quantityDiff ?? this.quantityDiff,
+    reason: reason ?? this.reason,
+    summary: summary ?? this.summary,
+    requestedBy: requestedBy.present ? requestedBy.value : this.requestedBy,
+    status: status ?? this.status,
+    approvedBy: approvedBy.present ? approvedBy.value : this.approvedBy,
+    approvedAt: approvedAt.present ? approvedAt.value : this.approvedAt,
+    createdAt: createdAt ?? this.createdAt,
+    lastUpdatedAt: lastUpdatedAt ?? this.lastUpdatedAt,
+  );
+  StockAdjustmentRequestData copyWithCompanion(
+    StockAdjustmentRequestsCompanion data,
+  ) {
+    return StockAdjustmentRequestData(
+      id: data.id.present ? data.id.value : this.id,
+      businessId: data.businessId.present
+          ? data.businessId.value
+          : this.businessId,
+      productId: data.productId.present ? data.productId.value : this.productId,
+      storeId: data.storeId.present ? data.storeId.value : this.storeId,
+      quantityDiff: data.quantityDiff.present
+          ? data.quantityDiff.value
+          : this.quantityDiff,
+      reason: data.reason.present ? data.reason.value : this.reason,
+      summary: data.summary.present ? data.summary.value : this.summary,
+      requestedBy: data.requestedBy.present
+          ? data.requestedBy.value
+          : this.requestedBy,
+      status: data.status.present ? data.status.value : this.status,
+      approvedBy: data.approvedBy.present
+          ? data.approvedBy.value
+          : this.approvedBy,
+      approvedAt: data.approvedAt.present
+          ? data.approvedAt.value
+          : this.approvedAt,
+      createdAt: data.createdAt.present ? data.createdAt.value : this.createdAt,
+      lastUpdatedAt: data.lastUpdatedAt.present
+          ? data.lastUpdatedAt.value
+          : this.lastUpdatedAt,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('StockAdjustmentRequestData(')
+          ..write('id: $id, ')
+          ..write('businessId: $businessId, ')
+          ..write('productId: $productId, ')
+          ..write('storeId: $storeId, ')
+          ..write('quantityDiff: $quantityDiff, ')
+          ..write('reason: $reason, ')
+          ..write('summary: $summary, ')
+          ..write('requestedBy: $requestedBy, ')
+          ..write('status: $status, ')
+          ..write('approvedBy: $approvedBy, ')
+          ..write('approvedAt: $approvedAt, ')
+          ..write('createdAt: $createdAt, ')
+          ..write('lastUpdatedAt: $lastUpdatedAt')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    id,
+    businessId,
+    productId,
+    storeId,
+    quantityDiff,
+    reason,
+    summary,
+    requestedBy,
+    status,
+    approvedBy,
+    approvedAt,
+    createdAt,
+    lastUpdatedAt,
+  );
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is StockAdjustmentRequestData &&
+          other.id == this.id &&
+          other.businessId == this.businessId &&
+          other.productId == this.productId &&
+          other.storeId == this.storeId &&
+          other.quantityDiff == this.quantityDiff &&
+          other.reason == this.reason &&
+          other.summary == this.summary &&
+          other.requestedBy == this.requestedBy &&
+          other.status == this.status &&
+          other.approvedBy == this.approvedBy &&
+          other.approvedAt == this.approvedAt &&
+          other.createdAt == this.createdAt &&
+          other.lastUpdatedAt == this.lastUpdatedAt);
+}
+
+class StockAdjustmentRequestsCompanion
+    extends UpdateCompanion<StockAdjustmentRequestData> {
+  final Value<String> id;
+  final Value<String> businessId;
+  final Value<String> productId;
+  final Value<String> storeId;
+  final Value<int> quantityDiff;
+  final Value<String> reason;
+  final Value<String> summary;
+  final Value<String?> requestedBy;
+  final Value<String> status;
+  final Value<String?> approvedBy;
+  final Value<DateTime?> approvedAt;
+  final Value<DateTime> createdAt;
+  final Value<DateTime> lastUpdatedAt;
+  final Value<int> rowid;
+  const StockAdjustmentRequestsCompanion({
+    this.id = const Value.absent(),
+    this.businessId = const Value.absent(),
+    this.productId = const Value.absent(),
+    this.storeId = const Value.absent(),
+    this.quantityDiff = const Value.absent(),
+    this.reason = const Value.absent(),
+    this.summary = const Value.absent(),
+    this.requestedBy = const Value.absent(),
+    this.status = const Value.absent(),
+    this.approvedBy = const Value.absent(),
+    this.approvedAt = const Value.absent(),
+    this.createdAt = const Value.absent(),
+    this.lastUpdatedAt = const Value.absent(),
+    this.rowid = const Value.absent(),
+  });
+  StockAdjustmentRequestsCompanion.insert({
+    this.id = const Value.absent(),
+    required String businessId,
+    required String productId,
+    required String storeId,
+    required int quantityDiff,
+    required String reason,
+    required String summary,
+    this.requestedBy = const Value.absent(),
+    this.status = const Value.absent(),
+    this.approvedBy = const Value.absent(),
+    this.approvedAt = const Value.absent(),
+    this.createdAt = const Value.absent(),
+    this.lastUpdatedAt = const Value.absent(),
+    this.rowid = const Value.absent(),
+  }) : businessId = Value(businessId),
+       productId = Value(productId),
+       storeId = Value(storeId),
+       quantityDiff = Value(quantityDiff),
+       reason = Value(reason),
+       summary = Value(summary);
+  static Insertable<StockAdjustmentRequestData> custom({
+    Expression<String>? id,
+    Expression<String>? businessId,
+    Expression<String>? productId,
+    Expression<String>? storeId,
+    Expression<int>? quantityDiff,
+    Expression<String>? reason,
+    Expression<String>? summary,
+    Expression<String>? requestedBy,
+    Expression<String>? status,
+    Expression<String>? approvedBy,
+    Expression<DateTime>? approvedAt,
+    Expression<DateTime>? createdAt,
+    Expression<DateTime>? lastUpdatedAt,
+    Expression<int>? rowid,
+  }) {
+    return RawValuesInsertable({
+      if (id != null) 'id': id,
+      if (businessId != null) 'business_id': businessId,
+      if (productId != null) 'product_id': productId,
+      if (storeId != null) 'store_id': storeId,
+      if (quantityDiff != null) 'quantity_diff': quantityDiff,
+      if (reason != null) 'reason': reason,
+      if (summary != null) 'summary': summary,
+      if (requestedBy != null) 'requested_by': requestedBy,
+      if (status != null) 'status': status,
+      if (approvedBy != null) 'approved_by': approvedBy,
+      if (approvedAt != null) 'approved_at': approvedAt,
+      if (createdAt != null) 'created_at': createdAt,
+      if (lastUpdatedAt != null) 'last_updated_at': lastUpdatedAt,
+      if (rowid != null) 'rowid': rowid,
+    });
+  }
+
+  StockAdjustmentRequestsCompanion copyWith({
+    Value<String>? id,
+    Value<String>? businessId,
+    Value<String>? productId,
+    Value<String>? storeId,
+    Value<int>? quantityDiff,
+    Value<String>? reason,
+    Value<String>? summary,
+    Value<String?>? requestedBy,
+    Value<String>? status,
+    Value<String?>? approvedBy,
+    Value<DateTime?>? approvedAt,
+    Value<DateTime>? createdAt,
+    Value<DateTime>? lastUpdatedAt,
+    Value<int>? rowid,
+  }) {
+    return StockAdjustmentRequestsCompanion(
+      id: id ?? this.id,
+      businessId: businessId ?? this.businessId,
+      productId: productId ?? this.productId,
+      storeId: storeId ?? this.storeId,
+      quantityDiff: quantityDiff ?? this.quantityDiff,
+      reason: reason ?? this.reason,
+      summary: summary ?? this.summary,
+      requestedBy: requestedBy ?? this.requestedBy,
+      status: status ?? this.status,
+      approvedBy: approvedBy ?? this.approvedBy,
+      approvedAt: approvedAt ?? this.approvedAt,
+      createdAt: createdAt ?? this.createdAt,
+      lastUpdatedAt: lastUpdatedAt ?? this.lastUpdatedAt,
+      rowid: rowid ?? this.rowid,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (id.present) {
+      map['id'] = Variable<String>(id.value);
+    }
+    if (businessId.present) {
+      map['business_id'] = Variable<String>(businessId.value);
+    }
+    if (productId.present) {
+      map['product_id'] = Variable<String>(productId.value);
+    }
+    if (storeId.present) {
+      map['store_id'] = Variable<String>(storeId.value);
+    }
+    if (quantityDiff.present) {
+      map['quantity_diff'] = Variable<int>(quantityDiff.value);
+    }
+    if (reason.present) {
+      map['reason'] = Variable<String>(reason.value);
+    }
+    if (summary.present) {
+      map['summary'] = Variable<String>(summary.value);
+    }
+    if (requestedBy.present) {
+      map['requested_by'] = Variable<String>(requestedBy.value);
+    }
+    if (status.present) {
+      map['status'] = Variable<String>(status.value);
+    }
+    if (approvedBy.present) {
+      map['approved_by'] = Variable<String>(approvedBy.value);
+    }
+    if (approvedAt.present) {
+      map['approved_at'] = Variable<DateTime>(approvedAt.value);
+    }
+    if (createdAt.present) {
+      map['created_at'] = Variable<DateTime>(createdAt.value);
+    }
+    if (lastUpdatedAt.present) {
+      map['last_updated_at'] = Variable<DateTime>(lastUpdatedAt.value);
+    }
+    if (rowid.present) {
+      map['rowid'] = Variable<int>(rowid.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('StockAdjustmentRequestsCompanion(')
+          ..write('id: $id, ')
+          ..write('businessId: $businessId, ')
+          ..write('productId: $productId, ')
+          ..write('storeId: $storeId, ')
+          ..write('quantityDiff: $quantityDiff, ')
+          ..write('reason: $reason, ')
+          ..write('summary: $summary, ')
+          ..write('requestedBy: $requestedBy, ')
+          ..write('status: $status, ')
+          ..write('approvedBy: $approvedBy, ')
+          ..write('approvedAt: $approvedAt, ')
+          ..write('createdAt: $createdAt, ')
+          ..write('lastUpdatedAt: $lastUpdatedAt, ')
+          ..write('rowid: $rowid')
+          ..write(')'))
+        .toString();
+  }
+}
+
 class $OrderItemsTable extends OrderItems
     with TableInfo<$OrderItemsTable, OrderItemData> {
   @override
@@ -29630,6 +30417,491 @@ class RolePermissionsCompanion extends UpdateCompanion<RolePermissionData> {
   }
 }
 
+class $UserPermissionOverridesTable extends UserPermissionOverrides
+    with TableInfo<$UserPermissionOverridesTable, UserPermissionOverrideData> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $UserPermissionOverridesTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _idMeta = const VerificationMeta('id');
+  @override
+  late final GeneratedColumn<String> id = GeneratedColumn<String>(
+    'id',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+    clientDefault: () => UuidV7.generate(),
+  );
+  static const VerificationMeta _businessIdMeta = const VerificationMeta(
+    'businessId',
+  );
+  @override
+  late final GeneratedColumn<String> businessId = GeneratedColumn<String>(
+    'business_id',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'REFERENCES businesses (id)',
+    ),
+  );
+  static const VerificationMeta _userIdMeta = const VerificationMeta('userId');
+  @override
+  late final GeneratedColumn<String> userId = GeneratedColumn<String>(
+    'user_id',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'REFERENCES users (id)',
+    ),
+  );
+  static const VerificationMeta _permissionKeyMeta = const VerificationMeta(
+    'permissionKey',
+  );
+  @override
+  late final GeneratedColumn<String> permissionKey = GeneratedColumn<String>(
+    'permission_key',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _isGrantedMeta = const VerificationMeta(
+    'isGranted',
+  );
+  @override
+  late final GeneratedColumn<bool> isGranted = GeneratedColumn<bool>(
+    'is_granted',
+    aliasedName,
+    false,
+    type: DriftSqlType.bool,
+    requiredDuringInsert: true,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'CHECK ("is_granted" IN (0, 1))',
+    ),
+  );
+  static const VerificationMeta _createdAtMeta = const VerificationMeta(
+    'createdAt',
+  );
+  @override
+  late final GeneratedColumn<DateTime> createdAt = GeneratedColumn<DateTime>(
+    'created_at',
+    aliasedName,
+    false,
+    type: DriftSqlType.dateTime,
+    requiredDuringInsert: false,
+    defaultValue: currentDateAndTime,
+  );
+  static const VerificationMeta _lastUpdatedAtMeta = const VerificationMeta(
+    'lastUpdatedAt',
+  );
+  @override
+  late final GeneratedColumn<DateTime> lastUpdatedAt =
+      GeneratedColumn<DateTime>(
+        'last_updated_at',
+        aliasedName,
+        false,
+        type: DriftSqlType.dateTime,
+        requiredDuringInsert: false,
+        defaultValue: currentDateAndTime,
+      );
+  @override
+  List<GeneratedColumn> get $columns => [
+    id,
+    businessId,
+    userId,
+    permissionKey,
+    isGranted,
+    createdAt,
+    lastUpdatedAt,
+  ];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'user_permission_overrides';
+  @override
+  VerificationContext validateIntegrity(
+    Insertable<UserPermissionOverrideData> instance, {
+    bool isInserting = false,
+  }) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('id')) {
+      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    }
+    if (data.containsKey('business_id')) {
+      context.handle(
+        _businessIdMeta,
+        businessId.isAcceptableOrUnknown(data['business_id']!, _businessIdMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_businessIdMeta);
+    }
+    if (data.containsKey('user_id')) {
+      context.handle(
+        _userIdMeta,
+        userId.isAcceptableOrUnknown(data['user_id']!, _userIdMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_userIdMeta);
+    }
+    if (data.containsKey('permission_key')) {
+      context.handle(
+        _permissionKeyMeta,
+        permissionKey.isAcceptableOrUnknown(
+          data['permission_key']!,
+          _permissionKeyMeta,
+        ),
+      );
+    } else if (isInserting) {
+      context.missing(_permissionKeyMeta);
+    }
+    if (data.containsKey('is_granted')) {
+      context.handle(
+        _isGrantedMeta,
+        isGranted.isAcceptableOrUnknown(data['is_granted']!, _isGrantedMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_isGrantedMeta);
+    }
+    if (data.containsKey('created_at')) {
+      context.handle(
+        _createdAtMeta,
+        createdAt.isAcceptableOrUnknown(data['created_at']!, _createdAtMeta),
+      );
+    }
+    if (data.containsKey('last_updated_at')) {
+      context.handle(
+        _lastUpdatedAtMeta,
+        lastUpdatedAt.isAcceptableOrUnknown(
+          data['last_updated_at']!,
+          _lastUpdatedAtMeta,
+        ),
+      );
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {id};
+  @override
+  UserPermissionOverrideData map(
+    Map<String, dynamic> data, {
+    String? tablePrefix,
+  }) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return UserPermissionOverrideData(
+      id: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}id'],
+      )!,
+      businessId: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}business_id'],
+      )!,
+      userId: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}user_id'],
+      )!,
+      permissionKey: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}permission_key'],
+      )!,
+      isGranted: attachedDatabase.typeMapping.read(
+        DriftSqlType.bool,
+        data['${effectivePrefix}is_granted'],
+      )!,
+      createdAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.dateTime,
+        data['${effectivePrefix}created_at'],
+      )!,
+      lastUpdatedAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.dateTime,
+        data['${effectivePrefix}last_updated_at'],
+      )!,
+    );
+  }
+
+  @override
+  $UserPermissionOverridesTable createAlias(String alias) {
+    return $UserPermissionOverridesTable(attachedDatabase, alias);
+  }
+}
+
+class UserPermissionOverrideData extends DataClass
+    implements Insertable<UserPermissionOverrideData> {
+  final String id;
+  final String businessId;
+  final String userId;
+  final String permissionKey;
+  final bool isGranted;
+  final DateTime createdAt;
+  final DateTime lastUpdatedAt;
+  const UserPermissionOverrideData({
+    required this.id,
+    required this.businessId,
+    required this.userId,
+    required this.permissionKey,
+    required this.isGranted,
+    required this.createdAt,
+    required this.lastUpdatedAt,
+  });
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['id'] = Variable<String>(id);
+    map['business_id'] = Variable<String>(businessId);
+    map['user_id'] = Variable<String>(userId);
+    map['permission_key'] = Variable<String>(permissionKey);
+    map['is_granted'] = Variable<bool>(isGranted);
+    map['created_at'] = Variable<DateTime>(createdAt);
+    map['last_updated_at'] = Variable<DateTime>(lastUpdatedAt);
+    return map;
+  }
+
+  UserPermissionOverridesCompanion toCompanion(bool nullToAbsent) {
+    return UserPermissionOverridesCompanion(
+      id: Value(id),
+      businessId: Value(businessId),
+      userId: Value(userId),
+      permissionKey: Value(permissionKey),
+      isGranted: Value(isGranted),
+      createdAt: Value(createdAt),
+      lastUpdatedAt: Value(lastUpdatedAt),
+    );
+  }
+
+  factory UserPermissionOverrideData.fromJson(
+    Map<String, dynamic> json, {
+    ValueSerializer? serializer,
+  }) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return UserPermissionOverrideData(
+      id: serializer.fromJson<String>(json['id']),
+      businessId: serializer.fromJson<String>(json['businessId']),
+      userId: serializer.fromJson<String>(json['userId']),
+      permissionKey: serializer.fromJson<String>(json['permissionKey']),
+      isGranted: serializer.fromJson<bool>(json['isGranted']),
+      createdAt: serializer.fromJson<DateTime>(json['createdAt']),
+      lastUpdatedAt: serializer.fromJson<DateTime>(json['lastUpdatedAt']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'id': serializer.toJson<String>(id),
+      'businessId': serializer.toJson<String>(businessId),
+      'userId': serializer.toJson<String>(userId),
+      'permissionKey': serializer.toJson<String>(permissionKey),
+      'isGranted': serializer.toJson<bool>(isGranted),
+      'createdAt': serializer.toJson<DateTime>(createdAt),
+      'lastUpdatedAt': serializer.toJson<DateTime>(lastUpdatedAt),
+    };
+  }
+
+  UserPermissionOverrideData copyWith({
+    String? id,
+    String? businessId,
+    String? userId,
+    String? permissionKey,
+    bool? isGranted,
+    DateTime? createdAt,
+    DateTime? lastUpdatedAt,
+  }) => UserPermissionOverrideData(
+    id: id ?? this.id,
+    businessId: businessId ?? this.businessId,
+    userId: userId ?? this.userId,
+    permissionKey: permissionKey ?? this.permissionKey,
+    isGranted: isGranted ?? this.isGranted,
+    createdAt: createdAt ?? this.createdAt,
+    lastUpdatedAt: lastUpdatedAt ?? this.lastUpdatedAt,
+  );
+  UserPermissionOverrideData copyWithCompanion(
+    UserPermissionOverridesCompanion data,
+  ) {
+    return UserPermissionOverrideData(
+      id: data.id.present ? data.id.value : this.id,
+      businessId: data.businessId.present
+          ? data.businessId.value
+          : this.businessId,
+      userId: data.userId.present ? data.userId.value : this.userId,
+      permissionKey: data.permissionKey.present
+          ? data.permissionKey.value
+          : this.permissionKey,
+      isGranted: data.isGranted.present ? data.isGranted.value : this.isGranted,
+      createdAt: data.createdAt.present ? data.createdAt.value : this.createdAt,
+      lastUpdatedAt: data.lastUpdatedAt.present
+          ? data.lastUpdatedAt.value
+          : this.lastUpdatedAt,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('UserPermissionOverrideData(')
+          ..write('id: $id, ')
+          ..write('businessId: $businessId, ')
+          ..write('userId: $userId, ')
+          ..write('permissionKey: $permissionKey, ')
+          ..write('isGranted: $isGranted, ')
+          ..write('createdAt: $createdAt, ')
+          ..write('lastUpdatedAt: $lastUpdatedAt')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    id,
+    businessId,
+    userId,
+    permissionKey,
+    isGranted,
+    createdAt,
+    lastUpdatedAt,
+  );
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is UserPermissionOverrideData &&
+          other.id == this.id &&
+          other.businessId == this.businessId &&
+          other.userId == this.userId &&
+          other.permissionKey == this.permissionKey &&
+          other.isGranted == this.isGranted &&
+          other.createdAt == this.createdAt &&
+          other.lastUpdatedAt == this.lastUpdatedAt);
+}
+
+class UserPermissionOverridesCompanion
+    extends UpdateCompanion<UserPermissionOverrideData> {
+  final Value<String> id;
+  final Value<String> businessId;
+  final Value<String> userId;
+  final Value<String> permissionKey;
+  final Value<bool> isGranted;
+  final Value<DateTime> createdAt;
+  final Value<DateTime> lastUpdatedAt;
+  final Value<int> rowid;
+  const UserPermissionOverridesCompanion({
+    this.id = const Value.absent(),
+    this.businessId = const Value.absent(),
+    this.userId = const Value.absent(),
+    this.permissionKey = const Value.absent(),
+    this.isGranted = const Value.absent(),
+    this.createdAt = const Value.absent(),
+    this.lastUpdatedAt = const Value.absent(),
+    this.rowid = const Value.absent(),
+  });
+  UserPermissionOverridesCompanion.insert({
+    this.id = const Value.absent(),
+    required String businessId,
+    required String userId,
+    required String permissionKey,
+    required bool isGranted,
+    this.createdAt = const Value.absent(),
+    this.lastUpdatedAt = const Value.absent(),
+    this.rowid = const Value.absent(),
+  }) : businessId = Value(businessId),
+       userId = Value(userId),
+       permissionKey = Value(permissionKey),
+       isGranted = Value(isGranted);
+  static Insertable<UserPermissionOverrideData> custom({
+    Expression<String>? id,
+    Expression<String>? businessId,
+    Expression<String>? userId,
+    Expression<String>? permissionKey,
+    Expression<bool>? isGranted,
+    Expression<DateTime>? createdAt,
+    Expression<DateTime>? lastUpdatedAt,
+    Expression<int>? rowid,
+  }) {
+    return RawValuesInsertable({
+      if (id != null) 'id': id,
+      if (businessId != null) 'business_id': businessId,
+      if (userId != null) 'user_id': userId,
+      if (permissionKey != null) 'permission_key': permissionKey,
+      if (isGranted != null) 'is_granted': isGranted,
+      if (createdAt != null) 'created_at': createdAt,
+      if (lastUpdatedAt != null) 'last_updated_at': lastUpdatedAt,
+      if (rowid != null) 'rowid': rowid,
+    });
+  }
+
+  UserPermissionOverridesCompanion copyWith({
+    Value<String>? id,
+    Value<String>? businessId,
+    Value<String>? userId,
+    Value<String>? permissionKey,
+    Value<bool>? isGranted,
+    Value<DateTime>? createdAt,
+    Value<DateTime>? lastUpdatedAt,
+    Value<int>? rowid,
+  }) {
+    return UserPermissionOverridesCompanion(
+      id: id ?? this.id,
+      businessId: businessId ?? this.businessId,
+      userId: userId ?? this.userId,
+      permissionKey: permissionKey ?? this.permissionKey,
+      isGranted: isGranted ?? this.isGranted,
+      createdAt: createdAt ?? this.createdAt,
+      lastUpdatedAt: lastUpdatedAt ?? this.lastUpdatedAt,
+      rowid: rowid ?? this.rowid,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (id.present) {
+      map['id'] = Variable<String>(id.value);
+    }
+    if (businessId.present) {
+      map['business_id'] = Variable<String>(businessId.value);
+    }
+    if (userId.present) {
+      map['user_id'] = Variable<String>(userId.value);
+    }
+    if (permissionKey.present) {
+      map['permission_key'] = Variable<String>(permissionKey.value);
+    }
+    if (isGranted.present) {
+      map['is_granted'] = Variable<bool>(isGranted.value);
+    }
+    if (createdAt.present) {
+      map['created_at'] = Variable<DateTime>(createdAt.value);
+    }
+    if (lastUpdatedAt.present) {
+      map['last_updated_at'] = Variable<DateTime>(lastUpdatedAt.value);
+    }
+    if (rowid.present) {
+      map['rowid'] = Variable<int>(rowid.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('UserPermissionOverridesCompanion(')
+          ..write('id: $id, ')
+          ..write('businessId: $businessId, ')
+          ..write('userId: $userId, ')
+          ..write('permissionKey: $permissionKey, ')
+          ..write('isGranted: $isGranted, ')
+          ..write('createdAt: $createdAt, ')
+          ..write('lastUpdatedAt: $lastUpdatedAt, ')
+          ..write('rowid: $rowid')
+          ..write(')'))
+        .toString();
+  }
+}
+
 class $RoleSettingsTable extends RoleSettings
     with TableInfo<$RoleSettingsTable, RoleSettingData> {
   @override
@@ -33779,6 +35051,8 @@ abstract class _$AppDatabase extends GeneratedDatabase {
   late final $ShipmentsTable shipments = $ShipmentsTable(this);
   late final $StockTransactionsTable stockTransactions =
       $StockTransactionsTable(this);
+  late final $StockAdjustmentRequestsTable stockAdjustmentRequests =
+      $StockAdjustmentRequestsTable(this);
   late final $OrderItemsTable orderItems = $OrderItemsTable(this);
   late final $PurchaseItemsTable purchaseItems = $PurchaseItemsTable(this);
   late final $ExpenseCategoriesTable expenseCategories =
@@ -33810,6 +35084,8 @@ abstract class _$AppDatabase extends GeneratedDatabase {
   late final $RolePermissionsTable rolePermissions = $RolePermissionsTable(
     this,
   );
+  late final $UserPermissionOverridesTable userPermissionOverrides =
+      $UserPermissionOverridesTable(this);
   late final $RoleSettingsTable roleSettings = $RoleSettingsTable(this);
   late final $UserBusinessesTable userBusinesses = $UserBusinessesTable(this);
   late final $InviteCodesTable inviteCodes = $InviteCodesTable(this);
@@ -33845,6 +35121,8 @@ abstract class _$AppDatabase extends GeneratedDatabase {
   late final StockTransferDao stockTransferDao = StockTransferDao(
     this as AppDatabase,
   );
+  late final StockAdjustmentRequestsDao stockAdjustmentRequestsDao =
+      StockAdjustmentRequestsDao(this as AppDatabase);
   late final PendingCrateReturnsDao pendingCrateReturnsDao =
       PendingCrateReturnsDao(this as AppDatabase);
   late final SessionsDao sessionsDao = SessionsDao(this as AppDatabase);
@@ -33888,6 +35166,8 @@ abstract class _$AppDatabase extends GeneratedDatabase {
   late final RolePermissionsDao rolePermissionsDao = RolePermissionsDao(
     this as AppDatabase,
   );
+  late final UserPermissionOverridesDao userPermissionOverridesDao =
+      UserPermissionOverridesDao(this as AppDatabase);
   late final RoleSettingsDao roleSettingsDao = RoleSettingsDao(
     this as AppDatabase,
   );
@@ -33925,6 +35205,7 @@ abstract class _$AppDatabase extends GeneratedDatabase {
     stockAdjustments,
     shipments,
     stockTransactions,
+    stockAdjustmentRequests,
     orderItems,
     purchaseItems,
     expenseCategories,
@@ -33946,6 +35227,7 @@ abstract class _$AppDatabase extends GeneratedDatabase {
     permissions,
     roles,
     rolePermissions,
+    userPermissionOverrides,
     roleSettings,
     userBusinesses,
     inviteCodes,
@@ -34442,6 +35724,34 @@ final class $$BusinessesTableReferences
     );
   }
 
+  static MultiTypedResultKey<
+    $StockAdjustmentRequestsTable,
+    List<StockAdjustmentRequestData>
+  >
+  _stockAdjustmentRequestsRefsTable(_$AppDatabase db) =>
+      MultiTypedResultKey.fromTable(
+        db.stockAdjustmentRequests,
+        aliasName: $_aliasNameGenerator(
+          db.businesses.id,
+          db.stockAdjustmentRequests.businessId,
+        ),
+      );
+
+  $$StockAdjustmentRequestsTableProcessedTableManager
+  get stockAdjustmentRequestsRefs {
+    final manager = $$StockAdjustmentRequestsTableTableManager(
+      $_db,
+      $_db.stockAdjustmentRequests,
+    ).filter((f) => f.businessId.id.sqlEquals($_itemColumn<String>('id')!));
+
+    final cache = $_typedResult.readTableOrNull(
+      _stockAdjustmentRequestsRefsTable($_db),
+    );
+    return ProcessedTableManager(
+      manager.$state.copyWith(prefetchedData: cache),
+    );
+  }
+
   static MultiTypedResultKey<$OrderItemsTable, List<OrderItemData>>
   _orderItemsRefsTable(_$AppDatabase db) => MultiTypedResultKey.fromTable(
     db.orderItems,
@@ -34851,6 +36161,34 @@ final class $$BusinessesTableReferences
 
     final cache = $_typedResult.readTableOrNull(
       _rolePermissionsRefsTable($_db),
+    );
+    return ProcessedTableManager(
+      manager.$state.copyWith(prefetchedData: cache),
+    );
+  }
+
+  static MultiTypedResultKey<
+    $UserPermissionOverridesTable,
+    List<UserPermissionOverrideData>
+  >
+  _userPermissionOverridesRefsTable(_$AppDatabase db) =>
+      MultiTypedResultKey.fromTable(
+        db.userPermissionOverrides,
+        aliasName: $_aliasNameGenerator(
+          db.businesses.id,
+          db.userPermissionOverrides.businessId,
+        ),
+      );
+
+  $$UserPermissionOverridesTableProcessedTableManager
+  get userPermissionOverridesRefs {
+    final manager = $$UserPermissionOverridesTableTableManager(
+      $_db,
+      $_db.userPermissionOverrides,
+    ).filter((f) => f.businessId.id.sqlEquals($_itemColumn<String>('id')!));
+
+    final cache = $_typedResult.readTableOrNull(
+      _userPermissionOverridesRefsTable($_db),
     );
     return ProcessedTableManager(
       manager.$state.copyWith(prefetchedData: cache),
@@ -35544,6 +36882,32 @@ class $$BusinessesTableFilterComposer
     return f(composer);
   }
 
+  Expression<bool> stockAdjustmentRequestsRefs(
+    Expression<bool> Function($$StockAdjustmentRequestsTableFilterComposer f) f,
+  ) {
+    final $$StockAdjustmentRequestsTableFilterComposer composer =
+        $composerBuilder(
+          composer: this,
+          getCurrentColumn: (t) => t.id,
+          referencedTable: $db.stockAdjustmentRequests,
+          getReferencedColumn: (t) => t.businessId,
+          builder:
+              (
+                joinBuilder, {
+                $addJoinBuilderToRootComposer,
+                $removeJoinBuilderFromRootComposer,
+              }) => $$StockAdjustmentRequestsTableFilterComposer(
+                $db: $db,
+                $table: $db.stockAdjustmentRequests,
+                $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+                joinBuilder: joinBuilder,
+                $removeJoinBuilderFromRootComposer:
+                    $removeJoinBuilderFromRootComposer,
+              ),
+        );
+    return f(composer);
+  }
+
   Expression<bool> orderItemsRefs(
     Expression<bool> Function($$OrderItemsTableFilterComposer f) f,
   ) {
@@ -36041,6 +37405,32 @@ class $$BusinessesTableFilterComposer
                 $removeJoinBuilderFromRootComposer,
           ),
     );
+    return f(composer);
+  }
+
+  Expression<bool> userPermissionOverridesRefs(
+    Expression<bool> Function($$UserPermissionOverridesTableFilterComposer f) f,
+  ) {
+    final $$UserPermissionOverridesTableFilterComposer composer =
+        $composerBuilder(
+          composer: this,
+          getCurrentColumn: (t) => t.id,
+          referencedTable: $db.userPermissionOverrides,
+          getReferencedColumn: (t) => t.businessId,
+          builder:
+              (
+                joinBuilder, {
+                $addJoinBuilderToRootComposer,
+                $removeJoinBuilderFromRootComposer,
+              }) => $$UserPermissionOverridesTableFilterComposer(
+                $db: $db,
+                $table: $db.userPermissionOverrides,
+                $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+                joinBuilder: joinBuilder,
+                $removeJoinBuilderFromRootComposer:
+                    $removeJoinBuilderFromRootComposer,
+              ),
+        );
     return f(composer);
   }
 
@@ -36804,6 +38194,33 @@ class $$BusinessesTableAnnotationComposer
     return f(composer);
   }
 
+  Expression<T> stockAdjustmentRequestsRefs<T extends Object>(
+    Expression<T> Function($$StockAdjustmentRequestsTableAnnotationComposer a)
+    f,
+  ) {
+    final $$StockAdjustmentRequestsTableAnnotationComposer composer =
+        $composerBuilder(
+          composer: this,
+          getCurrentColumn: (t) => t.id,
+          referencedTable: $db.stockAdjustmentRequests,
+          getReferencedColumn: (t) => t.businessId,
+          builder:
+              (
+                joinBuilder, {
+                $addJoinBuilderToRootComposer,
+                $removeJoinBuilderFromRootComposer,
+              }) => $$StockAdjustmentRequestsTableAnnotationComposer(
+                $db: $db,
+                $table: $db.stockAdjustmentRequests,
+                $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+                joinBuilder: joinBuilder,
+                $removeJoinBuilderFromRootComposer:
+                    $removeJoinBuilderFromRootComposer,
+              ),
+        );
+    return f(composer);
+  }
+
   Expression<T> orderItemsRefs<T extends Object>(
     Expression<T> Function($$OrderItemsTableAnnotationComposer a) f,
   ) {
@@ -37306,6 +38723,33 @@ class $$BusinessesTableAnnotationComposer
     return f(composer);
   }
 
+  Expression<T> userPermissionOverridesRefs<T extends Object>(
+    Expression<T> Function($$UserPermissionOverridesTableAnnotationComposer a)
+    f,
+  ) {
+    final $$UserPermissionOverridesTableAnnotationComposer composer =
+        $composerBuilder(
+          composer: this,
+          getCurrentColumn: (t) => t.id,
+          referencedTable: $db.userPermissionOverrides,
+          getReferencedColumn: (t) => t.businessId,
+          builder:
+              (
+                joinBuilder, {
+                $addJoinBuilderToRootComposer,
+                $removeJoinBuilderFromRootComposer,
+              }) => $$UserPermissionOverridesTableAnnotationComposer(
+                $db: $db,
+                $table: $db.userPermissionOverrides,
+                $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+                joinBuilder: joinBuilder,
+                $removeJoinBuilderFromRootComposer:
+                    $removeJoinBuilderFromRootComposer,
+              ),
+        );
+    return f(composer);
+  }
+
   Expression<T> roleSettingsRefs<T extends Object>(
     Expression<T> Function($$RoleSettingsTableAnnotationComposer a) f,
   ) {
@@ -37467,6 +38911,7 @@ class $$BusinessesTableTableManager
             bool stockAdjustmentsRefs,
             bool shipmentsRefs,
             bool stockTransactionsRefs,
+            bool stockAdjustmentRequestsRefs,
             bool orderItemsRefs,
             bool purchaseItemsRefs,
             bool expenseCategoriesRefs,
@@ -37487,6 +38932,7 @@ class $$BusinessesTableTableManager
             bool sessionsRefs,
             bool rolesRefs,
             bool rolePermissionsRefs,
+            bool userPermissionOverridesRefs,
             bool roleSettingsRefs,
             bool userBusinessesRefs,
             bool inviteCodesRefs,
@@ -37588,6 +39034,7 @@ class $$BusinessesTableTableManager
                 stockAdjustmentsRefs = false,
                 shipmentsRefs = false,
                 stockTransactionsRefs = false,
+                stockAdjustmentRequestsRefs = false,
                 orderItemsRefs = false,
                 purchaseItemsRefs = false,
                 expenseCategoriesRefs = false,
@@ -37608,6 +39055,7 @@ class $$BusinessesTableTableManager
                 sessionsRefs = false,
                 rolesRefs = false,
                 rolePermissionsRefs = false,
+                userPermissionOverridesRefs = false,
                 roleSettingsRefs = false,
                 userBusinessesRefs = false,
                 inviteCodesRefs = false,
@@ -37639,6 +39087,7 @@ class $$BusinessesTableTableManager
                     if (stockAdjustmentsRefs) db.stockAdjustments,
                     if (shipmentsRefs) db.shipments,
                     if (stockTransactionsRefs) db.stockTransactions,
+                    if (stockAdjustmentRequestsRefs) db.stockAdjustmentRequests,
                     if (orderItemsRefs) db.orderItems,
                     if (purchaseItemsRefs) db.purchaseItems,
                     if (expenseCategoriesRefs) db.expenseCategories,
@@ -37659,6 +39108,7 @@ class $$BusinessesTableTableManager
                     if (sessionsRefs) db.sessions,
                     if (rolesRefs) db.roles,
                     if (rolePermissionsRefs) db.rolePermissions,
+                    if (userPermissionOverridesRefs) db.userPermissionOverrides,
                     if (roleSettingsRefs) db.roleSettings,
                     if (userBusinessesRefs) db.userBusinesses,
                     if (inviteCodesRefs) db.inviteCodes,
@@ -38109,6 +39559,27 @@ class $$BusinessesTableTableManager
                               ),
                           typedResults: items,
                         ),
+                      if (stockAdjustmentRequestsRefs)
+                        await $_getPrefetchedData<
+                          BusinessData,
+                          $BusinessesTable,
+                          StockAdjustmentRequestData
+                        >(
+                          currentTable: table,
+                          referencedTable: $$BusinessesTableReferences
+                              ._stockAdjustmentRequestsRefsTable(db),
+                          managerFromTypedResult: (p0) =>
+                              $$BusinessesTableReferences(
+                                db,
+                                table,
+                                p0,
+                              ).stockAdjustmentRequestsRefs,
+                          referencedItemsForCurrentItem:
+                              (item, referencedItems) => referencedItems.where(
+                                (e) => e.businessId == item.id,
+                              ),
+                          typedResults: items,
+                        ),
                       if (orderItemsRefs)
                         await $_getPrefetchedData<
                           BusinessData,
@@ -38529,6 +40000,27 @@ class $$BusinessesTableTableManager
                               ),
                           typedResults: items,
                         ),
+                      if (userPermissionOverridesRefs)
+                        await $_getPrefetchedData<
+                          BusinessData,
+                          $BusinessesTable,
+                          UserPermissionOverrideData
+                        >(
+                          currentTable: table,
+                          referencedTable: $$BusinessesTableReferences
+                              ._userPermissionOverridesRefsTable(db),
+                          managerFromTypedResult: (p0) =>
+                              $$BusinessesTableReferences(
+                                db,
+                                table,
+                                p0,
+                              ).userPermissionOverridesRefs,
+                          referencedItemsForCurrentItem:
+                              (item, referencedItems) => referencedItems.where(
+                                (e) => e.businessId == item.id,
+                              ),
+                          typedResults: items,
+                        ),
                       if (roleSettingsRefs)
                         await $_getPrefetchedData<
                           BusinessData,
@@ -38676,6 +40168,7 @@ typedef $$BusinessesTableProcessedTableManager =
         bool stockAdjustmentsRefs,
         bool shipmentsRefs,
         bool stockTransactionsRefs,
+        bool stockAdjustmentRequestsRefs,
         bool orderItemsRefs,
         bool purchaseItemsRefs,
         bool expenseCategoriesRefs,
@@ -38696,6 +40189,7 @@ typedef $$BusinessesTableProcessedTableManager =
         bool sessionsRefs,
         bool rolesRefs,
         bool rolePermissionsRefs,
+        bool userPermissionOverridesRefs,
         bool roleSettingsRefs,
         bool userBusinessesRefs,
         bool inviteCodesRefs,
@@ -40487,6 +41981,34 @@ final class $$StoresTableReferences
     );
   }
 
+  static MultiTypedResultKey<
+    $StockAdjustmentRequestsTable,
+    List<StockAdjustmentRequestData>
+  >
+  _stockAdjustmentRequestsRefsTable(_$AppDatabase db) =>
+      MultiTypedResultKey.fromTable(
+        db.stockAdjustmentRequests,
+        aliasName: $_aliasNameGenerator(
+          db.stores.id,
+          db.stockAdjustmentRequests.storeId,
+        ),
+      );
+
+  $$StockAdjustmentRequestsTableProcessedTableManager
+  get stockAdjustmentRequestsRefs {
+    final manager = $$StockAdjustmentRequestsTableTableManager(
+      $_db,
+      $_db.stockAdjustmentRequests,
+    ).filter((f) => f.storeId.id.sqlEquals($_itemColumn<String>('id')!));
+
+    final cache = $_typedResult.readTableOrNull(
+      _stockAdjustmentRequestsRefsTable($_db),
+    );
+    return ProcessedTableManager(
+      manager.$state.copyWith(prefetchedData: cache),
+    );
+  }
+
   static MultiTypedResultKey<$OrderItemsTable, List<OrderItemData>>
   _orderItemsRefsTable(_$AppDatabase db) => MultiTypedResultKey.fromTable(
     db.orderItems,
@@ -40899,6 +42421,32 @@ class $$StoresTableFilterComposer
                 $removeJoinBuilderFromRootComposer,
           ),
     );
+    return f(composer);
+  }
+
+  Expression<bool> stockAdjustmentRequestsRefs(
+    Expression<bool> Function($$StockAdjustmentRequestsTableFilterComposer f) f,
+  ) {
+    final $$StockAdjustmentRequestsTableFilterComposer composer =
+        $composerBuilder(
+          composer: this,
+          getCurrentColumn: (t) => t.id,
+          referencedTable: $db.stockAdjustmentRequests,
+          getReferencedColumn: (t) => t.storeId,
+          builder:
+              (
+                joinBuilder, {
+                $addJoinBuilderToRootComposer,
+                $removeJoinBuilderFromRootComposer,
+              }) => $$StockAdjustmentRequestsTableFilterComposer(
+                $db: $db,
+                $table: $db.stockAdjustmentRequests,
+                $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+                joinBuilder: joinBuilder,
+                $removeJoinBuilderFromRootComposer:
+                    $removeJoinBuilderFromRootComposer,
+              ),
+        );
     return f(composer);
   }
 
@@ -41444,6 +42992,33 @@ class $$StoresTableAnnotationComposer
     return f(composer);
   }
 
+  Expression<T> stockAdjustmentRequestsRefs<T extends Object>(
+    Expression<T> Function($$StockAdjustmentRequestsTableAnnotationComposer a)
+    f,
+  ) {
+    final $$StockAdjustmentRequestsTableAnnotationComposer composer =
+        $composerBuilder(
+          composer: this,
+          getCurrentColumn: (t) => t.id,
+          referencedTable: $db.stockAdjustmentRequests,
+          getReferencedColumn: (t) => t.storeId,
+          builder:
+              (
+                joinBuilder, {
+                $addJoinBuilderToRootComposer,
+                $removeJoinBuilderFromRootComposer,
+              }) => $$StockAdjustmentRequestsTableAnnotationComposer(
+                $db: $db,
+                $table: $db.stockAdjustmentRequests,
+                $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+                joinBuilder: joinBuilder,
+                $removeJoinBuilderFromRootComposer:
+                    $removeJoinBuilderFromRootComposer,
+              ),
+        );
+    return f(composer);
+  }
+
   Expression<T> orderItemsRefs<T extends Object>(
     Expression<T> Function($$OrderItemsTableAnnotationComposer a) f,
   ) {
@@ -41741,6 +43316,7 @@ class $$StoresTableTableManager
             bool inventoryRefs,
             bool stockAdjustmentsRefs,
             bool stockTransactionsRefs,
+            bool stockAdjustmentRequestsRefs,
             bool orderItemsRefs,
             bool fundsAccountsRefs,
             bool expensesRefs,
@@ -41820,6 +43396,7 @@ class $$StoresTableTableManager
                 inventoryRefs = false,
                 stockAdjustmentsRefs = false,
                 stockTransactionsRefs = false,
+                stockAdjustmentRequestsRefs = false,
                 orderItemsRefs = false,
                 fundsAccountsRefs = false,
                 expensesRefs = false,
@@ -41841,6 +43418,7 @@ class $$StoresTableTableManager
                     if (inventoryRefs) db.inventory,
                     if (stockAdjustmentsRefs) db.stockAdjustments,
                     if (stockTransactionsRefs) db.stockTransactions,
+                    if (stockAdjustmentRequestsRefs) db.stockAdjustmentRequests,
                     if (orderItemsRefs) db.orderItems,
                     if (fundsAccountsRefs) db.fundsAccounts,
                     if (expensesRefs) db.expenses,
@@ -42002,6 +43580,27 @@ class $$StoresTableTableManager
                           referencedItemsForCurrentItem:
                               (item, referencedItems) => referencedItems.where(
                                 (e) => e.locationId == item.id,
+                              ),
+                          typedResults: items,
+                        ),
+                      if (stockAdjustmentRequestsRefs)
+                        await $_getPrefetchedData<
+                          StoreData,
+                          $StoresTable,
+                          StockAdjustmentRequestData
+                        >(
+                          currentTable: table,
+                          referencedTable: $$StoresTableReferences
+                              ._stockAdjustmentRequestsRefsTable(db),
+                          managerFromTypedResult: (p0) =>
+                              $$StoresTableReferences(
+                                db,
+                                table,
+                                p0,
+                              ).stockAdjustmentRequestsRefs,
+                          referencedItemsForCurrentItem:
+                              (item, referencedItems) => referencedItems.where(
+                                (e) => e.storeId == item.id,
                               ),
                           typedResults: items,
                         ),
@@ -42264,6 +43863,7 @@ typedef $$StoresTableProcessedTableManager =
         bool inventoryRefs,
         bool stockAdjustmentsRefs,
         bool stockTransactionsRefs,
+        bool stockAdjustmentRequestsRefs,
         bool orderItemsRefs,
         bool fundsAccountsRefs,
         bool expensesRefs,
@@ -42474,6 +44074,34 @@ final class $$UsersTableReferences
     ).filter((f) => f.userId.id.sqlEquals($_itemColumn<String>('id')!));
 
     final cache = $_typedResult.readTableOrNull(_sessionsRefsTable($_db));
+    return ProcessedTableManager(
+      manager.$state.copyWith(prefetchedData: cache),
+    );
+  }
+
+  static MultiTypedResultKey<
+    $UserPermissionOverridesTable,
+    List<UserPermissionOverrideData>
+  >
+  _userPermissionOverridesRefsTable(_$AppDatabase db) =>
+      MultiTypedResultKey.fromTable(
+        db.userPermissionOverrides,
+        aliasName: $_aliasNameGenerator(
+          db.users.id,
+          db.userPermissionOverrides.userId,
+        ),
+      );
+
+  $$UserPermissionOverridesTableProcessedTableManager
+  get userPermissionOverridesRefs {
+    final manager = $$UserPermissionOverridesTableTableManager(
+      $_db,
+      $_db.userPermissionOverrides,
+    ).filter((f) => f.userId.id.sqlEquals($_itemColumn<String>('id')!));
+
+    final cache = $_typedResult.readTableOrNull(
+      _userPermissionOverridesRefsTable($_db),
+    );
     return ProcessedTableManager(
       manager.$state.copyWith(prefetchedData: cache),
     );
@@ -42787,6 +44415,32 @@ class $$UsersTableFilterComposer extends Composer<_$AppDatabase, $UsersTable> {
                 $removeJoinBuilderFromRootComposer,
           ),
     );
+    return f(composer);
+  }
+
+  Expression<bool> userPermissionOverridesRefs(
+    Expression<bool> Function($$UserPermissionOverridesTableFilterComposer f) f,
+  ) {
+    final $$UserPermissionOverridesTableFilterComposer composer =
+        $composerBuilder(
+          composer: this,
+          getCurrentColumn: (t) => t.id,
+          referencedTable: $db.userPermissionOverrides,
+          getReferencedColumn: (t) => t.userId,
+          builder:
+              (
+                joinBuilder, {
+                $addJoinBuilderToRootComposer,
+                $removeJoinBuilderFromRootComposer,
+              }) => $$UserPermissionOverridesTableFilterComposer(
+                $db: $db,
+                $table: $db.userPermissionOverrides,
+                $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+                joinBuilder: joinBuilder,
+                $removeJoinBuilderFromRootComposer:
+                    $removeJoinBuilderFromRootComposer,
+              ),
+        );
     return f(composer);
   }
 
@@ -43228,6 +44882,33 @@ class $$UsersTableAnnotationComposer
     return f(composer);
   }
 
+  Expression<T> userPermissionOverridesRefs<T extends Object>(
+    Expression<T> Function($$UserPermissionOverridesTableAnnotationComposer a)
+    f,
+  ) {
+    final $$UserPermissionOverridesTableAnnotationComposer composer =
+        $composerBuilder(
+          composer: this,
+          getCurrentColumn: (t) => t.id,
+          referencedTable: $db.userPermissionOverrides,
+          getReferencedColumn: (t) => t.userId,
+          builder:
+              (
+                joinBuilder, {
+                $addJoinBuilderToRootComposer,
+                $removeJoinBuilderFromRootComposer,
+              }) => $$UserPermissionOverridesTableAnnotationComposer(
+                $db: $db,
+                $table: $db.userPermissionOverrides,
+                $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+                joinBuilder: joinBuilder,
+                $removeJoinBuilderFromRootComposer:
+                    $removeJoinBuilderFromRootComposer,
+              ),
+        );
+    return f(composer);
+  }
+
   Expression<T> userBusinessesRefs<T extends Object>(
     Expression<T> Function($$UserBusinessesTableAnnotationComposer a) f,
   ) {
@@ -43301,6 +44982,7 @@ class $$UsersTableTableManager
             bool stockCountsRefs,
             bool notificationsRefs,
             bool sessionsRefs,
+            bool userPermissionOverridesRefs,
             bool userBusinessesRefs,
             bool userStoresRefs,
           })
@@ -43408,6 +45090,7 @@ class $$UsersTableTableManager
                 stockCountsRefs = false,
                 notificationsRefs = false,
                 sessionsRefs = false,
+                userPermissionOverridesRefs = false,
                 userBusinessesRefs = false,
                 userStoresRefs = false,
               }) {
@@ -43420,6 +45103,7 @@ class $$UsersTableTableManager
                     if (stockCountsRefs) db.stockCounts,
                     if (notificationsRefs) db.notifications,
                     if (sessionsRefs) db.sessions,
+                    if (userPermissionOverridesRefs) db.userPermissionOverrides,
                     if (userBusinessesRefs) db.userBusinesses,
                     if (userStoresRefs) db.userStores,
                   ],
@@ -43592,6 +45276,27 @@ class $$UsersTableTableManager
                               ),
                           typedResults: items,
                         ),
+                      if (userPermissionOverridesRefs)
+                        await $_getPrefetchedData<
+                          UserData,
+                          $UsersTable,
+                          UserPermissionOverrideData
+                        >(
+                          currentTable: table,
+                          referencedTable: $$UsersTableReferences
+                              ._userPermissionOverridesRefsTable(db),
+                          managerFromTypedResult: (p0) =>
+                              $$UsersTableReferences(
+                                db,
+                                table,
+                                p0,
+                              ).userPermissionOverridesRefs,
+                          referencedItemsForCurrentItem:
+                              (item, referencedItems) => referencedItems.where(
+                                (e) => e.userId == item.id,
+                              ),
+                          typedResults: items,
+                        ),
                       if (userBusinessesRefs)
                         await $_getPrefetchedData<
                           UserData,
@@ -43663,6 +45368,7 @@ typedef $$UsersTableProcessedTableManager =
         bool stockCountsRefs,
         bool notificationsRefs,
         bool sessionsRefs,
+        bool userPermissionOverridesRefs,
         bool userBusinessesRefs,
         bool userStoresRefs,
       })
@@ -45103,6 +46809,34 @@ final class $$ProductsTableReferences
     );
   }
 
+  static MultiTypedResultKey<
+    $StockAdjustmentRequestsTable,
+    List<StockAdjustmentRequestData>
+  >
+  _stockAdjustmentRequestsRefsTable(_$AppDatabase db) =>
+      MultiTypedResultKey.fromTable(
+        db.stockAdjustmentRequests,
+        aliasName: $_aliasNameGenerator(
+          db.products.id,
+          db.stockAdjustmentRequests.productId,
+        ),
+      );
+
+  $$StockAdjustmentRequestsTableProcessedTableManager
+  get stockAdjustmentRequestsRefs {
+    final manager = $$StockAdjustmentRequestsTableTableManager(
+      $_db,
+      $_db.stockAdjustmentRequests,
+    ).filter((f) => f.productId.id.sqlEquals($_itemColumn<String>('id')!));
+
+    final cache = $_typedResult.readTableOrNull(
+      _stockAdjustmentRequestsRefsTable($_db),
+    );
+    return ProcessedTableManager(
+      manager.$state.copyWith(prefetchedData: cache),
+    );
+  }
+
   static MultiTypedResultKey<$OrderItemsTable, List<OrderItemData>>
   _orderItemsRefsTable(_$AppDatabase db) => MultiTypedResultKey.fromTable(
     db.orderItems,
@@ -45521,6 +47255,32 @@ class $$ProductsTableFilterComposer
                 $removeJoinBuilderFromRootComposer,
           ),
     );
+    return f(composer);
+  }
+
+  Expression<bool> stockAdjustmentRequestsRefs(
+    Expression<bool> Function($$StockAdjustmentRequestsTableFilterComposer f) f,
+  ) {
+    final $$StockAdjustmentRequestsTableFilterComposer composer =
+        $composerBuilder(
+          composer: this,
+          getCurrentColumn: (t) => t.id,
+          referencedTable: $db.stockAdjustmentRequests,
+          getReferencedColumn: (t) => t.productId,
+          builder:
+              (
+                joinBuilder, {
+                $addJoinBuilderToRootComposer,
+                $removeJoinBuilderFromRootComposer,
+              }) => $$StockAdjustmentRequestsTableFilterComposer(
+                $db: $db,
+                $table: $db.stockAdjustmentRequests,
+                $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+                joinBuilder: joinBuilder,
+                $removeJoinBuilderFromRootComposer:
+                    $removeJoinBuilderFromRootComposer,
+              ),
+        );
     return f(composer);
   }
 
@@ -46196,6 +47956,33 @@ class $$ProductsTableAnnotationComposer
     return f(composer);
   }
 
+  Expression<T> stockAdjustmentRequestsRefs<T extends Object>(
+    Expression<T> Function($$StockAdjustmentRequestsTableAnnotationComposer a)
+    f,
+  ) {
+    final $$StockAdjustmentRequestsTableAnnotationComposer composer =
+        $composerBuilder(
+          composer: this,
+          getCurrentColumn: (t) => t.id,
+          referencedTable: $db.stockAdjustmentRequests,
+          getReferencedColumn: (t) => t.productId,
+          builder:
+              (
+                joinBuilder, {
+                $addJoinBuilderToRootComposer,
+                $removeJoinBuilderFromRootComposer,
+              }) => $$StockAdjustmentRequestsTableAnnotationComposer(
+                $db: $db,
+                $table: $db.stockAdjustmentRequests,
+                $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+                joinBuilder: joinBuilder,
+                $removeJoinBuilderFromRootComposer:
+                    $removeJoinBuilderFromRootComposer,
+              ),
+        );
+    return f(composer);
+  }
+
   Expression<T> orderItemsRefs<T extends Object>(
     Expression<T> Function($$OrderItemsTableAnnotationComposer a) f,
   ) {
@@ -46271,6 +48058,7 @@ class $$ProductsTableTableManager
             bool stockTransfersRefs,
             bool stockAdjustmentsRefs,
             bool stockTransactionsRefs,
+            bool stockAdjustmentRequestsRefs,
             bool orderItemsRefs,
             bool purchaseItemsRefs,
           })
@@ -46446,6 +48234,7 @@ class $$ProductsTableTableManager
                 stockTransfersRefs = false,
                 stockAdjustmentsRefs = false,
                 stockTransactionsRefs = false,
+                stockAdjustmentRequestsRefs = false,
                 orderItemsRefs = false,
                 purchaseItemsRefs = false,
               }) {
@@ -46457,6 +48246,7 @@ class $$ProductsTableTableManager
                     if (stockTransfersRefs) db.stockTransfers,
                     if (stockAdjustmentsRefs) db.stockAdjustments,
                     if (stockTransactionsRefs) db.stockTransactions,
+                    if (stockAdjustmentRequestsRefs) db.stockAdjustmentRequests,
                     if (orderItemsRefs) db.orderItems,
                     if (purchaseItemsRefs) db.purchaseItems,
                   ],
@@ -46651,6 +48441,27 @@ class $$ProductsTableTableManager
                               ),
                           typedResults: items,
                         ),
+                      if (stockAdjustmentRequestsRefs)
+                        await $_getPrefetchedData<
+                          ProductData,
+                          $ProductsTable,
+                          StockAdjustmentRequestData
+                        >(
+                          currentTable: table,
+                          referencedTable: $$ProductsTableReferences
+                              ._stockAdjustmentRequestsRefsTable(db),
+                          managerFromTypedResult: (p0) =>
+                              $$ProductsTableReferences(
+                                db,
+                                table,
+                                p0,
+                              ).stockAdjustmentRequestsRefs,
+                          referencedItemsForCurrentItem:
+                              (item, referencedItems) => referencedItems.where(
+                                (e) => e.productId == item.id,
+                              ),
+                          typedResults: items,
+                        ),
                       if (orderItemsRefs)
                         await $_getPrefetchedData<
                           ProductData,
@@ -46724,6 +48535,7 @@ typedef $$ProductsTableProcessedTableManager =
         bool stockTransfersRefs,
         bool stockAdjustmentsRefs,
         bool stockTransactionsRefs,
+        bool stockAdjustmentRequestsRefs,
         bool orderItemsRefs,
         bool purchaseItemsRefs,
       })
@@ -59702,6 +61514,894 @@ typedef $$StockTransactionsTableProcessedTableManager =
         bool shipmentId,
         bool performedBy,
         bool voidedBy,
+      })
+    >;
+typedef $$StockAdjustmentRequestsTableCreateCompanionBuilder =
+    StockAdjustmentRequestsCompanion Function({
+      Value<String> id,
+      required String businessId,
+      required String productId,
+      required String storeId,
+      required int quantityDiff,
+      required String reason,
+      required String summary,
+      Value<String?> requestedBy,
+      Value<String> status,
+      Value<String?> approvedBy,
+      Value<DateTime?> approvedAt,
+      Value<DateTime> createdAt,
+      Value<DateTime> lastUpdatedAt,
+      Value<int> rowid,
+    });
+typedef $$StockAdjustmentRequestsTableUpdateCompanionBuilder =
+    StockAdjustmentRequestsCompanion Function({
+      Value<String> id,
+      Value<String> businessId,
+      Value<String> productId,
+      Value<String> storeId,
+      Value<int> quantityDiff,
+      Value<String> reason,
+      Value<String> summary,
+      Value<String?> requestedBy,
+      Value<String> status,
+      Value<String?> approvedBy,
+      Value<DateTime?> approvedAt,
+      Value<DateTime> createdAt,
+      Value<DateTime> lastUpdatedAt,
+      Value<int> rowid,
+    });
+
+final class $$StockAdjustmentRequestsTableReferences
+    extends
+        BaseReferences<
+          _$AppDatabase,
+          $StockAdjustmentRequestsTable,
+          StockAdjustmentRequestData
+        > {
+  $$StockAdjustmentRequestsTableReferences(
+    super.$_db,
+    super.$_table,
+    super.$_typedResult,
+  );
+
+  static $BusinessesTable _businessIdTable(_$AppDatabase db) =>
+      db.businesses.createAlias(
+        $_aliasNameGenerator(
+          db.stockAdjustmentRequests.businessId,
+          db.businesses.id,
+        ),
+      );
+
+  $$BusinessesTableProcessedTableManager get businessId {
+    final $_column = $_itemColumn<String>('business_id')!;
+
+    final manager = $$BusinessesTableTableManager(
+      $_db,
+      $_db.businesses,
+    ).filter((f) => f.id.sqlEquals($_column));
+    final item = $_typedResult.readTableOrNull(_businessIdTable($_db));
+    if (item == null) return manager;
+    return ProcessedTableManager(
+      manager.$state.copyWith(prefetchedData: [item]),
+    );
+  }
+
+  static $ProductsTable _productIdTable(_$AppDatabase db) =>
+      db.products.createAlias(
+        $_aliasNameGenerator(
+          db.stockAdjustmentRequests.productId,
+          db.products.id,
+        ),
+      );
+
+  $$ProductsTableProcessedTableManager get productId {
+    final $_column = $_itemColumn<String>('product_id')!;
+
+    final manager = $$ProductsTableTableManager(
+      $_db,
+      $_db.products,
+    ).filter((f) => f.id.sqlEquals($_column));
+    final item = $_typedResult.readTableOrNull(_productIdTable($_db));
+    if (item == null) return manager;
+    return ProcessedTableManager(
+      manager.$state.copyWith(prefetchedData: [item]),
+    );
+  }
+
+  static $StoresTable _storeIdTable(_$AppDatabase db) => db.stores.createAlias(
+    $_aliasNameGenerator(db.stockAdjustmentRequests.storeId, db.stores.id),
+  );
+
+  $$StoresTableProcessedTableManager get storeId {
+    final $_column = $_itemColumn<String>('store_id')!;
+
+    final manager = $$StoresTableTableManager(
+      $_db,
+      $_db.stores,
+    ).filter((f) => f.id.sqlEquals($_column));
+    final item = $_typedResult.readTableOrNull(_storeIdTable($_db));
+    if (item == null) return manager;
+    return ProcessedTableManager(
+      manager.$state.copyWith(prefetchedData: [item]),
+    );
+  }
+
+  static $UsersTable _requestedByTable(_$AppDatabase db) =>
+      db.users.createAlias(
+        $_aliasNameGenerator(
+          db.stockAdjustmentRequests.requestedBy,
+          db.users.id,
+        ),
+      );
+
+  $$UsersTableProcessedTableManager? get requestedBy {
+    final $_column = $_itemColumn<String>('requested_by');
+    if ($_column == null) return null;
+    final manager = $$UsersTableTableManager(
+      $_db,
+      $_db.users,
+    ).filter((f) => f.id.sqlEquals($_column));
+    final item = $_typedResult.readTableOrNull(_requestedByTable($_db));
+    if (item == null) return manager;
+    return ProcessedTableManager(
+      manager.$state.copyWith(prefetchedData: [item]),
+    );
+  }
+
+  static $UsersTable _approvedByTable(_$AppDatabase db) => db.users.createAlias(
+    $_aliasNameGenerator(db.stockAdjustmentRequests.approvedBy, db.users.id),
+  );
+
+  $$UsersTableProcessedTableManager? get approvedBy {
+    final $_column = $_itemColumn<String>('approved_by');
+    if ($_column == null) return null;
+    final manager = $$UsersTableTableManager(
+      $_db,
+      $_db.users,
+    ).filter((f) => f.id.sqlEquals($_column));
+    final item = $_typedResult.readTableOrNull(_approvedByTable($_db));
+    if (item == null) return manager;
+    return ProcessedTableManager(
+      manager.$state.copyWith(prefetchedData: [item]),
+    );
+  }
+}
+
+class $$StockAdjustmentRequestsTableFilterComposer
+    extends Composer<_$AppDatabase, $StockAdjustmentRequestsTable> {
+  $$StockAdjustmentRequestsTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<String> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get quantityDiff => $composableBuilder(
+    column: $table.quantityDiff,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get reason => $composableBuilder(
+    column: $table.reason,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get summary => $composableBuilder(
+    column: $table.summary,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get status => $composableBuilder(
+    column: $table.status,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<DateTime> get approvedAt => $composableBuilder(
+    column: $table.approvedAt,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<DateTime> get createdAt => $composableBuilder(
+    column: $table.createdAt,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<DateTime> get lastUpdatedAt => $composableBuilder(
+    column: $table.lastUpdatedAt,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  $$BusinessesTableFilterComposer get businessId {
+    final $$BusinessesTableFilterComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.businessId,
+      referencedTable: $db.businesses,
+      getReferencedColumn: (t) => t.id,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$BusinessesTableFilterComposer(
+            $db: $db,
+            $table: $db.businesses,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
+
+  $$ProductsTableFilterComposer get productId {
+    final $$ProductsTableFilterComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.productId,
+      referencedTable: $db.products,
+      getReferencedColumn: (t) => t.id,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$ProductsTableFilterComposer(
+            $db: $db,
+            $table: $db.products,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
+
+  $$StoresTableFilterComposer get storeId {
+    final $$StoresTableFilterComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.storeId,
+      referencedTable: $db.stores,
+      getReferencedColumn: (t) => t.id,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$StoresTableFilterComposer(
+            $db: $db,
+            $table: $db.stores,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
+
+  $$UsersTableFilterComposer get requestedBy {
+    final $$UsersTableFilterComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.requestedBy,
+      referencedTable: $db.users,
+      getReferencedColumn: (t) => t.id,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$UsersTableFilterComposer(
+            $db: $db,
+            $table: $db.users,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
+
+  $$UsersTableFilterComposer get approvedBy {
+    final $$UsersTableFilterComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.approvedBy,
+      referencedTable: $db.users,
+      getReferencedColumn: (t) => t.id,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$UsersTableFilterComposer(
+            $db: $db,
+            $table: $db.users,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
+}
+
+class $$StockAdjustmentRequestsTableOrderingComposer
+    extends Composer<_$AppDatabase, $StockAdjustmentRequestsTable> {
+  $$StockAdjustmentRequestsTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<String> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get quantityDiff => $composableBuilder(
+    column: $table.quantityDiff,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get reason => $composableBuilder(
+    column: $table.reason,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get summary => $composableBuilder(
+    column: $table.summary,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get status => $composableBuilder(
+    column: $table.status,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<DateTime> get approvedAt => $composableBuilder(
+    column: $table.approvedAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<DateTime> get createdAt => $composableBuilder(
+    column: $table.createdAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<DateTime> get lastUpdatedAt => $composableBuilder(
+    column: $table.lastUpdatedAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  $$BusinessesTableOrderingComposer get businessId {
+    final $$BusinessesTableOrderingComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.businessId,
+      referencedTable: $db.businesses,
+      getReferencedColumn: (t) => t.id,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$BusinessesTableOrderingComposer(
+            $db: $db,
+            $table: $db.businesses,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
+
+  $$ProductsTableOrderingComposer get productId {
+    final $$ProductsTableOrderingComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.productId,
+      referencedTable: $db.products,
+      getReferencedColumn: (t) => t.id,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$ProductsTableOrderingComposer(
+            $db: $db,
+            $table: $db.products,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
+
+  $$StoresTableOrderingComposer get storeId {
+    final $$StoresTableOrderingComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.storeId,
+      referencedTable: $db.stores,
+      getReferencedColumn: (t) => t.id,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$StoresTableOrderingComposer(
+            $db: $db,
+            $table: $db.stores,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
+
+  $$UsersTableOrderingComposer get requestedBy {
+    final $$UsersTableOrderingComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.requestedBy,
+      referencedTable: $db.users,
+      getReferencedColumn: (t) => t.id,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$UsersTableOrderingComposer(
+            $db: $db,
+            $table: $db.users,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
+
+  $$UsersTableOrderingComposer get approvedBy {
+    final $$UsersTableOrderingComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.approvedBy,
+      referencedTable: $db.users,
+      getReferencedColumn: (t) => t.id,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$UsersTableOrderingComposer(
+            $db: $db,
+            $table: $db.users,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
+}
+
+class $$StockAdjustmentRequestsTableAnnotationComposer
+    extends Composer<_$AppDatabase, $StockAdjustmentRequestsTable> {
+  $$StockAdjustmentRequestsTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<String> get id =>
+      $composableBuilder(column: $table.id, builder: (column) => column);
+
+  GeneratedColumn<int> get quantityDiff => $composableBuilder(
+    column: $table.quantityDiff,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get reason =>
+      $composableBuilder(column: $table.reason, builder: (column) => column);
+
+  GeneratedColumn<String> get summary =>
+      $composableBuilder(column: $table.summary, builder: (column) => column);
+
+  GeneratedColumn<String> get status =>
+      $composableBuilder(column: $table.status, builder: (column) => column);
+
+  GeneratedColumn<DateTime> get approvedAt => $composableBuilder(
+    column: $table.approvedAt,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<DateTime> get createdAt =>
+      $composableBuilder(column: $table.createdAt, builder: (column) => column);
+
+  GeneratedColumn<DateTime> get lastUpdatedAt => $composableBuilder(
+    column: $table.lastUpdatedAt,
+    builder: (column) => column,
+  );
+
+  $$BusinessesTableAnnotationComposer get businessId {
+    final $$BusinessesTableAnnotationComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.businessId,
+      referencedTable: $db.businesses,
+      getReferencedColumn: (t) => t.id,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$BusinessesTableAnnotationComposer(
+            $db: $db,
+            $table: $db.businesses,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
+
+  $$ProductsTableAnnotationComposer get productId {
+    final $$ProductsTableAnnotationComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.productId,
+      referencedTable: $db.products,
+      getReferencedColumn: (t) => t.id,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$ProductsTableAnnotationComposer(
+            $db: $db,
+            $table: $db.products,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
+
+  $$StoresTableAnnotationComposer get storeId {
+    final $$StoresTableAnnotationComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.storeId,
+      referencedTable: $db.stores,
+      getReferencedColumn: (t) => t.id,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$StoresTableAnnotationComposer(
+            $db: $db,
+            $table: $db.stores,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
+
+  $$UsersTableAnnotationComposer get requestedBy {
+    final $$UsersTableAnnotationComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.requestedBy,
+      referencedTable: $db.users,
+      getReferencedColumn: (t) => t.id,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$UsersTableAnnotationComposer(
+            $db: $db,
+            $table: $db.users,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
+
+  $$UsersTableAnnotationComposer get approvedBy {
+    final $$UsersTableAnnotationComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.approvedBy,
+      referencedTable: $db.users,
+      getReferencedColumn: (t) => t.id,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$UsersTableAnnotationComposer(
+            $db: $db,
+            $table: $db.users,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
+}
+
+class $$StockAdjustmentRequestsTableTableManager
+    extends
+        RootTableManager<
+          _$AppDatabase,
+          $StockAdjustmentRequestsTable,
+          StockAdjustmentRequestData,
+          $$StockAdjustmentRequestsTableFilterComposer,
+          $$StockAdjustmentRequestsTableOrderingComposer,
+          $$StockAdjustmentRequestsTableAnnotationComposer,
+          $$StockAdjustmentRequestsTableCreateCompanionBuilder,
+          $$StockAdjustmentRequestsTableUpdateCompanionBuilder,
+          (
+            StockAdjustmentRequestData,
+            $$StockAdjustmentRequestsTableReferences,
+          ),
+          StockAdjustmentRequestData,
+          PrefetchHooks Function({
+            bool businessId,
+            bool productId,
+            bool storeId,
+            bool requestedBy,
+            bool approvedBy,
+          })
+        > {
+  $$StockAdjustmentRequestsTableTableManager(
+    _$AppDatabase db,
+    $StockAdjustmentRequestsTable table,
+  ) : super(
+        TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer: () =>
+              $$StockAdjustmentRequestsTableFilterComposer(
+                $db: db,
+                $table: table,
+              ),
+          createOrderingComposer: () =>
+              $$StockAdjustmentRequestsTableOrderingComposer(
+                $db: db,
+                $table: table,
+              ),
+          createComputedFieldComposer: () =>
+              $$StockAdjustmentRequestsTableAnnotationComposer(
+                $db: db,
+                $table: table,
+              ),
+          updateCompanionCallback:
+              ({
+                Value<String> id = const Value.absent(),
+                Value<String> businessId = const Value.absent(),
+                Value<String> productId = const Value.absent(),
+                Value<String> storeId = const Value.absent(),
+                Value<int> quantityDiff = const Value.absent(),
+                Value<String> reason = const Value.absent(),
+                Value<String> summary = const Value.absent(),
+                Value<String?> requestedBy = const Value.absent(),
+                Value<String> status = const Value.absent(),
+                Value<String?> approvedBy = const Value.absent(),
+                Value<DateTime?> approvedAt = const Value.absent(),
+                Value<DateTime> createdAt = const Value.absent(),
+                Value<DateTime> lastUpdatedAt = const Value.absent(),
+                Value<int> rowid = const Value.absent(),
+              }) => StockAdjustmentRequestsCompanion(
+                id: id,
+                businessId: businessId,
+                productId: productId,
+                storeId: storeId,
+                quantityDiff: quantityDiff,
+                reason: reason,
+                summary: summary,
+                requestedBy: requestedBy,
+                status: status,
+                approvedBy: approvedBy,
+                approvedAt: approvedAt,
+                createdAt: createdAt,
+                lastUpdatedAt: lastUpdatedAt,
+                rowid: rowid,
+              ),
+          createCompanionCallback:
+              ({
+                Value<String> id = const Value.absent(),
+                required String businessId,
+                required String productId,
+                required String storeId,
+                required int quantityDiff,
+                required String reason,
+                required String summary,
+                Value<String?> requestedBy = const Value.absent(),
+                Value<String> status = const Value.absent(),
+                Value<String?> approvedBy = const Value.absent(),
+                Value<DateTime?> approvedAt = const Value.absent(),
+                Value<DateTime> createdAt = const Value.absent(),
+                Value<DateTime> lastUpdatedAt = const Value.absent(),
+                Value<int> rowid = const Value.absent(),
+              }) => StockAdjustmentRequestsCompanion.insert(
+                id: id,
+                businessId: businessId,
+                productId: productId,
+                storeId: storeId,
+                quantityDiff: quantityDiff,
+                reason: reason,
+                summary: summary,
+                requestedBy: requestedBy,
+                status: status,
+                approvedBy: approvedBy,
+                approvedAt: approvedAt,
+                createdAt: createdAt,
+                lastUpdatedAt: lastUpdatedAt,
+                rowid: rowid,
+              ),
+          withReferenceMapper: (p0) => p0
+              .map(
+                (e) => (
+                  e.readTable(table),
+                  $$StockAdjustmentRequestsTableReferences(db, table, e),
+                ),
+              )
+              .toList(),
+          prefetchHooksCallback:
+              ({
+                businessId = false,
+                productId = false,
+                storeId = false,
+                requestedBy = false,
+                approvedBy = false,
+              }) {
+                return PrefetchHooks(
+                  db: db,
+                  explicitlyWatchedTables: [],
+                  addJoins:
+                      <
+                        T extends TableManagerState<
+                          dynamic,
+                          dynamic,
+                          dynamic,
+                          dynamic,
+                          dynamic,
+                          dynamic,
+                          dynamic,
+                          dynamic,
+                          dynamic,
+                          dynamic,
+                          dynamic
+                        >
+                      >(state) {
+                        if (businessId) {
+                          state =
+                              state.withJoin(
+                                    currentTable: table,
+                                    currentColumn: table.businessId,
+                                    referencedTable:
+                                        $$StockAdjustmentRequestsTableReferences
+                                            ._businessIdTable(db),
+                                    referencedColumn:
+                                        $$StockAdjustmentRequestsTableReferences
+                                            ._businessIdTable(db)
+                                            .id,
+                                  )
+                                  as T;
+                        }
+                        if (productId) {
+                          state =
+                              state.withJoin(
+                                    currentTable: table,
+                                    currentColumn: table.productId,
+                                    referencedTable:
+                                        $$StockAdjustmentRequestsTableReferences
+                                            ._productIdTable(db),
+                                    referencedColumn:
+                                        $$StockAdjustmentRequestsTableReferences
+                                            ._productIdTable(db)
+                                            .id,
+                                  )
+                                  as T;
+                        }
+                        if (storeId) {
+                          state =
+                              state.withJoin(
+                                    currentTable: table,
+                                    currentColumn: table.storeId,
+                                    referencedTable:
+                                        $$StockAdjustmentRequestsTableReferences
+                                            ._storeIdTable(db),
+                                    referencedColumn:
+                                        $$StockAdjustmentRequestsTableReferences
+                                            ._storeIdTable(db)
+                                            .id,
+                                  )
+                                  as T;
+                        }
+                        if (requestedBy) {
+                          state =
+                              state.withJoin(
+                                    currentTable: table,
+                                    currentColumn: table.requestedBy,
+                                    referencedTable:
+                                        $$StockAdjustmentRequestsTableReferences
+                                            ._requestedByTable(db),
+                                    referencedColumn:
+                                        $$StockAdjustmentRequestsTableReferences
+                                            ._requestedByTable(db)
+                                            .id,
+                                  )
+                                  as T;
+                        }
+                        if (approvedBy) {
+                          state =
+                              state.withJoin(
+                                    currentTable: table,
+                                    currentColumn: table.approvedBy,
+                                    referencedTable:
+                                        $$StockAdjustmentRequestsTableReferences
+                                            ._approvedByTable(db),
+                                    referencedColumn:
+                                        $$StockAdjustmentRequestsTableReferences
+                                            ._approvedByTable(db)
+                                            .id,
+                                  )
+                                  as T;
+                        }
+
+                        return state;
+                      },
+                  getPrefetchedDataCallback: (items) async {
+                    return [];
+                  },
+                );
+              },
+        ),
+      );
+}
+
+typedef $$StockAdjustmentRequestsTableProcessedTableManager =
+    ProcessedTableManager<
+      _$AppDatabase,
+      $StockAdjustmentRequestsTable,
+      StockAdjustmentRequestData,
+      $$StockAdjustmentRequestsTableFilterComposer,
+      $$StockAdjustmentRequestsTableOrderingComposer,
+      $$StockAdjustmentRequestsTableAnnotationComposer,
+      $$StockAdjustmentRequestsTableCreateCompanionBuilder,
+      $$StockAdjustmentRequestsTableUpdateCompanionBuilder,
+      (StockAdjustmentRequestData, $$StockAdjustmentRequestsTableReferences),
+      StockAdjustmentRequestData,
+      PrefetchHooks Function({
+        bool businessId,
+        bool productId,
+        bool storeId,
+        bool requestedBy,
+        bool approvedBy,
       })
     >;
 typedef $$OrderItemsTableCreateCompanionBuilder =
@@ -73993,6 +76693,484 @@ typedef $$RolePermissionsTableProcessedTableManager =
       RolePermissionData,
       PrefetchHooks Function({bool businessId, bool roleId})
     >;
+typedef $$UserPermissionOverridesTableCreateCompanionBuilder =
+    UserPermissionOverridesCompanion Function({
+      Value<String> id,
+      required String businessId,
+      required String userId,
+      required String permissionKey,
+      required bool isGranted,
+      Value<DateTime> createdAt,
+      Value<DateTime> lastUpdatedAt,
+      Value<int> rowid,
+    });
+typedef $$UserPermissionOverridesTableUpdateCompanionBuilder =
+    UserPermissionOverridesCompanion Function({
+      Value<String> id,
+      Value<String> businessId,
+      Value<String> userId,
+      Value<String> permissionKey,
+      Value<bool> isGranted,
+      Value<DateTime> createdAt,
+      Value<DateTime> lastUpdatedAt,
+      Value<int> rowid,
+    });
+
+final class $$UserPermissionOverridesTableReferences
+    extends
+        BaseReferences<
+          _$AppDatabase,
+          $UserPermissionOverridesTable,
+          UserPermissionOverrideData
+        > {
+  $$UserPermissionOverridesTableReferences(
+    super.$_db,
+    super.$_table,
+    super.$_typedResult,
+  );
+
+  static $BusinessesTable _businessIdTable(_$AppDatabase db) =>
+      db.businesses.createAlias(
+        $_aliasNameGenerator(
+          db.userPermissionOverrides.businessId,
+          db.businesses.id,
+        ),
+      );
+
+  $$BusinessesTableProcessedTableManager get businessId {
+    final $_column = $_itemColumn<String>('business_id')!;
+
+    final manager = $$BusinessesTableTableManager(
+      $_db,
+      $_db.businesses,
+    ).filter((f) => f.id.sqlEquals($_column));
+    final item = $_typedResult.readTableOrNull(_businessIdTable($_db));
+    if (item == null) return manager;
+    return ProcessedTableManager(
+      manager.$state.copyWith(prefetchedData: [item]),
+    );
+  }
+
+  static $UsersTable _userIdTable(_$AppDatabase db) => db.users.createAlias(
+    $_aliasNameGenerator(db.userPermissionOverrides.userId, db.users.id),
+  );
+
+  $$UsersTableProcessedTableManager get userId {
+    final $_column = $_itemColumn<String>('user_id')!;
+
+    final manager = $$UsersTableTableManager(
+      $_db,
+      $_db.users,
+    ).filter((f) => f.id.sqlEquals($_column));
+    final item = $_typedResult.readTableOrNull(_userIdTable($_db));
+    if (item == null) return manager;
+    return ProcessedTableManager(
+      manager.$state.copyWith(prefetchedData: [item]),
+    );
+  }
+}
+
+class $$UserPermissionOverridesTableFilterComposer
+    extends Composer<_$AppDatabase, $UserPermissionOverridesTable> {
+  $$UserPermissionOverridesTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<String> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get permissionKey => $composableBuilder(
+    column: $table.permissionKey,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<bool> get isGranted => $composableBuilder(
+    column: $table.isGranted,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<DateTime> get createdAt => $composableBuilder(
+    column: $table.createdAt,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<DateTime> get lastUpdatedAt => $composableBuilder(
+    column: $table.lastUpdatedAt,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  $$BusinessesTableFilterComposer get businessId {
+    final $$BusinessesTableFilterComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.businessId,
+      referencedTable: $db.businesses,
+      getReferencedColumn: (t) => t.id,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$BusinessesTableFilterComposer(
+            $db: $db,
+            $table: $db.businesses,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
+
+  $$UsersTableFilterComposer get userId {
+    final $$UsersTableFilterComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.userId,
+      referencedTable: $db.users,
+      getReferencedColumn: (t) => t.id,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$UsersTableFilterComposer(
+            $db: $db,
+            $table: $db.users,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
+}
+
+class $$UserPermissionOverridesTableOrderingComposer
+    extends Composer<_$AppDatabase, $UserPermissionOverridesTable> {
+  $$UserPermissionOverridesTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<String> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get permissionKey => $composableBuilder(
+    column: $table.permissionKey,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<bool> get isGranted => $composableBuilder(
+    column: $table.isGranted,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<DateTime> get createdAt => $composableBuilder(
+    column: $table.createdAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<DateTime> get lastUpdatedAt => $composableBuilder(
+    column: $table.lastUpdatedAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  $$BusinessesTableOrderingComposer get businessId {
+    final $$BusinessesTableOrderingComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.businessId,
+      referencedTable: $db.businesses,
+      getReferencedColumn: (t) => t.id,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$BusinessesTableOrderingComposer(
+            $db: $db,
+            $table: $db.businesses,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
+
+  $$UsersTableOrderingComposer get userId {
+    final $$UsersTableOrderingComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.userId,
+      referencedTable: $db.users,
+      getReferencedColumn: (t) => t.id,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$UsersTableOrderingComposer(
+            $db: $db,
+            $table: $db.users,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
+}
+
+class $$UserPermissionOverridesTableAnnotationComposer
+    extends Composer<_$AppDatabase, $UserPermissionOverridesTable> {
+  $$UserPermissionOverridesTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<String> get id =>
+      $composableBuilder(column: $table.id, builder: (column) => column);
+
+  GeneratedColumn<String> get permissionKey => $composableBuilder(
+    column: $table.permissionKey,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<bool> get isGranted =>
+      $composableBuilder(column: $table.isGranted, builder: (column) => column);
+
+  GeneratedColumn<DateTime> get createdAt =>
+      $composableBuilder(column: $table.createdAt, builder: (column) => column);
+
+  GeneratedColumn<DateTime> get lastUpdatedAt => $composableBuilder(
+    column: $table.lastUpdatedAt,
+    builder: (column) => column,
+  );
+
+  $$BusinessesTableAnnotationComposer get businessId {
+    final $$BusinessesTableAnnotationComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.businessId,
+      referencedTable: $db.businesses,
+      getReferencedColumn: (t) => t.id,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$BusinessesTableAnnotationComposer(
+            $db: $db,
+            $table: $db.businesses,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
+
+  $$UsersTableAnnotationComposer get userId {
+    final $$UsersTableAnnotationComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.userId,
+      referencedTable: $db.users,
+      getReferencedColumn: (t) => t.id,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$UsersTableAnnotationComposer(
+            $db: $db,
+            $table: $db.users,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
+}
+
+class $$UserPermissionOverridesTableTableManager
+    extends
+        RootTableManager<
+          _$AppDatabase,
+          $UserPermissionOverridesTable,
+          UserPermissionOverrideData,
+          $$UserPermissionOverridesTableFilterComposer,
+          $$UserPermissionOverridesTableOrderingComposer,
+          $$UserPermissionOverridesTableAnnotationComposer,
+          $$UserPermissionOverridesTableCreateCompanionBuilder,
+          $$UserPermissionOverridesTableUpdateCompanionBuilder,
+          (
+            UserPermissionOverrideData,
+            $$UserPermissionOverridesTableReferences,
+          ),
+          UserPermissionOverrideData,
+          PrefetchHooks Function({bool businessId, bool userId})
+        > {
+  $$UserPermissionOverridesTableTableManager(
+    _$AppDatabase db,
+    $UserPermissionOverridesTable table,
+  ) : super(
+        TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer: () =>
+              $$UserPermissionOverridesTableFilterComposer(
+                $db: db,
+                $table: table,
+              ),
+          createOrderingComposer: () =>
+              $$UserPermissionOverridesTableOrderingComposer(
+                $db: db,
+                $table: table,
+              ),
+          createComputedFieldComposer: () =>
+              $$UserPermissionOverridesTableAnnotationComposer(
+                $db: db,
+                $table: table,
+              ),
+          updateCompanionCallback:
+              ({
+                Value<String> id = const Value.absent(),
+                Value<String> businessId = const Value.absent(),
+                Value<String> userId = const Value.absent(),
+                Value<String> permissionKey = const Value.absent(),
+                Value<bool> isGranted = const Value.absent(),
+                Value<DateTime> createdAt = const Value.absent(),
+                Value<DateTime> lastUpdatedAt = const Value.absent(),
+                Value<int> rowid = const Value.absent(),
+              }) => UserPermissionOverridesCompanion(
+                id: id,
+                businessId: businessId,
+                userId: userId,
+                permissionKey: permissionKey,
+                isGranted: isGranted,
+                createdAt: createdAt,
+                lastUpdatedAt: lastUpdatedAt,
+                rowid: rowid,
+              ),
+          createCompanionCallback:
+              ({
+                Value<String> id = const Value.absent(),
+                required String businessId,
+                required String userId,
+                required String permissionKey,
+                required bool isGranted,
+                Value<DateTime> createdAt = const Value.absent(),
+                Value<DateTime> lastUpdatedAt = const Value.absent(),
+                Value<int> rowid = const Value.absent(),
+              }) => UserPermissionOverridesCompanion.insert(
+                id: id,
+                businessId: businessId,
+                userId: userId,
+                permissionKey: permissionKey,
+                isGranted: isGranted,
+                createdAt: createdAt,
+                lastUpdatedAt: lastUpdatedAt,
+                rowid: rowid,
+              ),
+          withReferenceMapper: (p0) => p0
+              .map(
+                (e) => (
+                  e.readTable(table),
+                  $$UserPermissionOverridesTableReferences(db, table, e),
+                ),
+              )
+              .toList(),
+          prefetchHooksCallback: ({businessId = false, userId = false}) {
+            return PrefetchHooks(
+              db: db,
+              explicitlyWatchedTables: [],
+              addJoins:
+                  <
+                    T extends TableManagerState<
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic
+                    >
+                  >(state) {
+                    if (businessId) {
+                      state =
+                          state.withJoin(
+                                currentTable: table,
+                                currentColumn: table.businessId,
+                                referencedTable:
+                                    $$UserPermissionOverridesTableReferences
+                                        ._businessIdTable(db),
+                                referencedColumn:
+                                    $$UserPermissionOverridesTableReferences
+                                        ._businessIdTable(db)
+                                        .id,
+                              )
+                              as T;
+                    }
+                    if (userId) {
+                      state =
+                          state.withJoin(
+                                currentTable: table,
+                                currentColumn: table.userId,
+                                referencedTable:
+                                    $$UserPermissionOverridesTableReferences
+                                        ._userIdTable(db),
+                                referencedColumn:
+                                    $$UserPermissionOverridesTableReferences
+                                        ._userIdTable(db)
+                                        .id,
+                              )
+                              as T;
+                    }
+
+                    return state;
+                  },
+              getPrefetchedDataCallback: (items) async {
+                return [];
+              },
+            );
+          },
+        ),
+      );
+}
+
+typedef $$UserPermissionOverridesTableProcessedTableManager =
+    ProcessedTableManager<
+      _$AppDatabase,
+      $UserPermissionOverridesTable,
+      UserPermissionOverrideData,
+      $$UserPermissionOverridesTableFilterComposer,
+      $$UserPermissionOverridesTableOrderingComposer,
+      $$UserPermissionOverridesTableAnnotationComposer,
+      $$UserPermissionOverridesTableCreateCompanionBuilder,
+      $$UserPermissionOverridesTableUpdateCompanionBuilder,
+      (UserPermissionOverrideData, $$UserPermissionOverridesTableReferences),
+      UserPermissionOverrideData,
+      PrefetchHooks Function({bool businessId, bool userId})
+    >;
 typedef $$RoleSettingsTableCreateCompanionBuilder =
     RoleSettingsCompanion Function({
       Value<String> id,
@@ -77560,6 +80738,11 @@ class $AppDatabaseManager {
       $$ShipmentsTableTableManager(_db, _db.shipments);
   $$StockTransactionsTableTableManager get stockTransactions =>
       $$StockTransactionsTableTableManager(_db, _db.stockTransactions);
+  $$StockAdjustmentRequestsTableTableManager get stockAdjustmentRequests =>
+      $$StockAdjustmentRequestsTableTableManager(
+        _db,
+        _db.stockAdjustmentRequests,
+      );
   $$OrderItemsTableTableManager get orderItems =>
       $$OrderItemsTableTableManager(_db, _db.orderItems);
   $$PurchaseItemsTableTableManager get purchaseItems =>
@@ -77602,6 +80785,11 @@ class $AppDatabaseManager {
       $$RolesTableTableManager(_db, _db.roles);
   $$RolePermissionsTableTableManager get rolePermissions =>
       $$RolePermissionsTableTableManager(_db, _db.rolePermissions);
+  $$UserPermissionOverridesTableTableManager get userPermissionOverrides =>
+      $$UserPermissionOverridesTableTableManager(
+        _db,
+        _db.userPermissionOverrides,
+      );
   $$RoleSettingsTableTableManager get roleSettings =>
       $$RoleSettingsTableTableManager(_db, _db.roleSettings);
   $$UserBusinessesTableTableManager get userBusinesses =>

--- a/lib/core/database/daos.dart
+++ b/lib/core/database/daos.dart
@@ -3190,6 +3190,16 @@ class SyncDao extends DatabaseAccessor<AppDatabase>
   }
 
   Future<void> enqueueUpsert(String tableName, Insertable row) async {
+    // Sync safeguard (CLAUDE.md §5): fail fast on an unknown/typo'd table.
+    // The pusher dispatches `<table>:upsert` to `_supabase.from(table)` with
+    // no whitelist, so a bad name would silently stick as a failed queue row.
+    if (!kEnqueueableTables.contains(tableName)) {
+      throw StateError(
+        'enqueueUpsert("$tableName"): not a registered synced/cache/businesses '
+        'table. Add it to _syncedTenantTables (or kSyncCacheTables) or fix the '
+        'table name — CLAUDE.md §5.',
+      );
+    }
     final payloadMap = serializeInsertable(row);
     // Resolve the queue row's businessId. Prefer the payload's value — it
     // covers the bootstrap case where the very first business/user is being
@@ -3274,6 +3284,15 @@ class SyncDao extends DatabaseAccessor<AppDatabase>
         'enqueueDelete is forbidden for append-only ledger table '
         '"$tableName". Append a compensating/void row through the '
         'corresponding DAO instead (e.g. WalletTransactionsDao.voidTransaction).',
+      );
+    }
+    // Sync safeguard (CLAUDE.md §5): delete targets are always synced tables
+    // (never caches, which the cloud rebuilds from domain responses). Reject
+    // an unknown/typo'd name before it sticks as a failed queue row.
+    if (!kSyncedTenantTables.contains(tableName)) {
+      throw StateError(
+        'enqueueDelete("$tableName"): not a registered synced table — '
+        'fix the table name or add it to _syncedTenantTables (CLAUDE.md §5).',
       );
     }
     final payloadMap = {
@@ -4250,6 +4269,212 @@ class StockTransferDao extends DatabaseAccessor<AppDatabase>
   // Transfer flows have no UI callers today; methods will land alongside the
   // transfer screens. Keeping the shell preserves the AppDatabase accessor
   // registration so adding methods later doesn't require schema regen.
+}
+
+@DriftAccessor(tables: [StockAdjustmentRequests])
+class StockAdjustmentRequestsDao extends DatabaseAccessor<AppDatabase>
+    with _$StockAdjustmentRequestsDaoMixin, BusinessScopedDao<AppDatabase> {
+  StockAdjustmentRequestsDao(super.db);
+
+  /// All still-pending requests for the business, newest first. Approver-side
+  /// store scoping (a Manager only sees their store's requests) is applied in
+  /// the UI, mirroring the home/inventory store-lock pattern.
+  Stream<List<StockAdjustmentRequestData>> watchPending() {
+    return (select(stockAdjustmentRequests)
+          ..where((t) => whereBusiness(t) & t.status.equals('pending'))
+          ..orderBy([
+            (t) =>
+                OrderingTerm(expression: t.createdAt, mode: OrderingMode.desc),
+          ]))
+        .watch();
+  }
+
+  /// §16.6.1 — a stock keeper submits an Add/Remove for approval. Writes a
+  /// `pending` row only (inventory is untouched until approval) and fires an
+  /// approval-request notification to the CEO and the Manager(s) of the
+  /// affected store. If no Manager is tied to that store, only the CEO is
+  /// notified (same audience rule as the old §26.4 post-hoc notice).
+  Future<void> requestStockAdjustment({
+    required String productId,
+    required String storeId,
+    required int quantityDiff,
+    required String reason,
+    required String summary,
+    required String? requestedBy,
+  }) async {
+    final row = StockAdjustmentRequestsCompanion.insert(
+      id: Value(UuidV7.generate()),
+      businessId: requireBusinessId(),
+      productId: productId,
+      storeId: storeId,
+      quantityDiff: quantityDiff,
+      reason: reason,
+      summary: summary,
+      requestedBy: Value(requestedBy),
+      lastUpdatedAt: Value(DateTime.now()),
+    );
+    await into(stockAdjustmentRequests).insert(row);
+    await db.syncDao.enqueueUpsert('stock_adjustment_requests', row);
+
+    await db.activityLogDao.log(
+      action: 'stock_adjustment_requested',
+      description: 'Requested approval: $summary',
+      staffId: requestedBy,
+      storeId: storeId,
+      productId: productId,
+    );
+
+    // Approval audience: CEO (never store-assigned) + Manager(s) of this store.
+    final ceoIds = await db.userBusinessesDao.getUserIdsForRoleSlugs(['ceo']);
+    final managerIds =
+        await db.userBusinessesDao.getUserIdsForRoleSlugs(['manager']);
+    final storeUserIds =
+        (await db.userStoresDao.getUserIdsForStore(storeId)).toSet();
+    final storeManagerIds = managerIds.where(storeUserIds.contains);
+    final isRemove = quantityDiff < 0;
+    for (final uid in <String>{...ceoIds, ...storeManagerIds}) {
+      await db.notificationsDao.fireNotification(
+        type: 'stock_approval.requested',
+        message: 'Approval needed: $summary',
+        severity: isRemove ? 'warning' : 'info',
+        linkedRecordId: row.id.value,
+        recipientUserId: uid,
+      );
+    }
+  }
+
+  /// Approve a pending request: apply the real inventory change via
+  /// `adjustStock` (keeping the atomic delta envelope), flip the row to
+  /// `approved`, and notify the requester. Throws (rolling back the whole
+  /// transaction) if the adjustment can't be applied — e.g. a Remove that would
+  /// take stock negative — leaving the request `pending` for a retry.
+  Future<void> approveRequest({
+    required String requestId,
+    required String approverId,
+  }) async {
+    String? requestedBy;
+    String? summary;
+    var didApprove = false;
+
+    await transaction(() async {
+      final req = await (select(stockAdjustmentRequests)
+            ..where((t) => t.id.equals(requestId) & whereBusiness(t)))
+          .getSingleOrNull();
+      if (req == null || req.status != 'pending') return;
+
+      // Apply the actual stock movement (atomic via pos_inventory_delta_v2).
+      await db.inventoryDao.adjustStock(
+        req.productId,
+        req.storeId,
+        req.quantityDiff,
+        req.reason,
+        req.requestedBy,
+      );
+
+      final now = DateTime.now();
+      final affected = await (update(stockAdjustmentRequests)
+            ..where((t) =>
+                t.id.equals(requestId) &
+                whereBusiness(t) &
+                t.status.equals('pending')))
+          .write(StockAdjustmentRequestsCompanion(
+        status: const Value('approved'),
+        approvedBy: Value(approverId),
+        approvedAt: Value(now),
+        lastUpdatedAt: Value(now),
+      ));
+      if (affected == 0) return; // lost the race
+      didApprove = true;
+      requestedBy = req.requestedBy;
+      summary = req.summary;
+
+      final updated = await (select(stockAdjustmentRequests)
+            ..where((t) => t.id.equals(requestId) & whereBusiness(t)))
+          .getSingle();
+      await db.syncDao
+          .enqueueUpsert('stock_adjustment_requests', updated.toCompanion(true));
+
+      await db.activityLogDao.log(
+        action: 'stock_adjustment_approved',
+        description: 'Approved stock change: ${req.summary}',
+        staffId: approverId,
+        storeId: req.storeId,
+        productId: req.productId,
+      );
+    });
+
+    if (didApprove && requestedBy != null) {
+      await db.notificationsDao.fireNotification(
+        type: 'stock_approval.approved',
+        message: 'Your stock request was approved & applied — $summary',
+        severity: 'info',
+        linkedRecordId: requestId,
+        recipientUserId: requestedBy,
+      );
+    }
+  }
+
+  /// Reject a pending request — no inventory movement. The optional [reason]
+  /// (why it was rejected) is shown to the requester in the rejection
+  /// notification and recorded in the activity log. Notifies the requester.
+  Future<void> rejectRequest({
+    required String requestId,
+    required String approverId,
+    String? reason,
+  }) async {
+    final trimmedReason = reason?.trim();
+    final hasReason = trimmedReason != null && trimmedReason.isNotEmpty;
+    String? requestedBy;
+    var didReject = false;
+
+    await transaction(() async {
+      final req = await (select(stockAdjustmentRequests)
+            ..where((t) => t.id.equals(requestId) & whereBusiness(t)))
+          .getSingleOrNull();
+      if (req == null || req.status != 'pending') return;
+      final now = DateTime.now();
+      final affected = await (update(stockAdjustmentRequests)
+            ..where((t) =>
+                t.id.equals(requestId) &
+                whereBusiness(t) &
+                t.status.equals('pending')))
+          .write(StockAdjustmentRequestsCompanion(
+        status: const Value('rejected'),
+        approvedBy: Value(approverId),
+        approvedAt: Value(now),
+        lastUpdatedAt: Value(now),
+      ));
+      if (affected == 0) return;
+      didReject = true;
+      requestedBy = req.requestedBy;
+
+      final updated = await (select(stockAdjustmentRequests)
+            ..where((t) => t.id.equals(requestId) & whereBusiness(t)))
+          .getSingle();
+      await db.syncDao
+          .enqueueUpsert('stock_adjustment_requests', updated.toCompanion(true));
+
+      await db.activityLogDao.log(
+        action: 'stock_adjustment_rejected',
+        description: 'Rejected stock change: ${req.summary}'
+            '${hasReason ? ' — Reason: $trimmedReason' : ''}',
+        staffId: approverId,
+        storeId: req.storeId,
+        productId: req.productId,
+      );
+    });
+
+    if (didReject && requestedBy != null) {
+      await db.notificationsDao.fireNotification(
+        type: 'stock_approval.rejected',
+        message: 'Your stock request was rejected'
+            '${hasReason ? ' — $trimmedReason' : '.'}',
+        severity: 'warning',
+        linkedRecordId: requestId,
+        recipientUserId: requestedBy,
+      );
+    }
+  }
 }
 
 @DriftAccessor(tables: [PendingCrateReturns])
@@ -5838,6 +6063,100 @@ class RolePermissionsDao extends DatabaseAccessor<AppDatabase>
     await (delete(rolePermissions)..where((t) => t.id.equals(existing.id)))
         .go();
     await db.syncDao.enqueueDelete('role_permissions', existing.id);
+  }
+}
+
+@DriftAccessor(tables: [UserPermissionOverrides])
+class UserPermissionOverridesDao extends DatabaseAccessor<AppDatabase>
+    with _$UserPermissionOverridesDaoMixin, BusinessScopedDao<AppDatabase> {
+  UserPermissionOverridesDao(super.db);
+
+  Stream<List<UserPermissionOverrideData>> watchForUser(String userId) {
+    return (select(userPermissionOverrides)
+          ..where((t) => whereBusiness(t) & t.userId.equals(userId))
+          ..orderBy([(t) => OrderingTerm.asc(t.permissionKey)]))
+        .watch();
+  }
+
+  Future<List<UserPermissionOverrideData>> getForUser(String userId) {
+    return (select(userPermissionOverrides)
+          ..where((t) => whereBusiness(t) & t.userId.equals(userId))
+          ..orderBy([(t) => OrderingTerm.asc(t.permissionKey)]))
+        .get();
+  }
+
+  /// Set or clear a staff member's override for [permissionKey] (§10.2.1).
+  /// [value] true = force-grant, false = force-revoke, null = clear the
+  /// override (inherit the role default). Idempotent on the logical identity
+  /// (business_id, user_id, permission_key): a value that already matches is a
+  /// no-op, so we never trip UNIQUE on a stale toggle or a row that arrived
+  /// from the cloud since the UI last built.
+  Future<void> setOverride(
+    String userId,
+    String permissionKey,
+    bool? value,
+  ) async {
+    final existing = await (select(userPermissionOverrides)
+          ..where((t) =>
+              whereBusiness(t) &
+              t.userId.equals(userId) &
+              t.permissionKey.equals(permissionKey))
+          ..limit(1))
+        .getSingleOrNull();
+
+    if (value == null) {
+      // Inherit — remove the override row and tombstone it cloud-side.
+      // `user_permission_overrides` is not an append-only ledger, so
+      // hard-delete via `enqueueDelete` is the right path here.
+      if (existing == null) return;
+      await (delete(userPermissionOverrides)
+            ..where((t) => t.id.equals(existing.id)))
+          .go();
+      await db.syncDao.enqueueDelete('user_permission_overrides', existing.id);
+      return;
+    }
+
+    if (existing != null) {
+      if (existing.isGranted == value) return; // already at this value
+      final row = UserPermissionOverridesCompanion(
+        id: Value(existing.id),
+        businessId: Value(existing.businessId),
+        userId: Value(existing.userId),
+        permissionKey: Value(existing.permissionKey),
+        isGranted: Value(value),
+        lastUpdatedAt: Value(DateTime.now()),
+      );
+      await (update(userPermissionOverrides)
+            ..where((t) => t.id.equals(existing.id)))
+          .write(row);
+      await db.syncDao.enqueueUpsert('user_permission_overrides', row);
+      return;
+    }
+
+    final row = UserPermissionOverridesCompanion.insert(
+      id: Value(UuidV7.generate()),
+      businessId: requireBusinessId(),
+      userId: userId,
+      permissionKey: permissionKey,
+      isGranted: value,
+      lastUpdatedAt: Value(DateTime.now()),
+    );
+    await into(userPermissionOverrides).insert(row);
+    await db.syncDao.enqueueUpsert('user_permission_overrides', row);
+  }
+
+  /// Restore defaults — clear EVERY override for [userId] so all permissions
+  /// revert to the role default. Each row is hard-deleted and tombstoned
+  /// (`enqueueDelete`) so other devices drop it too (same path as a single
+  /// inherit/clear in [setOverride]). Returns the number of overrides cleared.
+  Future<int> clearAllForUser(String userId) async {
+    final rows = await getForUser(userId);
+    for (final r in rows) {
+      await (delete(userPermissionOverrides)..where((t) => t.id.equals(r.id)))
+          .go();
+      await db.syncDao.enqueueDelete('user_permission_overrides', r.id);
+    }
+    return rows.length;
   }
 }
 

--- a/lib/core/database/daos.dart
+++ b/lib/core/database/daos.dart
@@ -6144,6 +6144,17 @@ class UserStoresDao extends DatabaseAccessor<AppDatabase>
     return (select(userStores)..where((t) => t.userId.equals(userId))).get();
   }
 
+  /// User ids assigned to [storeId] in the current business. Routes the §26.4
+  /// stock-keeper adjustment notification to the *affected store's* leadership
+  /// (intersected with the Manager audience by the caller). Business-scoped so
+  /// it never leaks across businesses held on the same device.
+  Future<List<String>> getUserIdsForStore(String storeId) async {
+    final rows = await (select(userStores)
+          ..where((t) => whereBusiness(t) & t.storeId.equals(storeId)))
+        .get();
+    return rows.map((r) => r.userId).toList();
+  }
+
   /// Assign a user to a store. UNIQUE (user_id, store_id) guards
   /// against duplicates.
   Future<void> assign(UserStoresCompanion row) async {

--- a/lib/core/database/daos.g.dart
+++ b/lib/core/database/daos.g.dart
@@ -636,6 +636,50 @@ class StockTransferDaoManager {
       );
 }
 
+mixin _$StockAdjustmentRequestsDaoMixin on DatabaseAccessor<AppDatabase> {
+  $BusinessesTable get businesses => attachedDatabase.businesses;
+  $CategoriesTable get categories => attachedDatabase.categories;
+  $CrateSizeGroupsTable get crateSizeGroups => attachedDatabase.crateSizeGroups;
+  $SuppliersTable get suppliers => attachedDatabase.suppliers;
+  $ManufacturersTable get manufacturers => attachedDatabase.manufacturers;
+  $ProductsTable get products => attachedDatabase.products;
+  $StoresTable get stores => attachedDatabase.stores;
+  $UsersTable get users => attachedDatabase.users;
+  $StockAdjustmentRequestsTable get stockAdjustmentRequests =>
+      attachedDatabase.stockAdjustmentRequests;
+  StockAdjustmentRequestsDaoManager get managers =>
+      StockAdjustmentRequestsDaoManager(this);
+}
+
+class StockAdjustmentRequestsDaoManager {
+  final _$StockAdjustmentRequestsDaoMixin _db;
+  StockAdjustmentRequestsDaoManager(this._db);
+  $$BusinessesTableTableManager get businesses =>
+      $$BusinessesTableTableManager(_db.attachedDatabase, _db.businesses);
+  $$CategoriesTableTableManager get categories =>
+      $$CategoriesTableTableManager(_db.attachedDatabase, _db.categories);
+  $$CrateSizeGroupsTableTableManager get crateSizeGroups =>
+      $$CrateSizeGroupsTableTableManager(
+        _db.attachedDatabase,
+        _db.crateSizeGroups,
+      );
+  $$SuppliersTableTableManager get suppliers =>
+      $$SuppliersTableTableManager(_db.attachedDatabase, _db.suppliers);
+  $$ManufacturersTableTableManager get manufacturers =>
+      $$ManufacturersTableTableManager(_db.attachedDatabase, _db.manufacturers);
+  $$ProductsTableTableManager get products =>
+      $$ProductsTableTableManager(_db.attachedDatabase, _db.products);
+  $$StoresTableTableManager get stores =>
+      $$StoresTableTableManager(_db.attachedDatabase, _db.stores);
+  $$UsersTableTableManager get users =>
+      $$UsersTableTableManager(_db.attachedDatabase, _db.users);
+  $$StockAdjustmentRequestsTableTableManager get stockAdjustmentRequests =>
+      $$StockAdjustmentRequestsTableTableManager(
+        _db.attachedDatabase,
+        _db.stockAdjustmentRequests,
+      );
+}
+
 mixin _$PendingCrateReturnsDaoMixin on DatabaseAccessor<AppDatabase> {
   $BusinessesTable get businesses => attachedDatabase.businesses;
   $StoresTable get stores => attachedDatabase.stores;
@@ -1257,6 +1301,32 @@ class RolePermissionsDaoManager {
       $$RolePermissionsTableTableManager(
         _db.attachedDatabase,
         _db.rolePermissions,
+      );
+}
+
+mixin _$UserPermissionOverridesDaoMixin on DatabaseAccessor<AppDatabase> {
+  $BusinessesTable get businesses => attachedDatabase.businesses;
+  $StoresTable get stores => attachedDatabase.stores;
+  $UsersTable get users => attachedDatabase.users;
+  $UserPermissionOverridesTable get userPermissionOverrides =>
+      attachedDatabase.userPermissionOverrides;
+  UserPermissionOverridesDaoManager get managers =>
+      UserPermissionOverridesDaoManager(this);
+}
+
+class UserPermissionOverridesDaoManager {
+  final _$UserPermissionOverridesDaoMixin _db;
+  UserPermissionOverridesDaoManager(this._db);
+  $$BusinessesTableTableManager get businesses =>
+      $$BusinessesTableTableManager(_db.attachedDatabase, _db.businesses);
+  $$StoresTableTableManager get stores =>
+      $$StoresTableTableManager(_db.attachedDatabase, _db.stores);
+  $$UsersTableTableManager get users =>
+      $$UsersTableTableManager(_db.attachedDatabase, _db.users);
+  $$UserPermissionOverridesTableTableManager get userPermissionOverrides =>
+      $$UserPermissionOverridesTableTableManager(
+        _db.attachedDatabase,
+        _db.userPermissionOverrides,
       );
 }
 

--- a/lib/core/providers/stream_providers.dart
+++ b/lib/core/providers/stream_providers.dart
@@ -85,6 +85,34 @@ int? resolveMonthlyBudgetKobo(
   return null;
 }
 
+// ── Stock adjustment approvals (§16.6.1) ─────────────────────────────────────
+/// All still-pending stock-adjustment requests for the business, newest first.
+/// Approver-side store scoping is applied by
+/// [viewerScopedPendingStockRequestsProvider].
+final pendingStockRequestsProvider =
+    StreamProvider<List<StockAdjustmentRequestData>>((ref) {
+  return ref.watch(databaseProvider).stockAdjustmentRequestsDao.watchPending();
+});
+
+/// Pending stock requests the current viewer may approve (§16.6.1): a CEO sees
+/// every store; a Manager sees only requests for the store(s) they're assigned
+/// to (mirrors the Home/Inventory store lock — confinement is computed locally,
+/// never via the dead nav-service flags).
+final viewerScopedPendingStockRequestsProvider =
+    Provider<List<StockAdjustmentRequestData>>((ref) {
+  final all = ref.watch(pendingStockRequestsProvider).valueOrNull ?? const [];
+  final role = ref.watch(currentUserRoleProvider);
+  if (role?.slug == 'ceo') return all;
+  final userId = ref.watch(authProvider).currentUser?.id;
+  if (userId == null) return const [];
+  final assignedStoreIds =
+      (ref.watch(myUserStoresProvider(userId)).valueOrNull ??
+              const <UserStoreData>[])
+          .map((s) => s.storeId)
+          .toSet();
+  return all.where((r) => assignedStoreIds.contains(r.storeId)).toList();
+});
+
 // ── Products by store ───────────────────────────────────────────────────────
 final productsByStoreProvider =
     StreamProvider.family<List<ProductDataWithStock>, String>((ref, storeId) {
@@ -215,6 +243,18 @@ final rolePermissionsProvider =
   return ref.watch(databaseProvider).rolePermissionsDao.watchForRole(roleId);
 });
 
+/// Per-staff permission overrides for a specific user (§10.2.1). A row forces
+/// `permissionKey` on (`isGranted` true) or off (false) for that user,
+/// overriding their role default; no row = inherit.
+final userPermissionOverridesProvider =
+    StreamProvider.family<List<UserPermissionOverrideData>, String>(
+        (ref, userId) {
+  return ref
+      .watch(databaseProvider)
+      .userPermissionOverridesDao
+      .watchForUser(userId);
+});
+
 /// Per-role tunable settings (max discount %, max expense approval kobo).
 final roleSettingsProvider =
     StreamProvider.family<List<RoleSettingData>, String>((ref, roleId) {
@@ -340,7 +380,27 @@ final currentUserPermissionsProvider = Provider<Set<String>>((ref) {
   if (role == null) return const <String>{};
   final grants = ref.watch(rolePermissionsProvider(role.id)).valueOrNull;
   if (grants == null) return const <String>{};
-  return grants.map((g) => g.permissionKey).toSet();
+  final effective = grants.map((g) => g.permissionKey).toSet();
+  // The CEO is always all-on and is never overridable (§10.2.1) — skip overrides.
+  if (role.slug == 'ceo') return effective;
+  // Apply this staff member's per-user overrides on top of the role default:
+  // isGranted true = force-grant, false = force-revoke (§10.2.1). Absence of a
+  // row = inherit, so only the explicit overrides touch the set.
+  final userId = ref.watch(authProvider).currentUser?.id;
+  if (userId != null) {
+    final overrides =
+        ref.watch(userPermissionOverridesProvider(userId)).valueOrNull;
+    if (overrides != null) {
+      for (final o in overrides) {
+        if (o.isGranted) {
+          effective.add(o.permissionKey);
+        } else {
+          effective.remove(o.permissionKey);
+        }
+      }
+    }
+  }
+  return effective;
 });
 
 /// True if the current user's role grants [key]. Thin reader over

--- a/lib/core/services/supabase_sync_service.dart
+++ b/lib/core/services/supabase_sync_service.dart
@@ -7,6 +7,12 @@ import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:reebaplus_pos/core/database/app_database.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+// sync-exempt-file: this is the sync engine — `_restoreTableData`,
+// `_applyDomainResponse`, `_deleteLocalRowById`, and the backfill path write
+// cloud-authoritative state back into the local mirror (CLAUDE.md §5 #1/#2).
+// Enqueuing here would push the cloud's own data back to it. The sync-write
+// leak scanner (test/sync/sync_raw_write_leak_test.dart) skips this file.
+
 /// Thrown by [SupabaseSyncService.flushSale] when a `domain:pos_record_sale`
 /// envelope fails permanently at the server (insufficient_stock, FK / unique
 /// violation, tenant mismatch). The local optimistic sale has already
@@ -457,6 +463,11 @@ class SupabaseSyncService {
     switch (table) {
       case 'role_permissions':
         await (_db.delete(_db.rolePermissions)..where((t) => t.id.equals(id)))
+            .go();
+        break;
+      case 'user_permission_overrides':
+        await (_db.delete(_db.userPermissionOverrides)
+              ..where((t) => t.id.equals(id)))
             .go();
         break;
       case 'saved_carts':
@@ -1427,6 +1438,11 @@ class SupabaseSyncService {
     'roles',
     'role_settings',
     'role_permissions',
+    // v33 (§10.2.1) — per-staff permission overrides. References businesses +
+    // users (pulled above) and the global permissions catalogue, so FK-safe
+    // here. Without this entry the pull/restore/realtime loops never ingest it
+    // and an override set on one device never reaches the others.
+    'user_permission_overrides',
     'user_businesses',
     'user_stores',
     // invite_codes references business/role/store/generated-by-user — all
@@ -1456,6 +1472,8 @@ class SupabaseSyncService {
     'drivers',
     'stock_transfers',
     'stock_adjustments',
+    // v34 (§16.6.1) — references products/stores/users, all pulled above.
+    'stock_adjustment_requests',
     'activity_logs',
     'notifications',
     'stock_transactions',
@@ -1701,6 +1719,7 @@ class SupabaseSyncService {
   /// carry `is_deleted` and must NEVER be hard-removed by a reconcile.
   static const _hardDeleteReconcileTables = {
     'role_permissions',
+    'user_permission_overrides',
     'saved_carts',
     'notifications',
   };
@@ -1759,6 +1778,11 @@ class SupabaseSyncService {
     switch (table) {
       case 'role_permissions':
         return (_db.delete(_db.rolePermissions)
+              ..where((t) =>
+                  t.businessId.equals(businessId) & t.id.isIn(ids).not()))
+            .go();
+      case 'user_permission_overrides':
+        return (_db.delete(_db.userPermissionOverrides)
               ..where((t) =>
                   t.businessId.equals(businessId) & t.id.isIn(ids).not()))
             .go();
@@ -2834,6 +2858,29 @@ class SupabaseSyncService {
             await _db.into(_db.rolePermissions).insertOnConflictUpdate(row);
           }
           break;
+        case 'user_permission_overrides':
+          for (var r in rows) {
+            final row = UserPermissionOverrideData.fromJson(r);
+            // Same shape as role_permissions: random `id`, logical identity
+            // (business_id, user_id, permission_key) enforced by UNIQUE. Two
+            // devices overriding the same (user, permission) mint different ids
+            // for the same triple, so upserting on `id` alone trips the unique
+            // constraint (2067). Drop any local row with the same logical key
+            // but a different id first, so the incoming cloud row applies
+            // cleanly and the device converges on the cloud's id. Restore path
+            // — local only, never enqueue (§5 exception #1; re-pushing loops).
+            await (_db.delete(_db.userPermissionOverrides)
+                  ..where((t) =>
+                      t.businessId.equals(row.businessId) &
+                      t.userId.equals(row.userId) &
+                      t.permissionKey.equals(row.permissionKey) &
+                      t.id.equals(row.id).not()))
+                .go();
+            await _db
+                .into(_db.userPermissionOverrides)
+                .insertOnConflictUpdate(row);
+          }
+          break;
         case 'role_settings':
           for (var r in rows) {
             await _db
@@ -3137,6 +3184,21 @@ class SupabaseSyncService {
               () => _db
                   .into(_db.stockAdjustments)
                   .insertOnConflictUpdate(StockAdjustmentData.fromJson(r)),
+            );
+          }
+          break;
+        case 'stock_adjustment_requests':
+          // §16.6.1 approval queue. FK-resilient: references products / stores /
+          // users. Plain id-keyed upsert (the client-minted id is preserved
+          // cloud-side), so an approve/reject status flip from one device
+          // overwrites the pending row on the others.
+          for (var r in rows) {
+            await _insertResilient(
+              'stock_adjustment_requests',
+              r,
+              fkSkipped,
+              () => _db.into(_db.stockAdjustmentRequests).insertOnConflictUpdate(
+                  StockAdjustmentRequestData.fromJson(r)),
             );
           }
           break;

--- a/lib/core/settings/role_permissions_detail_screen.dart
+++ b/lib/core/settings/role_permissions_detail_screen.dart
@@ -63,6 +63,10 @@ class _RolePermissionsDetailScreenState
   int? _lastSavedExpenseKobo;
   // Manager-only: CEO toggle that unlocks the Home store picker (§11.2).
   bool _viewAllStores = false;
+  // Permission scope (§10.2.1). Business is the real, default scope; Store is a
+  // Phase-1 placeholder ("coming with multi-store"). User-scope overrides live
+  // on the staff member's profile, not here.
+  bool _storeScope = false;
 
   RoleData get role => widget.role;
   bool get _isCeo => role.slug == 'ceo';
@@ -274,6 +278,25 @@ class _RolePermissionsDetailScreenState
         padding: EdgeInsets.fromLTRB(
             24, 24, 24, 24 + context.deviceBottomInset),
         children: [
+          // Permission scope selector (§10.2.1): Business (real, default) vs
+          // Store (Phase-1 placeholder). User-scope overrides live on the staff
+          // member's profile (Staff Management → staff → Permission access).
+          _scopeSelector(t),
+          const SizedBox(height: 10),
+          Text(
+            'Business applies to every store. Per-store overrides and a single '
+            'staff member\'s overrides come with multi-store — set a person\'s '
+            'overrides from their profile (Staff Management).',
+            style: TextStyle(
+              fontSize: 12,
+              height: 1.4,
+              color: t.colorScheme.onSurface.withValues(alpha: 0.55),
+            ),
+          ),
+          const SizedBox(height: 20),
+          if (_storeScope)
+            _storeScopePlaceholder(t)
+          else ...[
           if (_isCeo)
             Padding(
               padding: const EdgeInsets.only(bottom: 20),
@@ -315,6 +338,95 @@ class _RolePermissionsDetailScreenState
             ],
             const SizedBox(height: 20),
           ],
+          ],
+        ],
+      ),
+    );
+  }
+
+  /// Permission scope selector (§10.2.1). Business is the real, default scope
+  /// (the toggles below apply to every store); Store is a Phase-1 placeholder.
+  Widget _scopeSelector(ThemeData t) {
+    return Container(
+      padding: const EdgeInsets.all(4),
+      decoration: AppDecorations.glassCard(context, radius: 14),
+      child: Row(
+        children: [
+          _scopeSegment(t, 'Business', !_storeScope,
+              () => setState(() => _storeScope = false)),
+          _scopeSegment(
+              t, 'Store', _storeScope, () => setState(() => _storeScope = true)),
+        ],
+      ),
+    );
+  }
+
+  Widget _scopeSegment(
+    ThemeData t,
+    String label,
+    bool selected,
+    VoidCallback onTap,
+  ) {
+    return Expanded(
+      child: GestureDetector(
+        onTap: onTap,
+        behavior: HitTestBehavior.opaque,
+        child: AnimatedContainer(
+          duration: const Duration(milliseconds: 180),
+          padding: const EdgeInsets.symmetric(vertical: 10),
+          alignment: Alignment.center,
+          decoration: BoxDecoration(
+            color: selected ? t.colorScheme.primary : Colors.transparent,
+            borderRadius: BorderRadius.circular(10),
+          ),
+          child: Text(
+            label,
+            style: TextStyle(
+              fontSize: 14,
+              fontWeight: FontWeight.w600,
+              color: selected
+                  ? t.colorScheme.onPrimary
+                  : t.colorScheme.onSurface.withValues(alpha: 0.7),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  /// Store-scope body — a Phase-1 placeholder. Per-store permission overrides
+  /// arrive with multi-store (§10.2.1 / §2.2); nothing is stored or enforced.
+  Widget _storeScopePlaceholder(ThemeData t) {
+    return Container(
+      padding: const EdgeInsets.all(24),
+      decoration: AppDecorations.glassCard(context, radius: 16),
+      child: Column(
+        children: [
+          Icon(
+            Icons.storefront_outlined,
+            size: 36,
+            color: t.colorScheme.onSurface.withValues(alpha: 0.4),
+          ),
+          const SizedBox(height: 12),
+          Text(
+            'Per-store permissions',
+            style: TextStyle(
+              fontSize: 15,
+              fontWeight: FontWeight.w600,
+              color: t.colorScheme.onSurface,
+            ),
+          ),
+          const SizedBox(height: 6),
+          Text(
+            'Coming with multi-store. For now, every store uses the business '
+            'defaults set under the Business tab.',
+            textAlign: TextAlign.center,
+            style: TextStyle(
+              fontSize: 13,
+              height: 1.4,
+              color: t.colorScheme.onSurface.withValues(alpha: 0.6),
+            ),
+          ),
         ],
       ),
     );

--- a/lib/core/settings/role_permissions_detail_screen.dart
+++ b/lib/core/settings/role_permissions_detail_screen.dart
@@ -16,10 +16,20 @@ const _kMaxDiscount = 'max_discount_percent';
 const _kMaxExpenseKobo = 'max_expense_approval_kobo';
 
 /// Permission keys present in the catalogue but hidden from the Roles &
-/// Permissions UI. `sales.discount.give` is governed entirely by the per-role
-/// discount slider (`max_discount_percent`), so its on/off toggle is redundant.
-/// The key stays in the catalogue (unenforced) — hiding is reversible.
-const kHiddenPermissionKeys = {'sales.discount.give'};
+/// Permissions UI (and, via the same set, the per-staff override editor).
+/// The keys stay in the catalogue — hiding is reversible; re-show one the
+/// moment its feature ships.
+/// - `sales.discount.give` is governed entirely by the per-role discount slider
+///   (`max_discount_percent`), so its on/off toggle is redundant.
+/// - `customers.update` ("Update customer details") has no edit-customer UI yet
+///   (§18) — the toggle would be inert; un-hide when the edit flow ships.
+/// - `shipments.manage` ("Manage incoming shipments") has no Track-Shipments
+///   screen yet (§22) — un-hide when that screen ships.
+const kHiddenPermissionKeys = {
+  'sales.discount.give',
+  'customers.update',
+  'shipments.manage',
+};
 
 /// Permission categories in master-plan order. `allPermissionsProvider` returns
 /// them alphabetically, so the order is imposed here. Unknown categories (none

--- a/lib/core/utils/date_period.dart
+++ b/lib/core/utils/date_period.dart
@@ -1,9 +1,14 @@
 /// Canonical date-range filter for every Phase-1 browse/report filter chip.
 ///
 /// One source of truth so the same chip means the same thing on every screen.
-/// Each window is a *rolling* span measured back from "now" (e.g. "Last 7 days"
-/// = the last 7×24 hours), except [toDate] which is unbounded (everything up to
-/// now). Screens must not roll their own date math — route through this helper.
+/// Each window is a *calendar* period anchored to the start of the current
+/// day / week / month / year (the week starts on **Sunday**), except [toDate]
+/// which is unbounded (everything up to now). Screens must not roll their own
+/// date math — route through this helper.
+///
+/// Because the boundaries are calendar-anchored they are computed from the
+/// **local** date parts of "now" (local-zone dependent — e.g. "Today" means
+/// since local midnight, not a fixed 24h span).
 ///
 /// Scope note: this governs the browse/report period chips (Home, Reports,
 /// Orders, Expenses, Supplier Accounts, Customer wallet, Stock Audit). It does
@@ -12,12 +17,12 @@
 /// keeps its own ("Today / 7 Days / 30 Days / All") labels by design.
 library;
 
-/// The five canonical rolling windows.
+/// The five canonical calendar periods.
 enum DatePeriod {
-  last24Hours,
-  last7Days,
-  last30Days,
-  lastYear,
+  today,
+  thisWeek,
+  thisMonth,
+  thisYear,
   toDate,
 }
 
@@ -25,38 +30,41 @@ extension DatePeriodX on DatePeriod {
   /// Human label shown on the chip / dropdown.
   String get label {
     switch (this) {
-      case DatePeriod.last24Hours:
-        return 'Last 24 hours';
-      case DatePeriod.last7Days:
-        return 'Last 7 days';
-      case DatePeriod.last30Days:
-        return 'Last 30 days';
-      case DatePeriod.lastYear:
-        return 'Last year';
+      case DatePeriod.today:
+        return 'Today';
+      case DatePeriod.thisWeek:
+        return 'This Week';
+      case DatePeriod.thisMonth:
+        return 'This Month';
+      case DatePeriod.thisYear:
+        return 'This Year';
       case DatePeriod.toDate:
-        return 'To date';
+        return 'To Date';
     }
   }
 
-  /// The inclusive start of the window relative to [now], or `null` for
-  /// [toDate] (unbounded). A timestamp is "in period" iff it is at or after
-  /// this instant. Returned in the same zone as [now]; compare via UTC.
+  /// The inclusive start of the calendar period relative to [now], or `null`
+  /// for [toDate] (unbounded). A timestamp is "in period" iff it is at or after
+  /// this instant. Computed from [now]'s local date parts; compare via UTC.
   DateTime? startFrom(DateTime now) {
+    final midnight = DateTime(now.year, now.month, now.day);
     switch (this) {
-      case DatePeriod.last24Hours:
-        return now.subtract(const Duration(hours: 24));
-      case DatePeriod.last7Days:
-        return now.subtract(const Duration(days: 7));
-      case DatePeriod.last30Days:
-        return now.subtract(const Duration(days: 30));
-      case DatePeriod.lastYear:
-        return now.subtract(const Duration(days: 365));
+      case DatePeriod.today:
+        return midnight;
+      case DatePeriod.thisWeek:
+        // Week starts Sunday. `weekday` is Mon=1…Sun=7, so `% 7` gives the
+        // number of days back to Sunday (Sun=0, Mon=1 … Sat=6).
+        return midnight.subtract(Duration(days: midnight.weekday % 7));
+      case DatePeriod.thisMonth:
+        return DateTime(now.year, now.month, 1);
+      case DatePeriod.thisYear:
+        return DateTime(now.year, 1, 1);
       case DatePeriod.toDate:
         return null;
     }
   }
 
-  /// True iff [date] falls within this window measured from [now] (defaults to
+  /// True iff [date] falls within this period measured from [now] (defaults to
   /// `DateTime.now()`). Boundary is inclusive at the start; [toDate] includes
   /// everything. Both sides are normalised to UTC so local/UTC timestamps and
   /// the clock are compared as the same instant (no zone drift).
@@ -69,39 +77,45 @@ extension DatePeriodX on DatePeriod {
 
 /// Canonical chip labels, in display order. Use this for chip rows / dropdowns.
 const List<String> kDatePeriodLabels = [
-  'Last 24 hours',
-  'Last 7 days',
-  'Last 30 days',
-  'Last year',
-  'To date',
+  'Today',
+  'This Week',
+  'This Month',
+  'This Year',
+  'To Date',
 ];
 
+/// Labels a viewer may choose. Roles below Manager (Cashier, Stock keeper) are
+/// capped to Today / This Week / This Month (§19.2 / §30.11); Manager & CEO get
+/// the full set incl. This Year / To Date.
+List<String> datePeriodLabelsForRole({required bool managerUp}) =>
+    managerUp ? kDatePeriodLabels : kDatePeriodLabels.sublist(0, 3);
+
 /// Resolves a label to a [DatePeriod]. Tolerant of every legacy label the app
-/// used before this standardization — Day/Week/Month/Year/To Date,
-/// Today/This Week/This Month/This Year/This Quarter, All/All Time, 7 Days/30
-/// Days — so any persisted or in-flight value still resolves cleanly.
-/// Unknown labels fall back to [DatePeriod.toDate] (show everything).
+/// used — Day/Week/Month/Year/To Date, the rolling Last 24 hours/Last 7 days/
+/// Last 30 days/Last year set, and 7 Days/30 Days/All/All Time — so any
+/// persisted or in-flight value still resolves cleanly. Unknown labels fall
+/// back to [DatePeriod.toDate] (show everything).
 DatePeriod datePeriodFromLabel(String label) {
   switch (label.trim().toLowerCase()) {
-    case 'last 24 hours':
-    case 'day':
     case 'today':
-      return DatePeriod.last24Hours;
+    case 'day':
+    case 'last 24 hours':
+      return DatePeriod.today;
+    case 'this week':
+    case 'week':
     case 'last 7 days':
     case '7 days':
-    case 'week':
-    case 'this week':
-      return DatePeriod.last7Days;
+      return DatePeriod.thisWeek;
+    case 'this month':
+    case 'month':
     case 'last 30 days':
     case '30 days':
-    case 'month':
-    case 'this month':
     case 'this quarter':
-      return DatePeriod.last30Days;
-    case 'last year':
-    case 'year':
+      return DatePeriod.thisMonth;
     case 'this year':
-      return DatePeriod.lastYear;
+    case 'year':
+    case 'last year':
+      return DatePeriod.thisYear;
     case 'to date':
     case 'all':
     case 'all time':

--- a/lib/core/utils/responsive.dart
+++ b/lib/core/utils/responsive.dart
@@ -113,4 +113,17 @@ extension ResponsiveHelper on BuildContext {
     final raw = MediaQueryData.fromView(view);
     return raw.padding.bottom + raw.viewInsets.bottom;
   }
+
+  /// The system-navigation inset ONLY (no keyboard), read from the raw OS view
+  /// so an ancestor Scaffold can't zero it out. Same source as
+  /// [deviceBottomInset] but EXCLUDES the keyboard — use it for bottom-anchored
+  /// chrome that the Scaffold already lifts above the keyboard but NOT above the
+  /// system nav bar on edge-to-edge (a floating action button is the case this
+  /// exists for). Using [deviceBottomInset] there would double-count the
+  /// keyboard and jump the button too high when typing.
+  double get deviceBottomPadding {
+    final view = View.maybeOf(this);
+    if (view == null) return MediaQuery.maybeOf(this)?.padding.bottom ?? 0;
+    return MediaQueryData.fromView(view).padding.bottom;
+  }
 }

--- a/lib/core/widgets/app_fab.dart
+++ b/lib/core/widgets/app_fab.dart
@@ -11,6 +11,12 @@ class AppFAB extends StatelessWidget {
   final double? width;
   final Widget? trailing;
 
+  /// Lift the FAB above the system navigation bar on edge-to-edge devices
+  /// (3-button nav / gesture pill). Default true. Set false ONLY on bottom-nav
+  /// tab roots (POS, Stock) whose visible bottom bar already lifts the FAB clear
+  /// of the system nav — adding the inset there would leave a gap above the bar.
+  final bool reserveBottomInset;
+
   const AppFAB({
     super.key,
     required this.label,
@@ -19,6 +25,7 @@ class AppFAB extends StatelessWidget {
     this.heroTag,
     this.width,
     this.trailing,
+    this.reserveBottomInset = true,
   });
 
   @override
@@ -88,12 +95,20 @@ class AppFAB extends StatelessWidget {
       ),
     );
 
+    Widget result = fab;
     if (heroTag != null) {
-      return Hero(
-        tag: heroTag!,
-        child: fab,
+      result = Hero(tag: heroTag!, child: fab);
+    }
+    // Edge-to-edge: the Scaffold FAB slot places the button ~16px above the
+    // content bottom, which on a 3-button system nav lands UNDER that nav bar.
+    // Lift it by the real system-nav inset (keyboard excluded — the Scaffold
+    // already handles the keyboard). Skipped on visible-bottom-bar tab roots.
+    if (reserveBottomInset) {
+      result = Padding(
+        padding: EdgeInsets.only(bottom: context.deviceBottomPadding),
+        child: result,
       );
     }
-    return fab;
+    return result;
   }
 }

--- a/lib/features/auth/screens/staff_sign_up_screen.dart
+++ b/lib/features/auth/screens/staff_sign_up_screen.dart
@@ -559,6 +559,7 @@ class _StaffSignUpScreenState extends ConsumerState<StaffSignUpScreen> {
       // canonical cloud state — pushing it back is a no-op round trip.
       // insertOnConflictUpdate keeps this idempotent over whatever the pull
       // already restored.
+      // sync-exempt: §5 #7 — staff-sign-up local mirror after the redeem RPC.
       final now = DateTime.now();
       await db.transaction(() async {
         await db.into(db.users).insertOnConflictUpdate(

--- a/lib/features/customers/screens/customer_detail_screen.dart
+++ b/lib/features/customers/screens/customer_detail_screen.dart
@@ -46,7 +46,7 @@ class _CustomerDetailScreenState extends ConsumerState<CustomerDetailScreen> {
   CustomerData? _customerData;
   int _walletBalance = 0;
   List<WalletTransactionData> _walletHistory = [];
-  String _selectedPeriod = 'To date'; // §30.11 canonical chip set
+  String _selectedPeriod = 'To Date'; // §30.11 canonical chip set
   List<OrderData> _orders = [];
   List<CrateBalanceEntry> _crateBalances = [];
 
@@ -124,8 +124,19 @@ class _CustomerDetailScreenState extends ConsumerState<CustomerDetailScreen> {
       _customerData?.walletLimitKobo ?? widget.customer?.walletLimitKobo ?? 0;
   String? get _customerId => widget.customer?.id;
 
+  /// Period labels this viewer may choose (§19.2/§30.11 — roles below Manager
+  /// are capped to Today/This Week/This Month).
+  List<String> get _periodOptions =>
+      datePeriodLabelsForRole(managerUp: isManagerOrAbove(ref));
+
+  /// [_selectedPeriod] clamped into [_periodOptions], so the dropdown value and
+  /// the filter agree for capped viewers (default is "To Date", out of their set).
+  String get _effectivePeriod => _periodOptions.contains(_selectedPeriod)
+      ? _selectedPeriod
+      : _periodOptions.last;
+
   List<WalletTransactionData> get _filteredHistory {
-    final window = datePeriodFromLabel(_selectedPeriod);
+    final window = datePeriodFromLabel(_effectivePeriod);
     return _walletHistory
         .where((txn) => window.includes(txn.createdAt))
         .toList();
@@ -347,6 +358,23 @@ class _CustomerDetailScreenState extends ConsumerState<CustomerDetailScreen> {
                                   ? 'cash'
                                   : 'transfer';
                               final messenger = ScaffoldMessenger.of(context);
+                              // Defense-in-depth write-boundary re-check (§10.2.1):
+                              // the Add Funds button is already render-gated on
+                              // `customers.wallet.update`, but re-check the
+                              // effective permission before moving money so a
+                              // revoked override is honored at the action too.
+                              if (!ref
+                                  .read(currentUserPermissionsProvider)
+                                  .contains('customers.wallet.update')) {
+                                Navigator.pop(ctx);
+                                messenger.showSnackBar(
+                                  const SnackBar(
+                                    content: Text(
+                                        'You don\'t have permission to do that.'),
+                                  ),
+                                );
+                                return;
+                              }
                               Navigator.pop(ctx);
                               try {
                                 await ref
@@ -1089,7 +1117,7 @@ class _CustomerDetailScreenState extends ConsumerState<CustomerDetailScreen> {
                 SizedBox(width: context.getRSize(8)),
                 Expanded(
                   child: DropdownButton<String>(
-                    value: _selectedPeriod,
+                    value: _effectivePeriod,
                     isExpanded: true,
                     underline: const SizedBox.shrink(),
                     isDense: true,
@@ -1104,13 +1132,13 @@ class _CustomerDetailScreenState extends ConsumerState<CustomerDetailScreen> {
                       size: context.getRSize(11),
                       color: theme.colorScheme.onSurface.withAlpha(128),
                     ),
-                    items: kDatePeriodLabels
+                    items: _periodOptions
                         .map(
                           (p) => DropdownMenuItem(value: p, child: Text(p)),
                         )
                         .toList(),
                     onChanged: (v) =>
-                        setState(() => _selectedPeriod = v ?? 'To date'),
+                        setState(() => _selectedPeriod = v ?? 'To Date'),
                   ),
                 ),
               ],
@@ -1297,11 +1325,11 @@ class _CustomerDetailScreenState extends ConsumerState<CustomerDetailScreen> {
 
     return Column(
       children: [
-        // §18.4: Total In / Total Out are hidden for roles below Manager unless
-        // the CEO grants `customers.wallet.totals.view`. Manager + CEO always
-        // see them (isManagerOrAbove).
-        if (isManagerOrAbove(ref) ||
-            hasPermission(ref, 'customers.wallet.totals.view')) ...[
+        // §18.4: Total In / Total Out are gated by `customers.wallet.totals.view`
+        // (granted to Manager + CEO by default; the CEO can revoke it per staff
+        // member). Read the effective permission — no role-tier bypass — so a
+        // per-user override actually takes effect.
+        if (hasPermission(ref, 'customers.wallet.totals.view')) ...[
           _buildWalletSummaryRow(theme),
           SizedBox(height: context.getRSize(4)),
         ],

--- a/lib/features/customers/screens/customers_screen.dart
+++ b/lib/features/customers/screens/customers_screen.dart
@@ -155,12 +155,14 @@ class _CustomersScreenState extends ConsumerState<CustomersScreen> {
               ),
             ],
           ),
-          floatingActionButton: AppFAB(
-            heroTag: 'customers_fab',
-            onPressed: () => AddCustomerSheet.show(context),
-            icon: FontAwesomeIcons.userPlus,
-            label: 'Add Customer',
-          ),
+          floatingActionButton: hasPermission(ref, 'customers.add')
+              ? AppFAB(
+                  heroTag: 'customers_fab',
+                  onPressed: () => AddCustomerSheet.show(context),
+                  icon: FontAwesomeIcons.userPlus,
+                  label: 'Add Customer',
+                )
+              : null,
         );
   }
 

--- a/lib/features/customers/widgets/add_customer_sheet.dart
+++ b/lib/features/customers/widgets/add_customer_sheet.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 
 import 'package:reebaplus_pos/core/providers/app_providers.dart';
+import 'package:reebaplus_pos/core/providers/stream_providers.dart';
 import 'package:reebaplus_pos/core/utils/responsive.dart';
 import 'package:reebaplus_pos/core/database/app_database.dart';
 import 'package:reebaplus_pos/features/customers/data/models/customer.dart';
@@ -250,6 +251,16 @@ class _AddCustomerSheetState extends ConsumerState<AddCustomerSheet> {
                         text: 'Save Customer',
                         variant: AppButtonVariant.primary,
                         onPressed: () async {
+                          // Defense-in-depth (hard rule #6): this is the single
+                          // chokepoint for creating a customer — the Cart "New"
+                          // button and the Customers screen both route here — so
+                          // re-check `customers.add` at the write boundary.
+                          if (!ref
+                              .read(currentUserPermissionsProvider)
+                              .contains('customers.add')) {
+                            Navigator.pop(context);
+                            return;
+                          }
                           if (_formKey.currentState!.validate()) {
                             // Refuse the save if we don't yet know which business this row
                             // belongs to — a NULL business_id will fail the cloud RLS check

--- a/lib/features/dashboard/screens/daily_reconciliation_detail_screen.dart
+++ b/lib/features/dashboard/screens/daily_reconciliation_detail_screen.dart
@@ -48,11 +48,15 @@ class _DailyReconciliationDetailScreenState
       ['Sales — total value', (d.salesKobo / 100.0).toStringAsFixed(2)],
       ['Sales — best staff', d.bestStaff ?? ''],
       ['Sales — top item', d.topItem ?? ''],
-      for (final c in d.cash)
-        ['Cash: ${c.account}', 'expected ${(c.expectedKobo / 100.0).toStringAsFixed(2)}; '
-            'counted ${(c.countedKobo / 100.0).toStringAsFixed(2)}; '
-            'variance ${(c.varianceKobo / 100.0).toStringAsFixed(2)}'],
-      ['Cash — net variance', (d.netVarianceKobo / 100.0).toStringAsFixed(2)],
+      // Cash/funds rows only for `funds.view` holders (hard rule #6) — mirrors
+      // the gated cash card so the CSV can't leak balances the screen hides.
+      if (hasPermission(ref, 'funds.view')) ...[
+        for (final c in d.cash)
+          ['Cash: ${c.account}', 'expected ${(c.expectedKobo / 100.0).toStringAsFixed(2)}; '
+              'counted ${(c.countedKobo / 100.0).toStringAsFixed(2)}; '
+              'variance ${(c.varianceKobo / 100.0).toStringAsFixed(2)}'],
+        ['Cash — net variance', (d.netVarianceKobo / 100.0).toStringAsFixed(2)],
+      ],
       ['Stock — products counted', '${d.productsCounted}'],
       ['Stock — short (products/units)', '${d.shortageCount} / ${d.shortageUnits}'],
       ['Stock — surplus (products/units)', '${d.surplusCount} / ${d.surplusUnits}'],
@@ -112,8 +116,13 @@ class _DailyReconciliationDetailScreenState
         ),
         children: [
           _salesCard(theme, data),
-          SizedBox(height: context.spacingM),
-          _cashCard(theme, data),
+          // The cash/funds section exposes per-account balances — the data
+          // `funds.view` protects (hard rule #6). §25.3 keeps the rest of the
+          // reconciliation report Manager-accessible; only this block is gated.
+          if (hasPermission(ref, 'funds.view')) ...[
+            SizedBox(height: context.spacingM),
+            _cashCard(theme, data),
+          ],
           SizedBox(height: context.spacingM),
           _stockCard(theme, data),
           SizedBox(height: context.spacingM),

--- a/lib/features/dashboard/screens/home_screen.dart
+++ b/lib/features/dashboard/screens/home_screen.dart
@@ -33,8 +33,7 @@ class HomeScreen extends ConsumerStatefulWidget {
 }
 
 class _HomeScreenState extends ConsumerState<HomeScreen> {
-  String _selectedPeriod = kDatePeriodLabels.first; // Last 24 hours (§30.6/§30.11)
-  final List<String> _periods = kDatePeriodLabels;
+  String _selectedPeriod = kDatePeriodLabels.first; // Today (§30.6/§30.11)
 
   // Store filter (null = All)
   String? _selectedStoreId;
@@ -179,13 +178,21 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
     final isCashier = slug == 'cashier';
     final isStockKeeper = slug == 'stock_keeper';
 
-    final showTotalSales = isCeo || isManager || isCashier;
-    final showNetProfit = isCeo;
+    // §11.4 card visibility also respects the report permissions (hard rule
+    // #6): these cards open the full Sales / Expenses breakdowns, so a
+    // Manager/Cashier whose report key is revoked must not see the card. CEO is
+    // always-on.
+    final showTotalSales = isCeo ||
+        ((isManager || isCashier) && hasPermission(ref, 'reports.see_sales'));
+    final showNetProfit = isCeo || hasPermission(ref, 'reports.see_profit');
     final showPending = slug != null; // all four roles
-    final showExpenses = isCeo || isManager;
-    final showStockValue = isCeo || isManager;
+    final showExpenses =
+        isCeo || (isManager && hasPermission(ref, 'reports.see_expenses'));
+    final showStockValue =
+        isCeo || (isManager && hasPermission(ref, 'stock.view'));
     final showTotalSkus = isCashier || isStockKeeper;
-    final showWallet = isCeo || isManager || isCashier;
+    final showWallet = isCeo ||
+        ((isManager || isCashier) && hasPermission(ref, 'customers.add'));
     final showStaffSales = isCeo || isManager;
 
     final subtitle = isCashier
@@ -557,11 +564,15 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
   }
 
   Widget _buildPeriodDropdown() {
+    // §30.11 / §19.2: roles below Manager are capped to Today/This Week/This Month.
+    final options = datePeriodLabelsForRole(managerUp: isManagerOrAbove(ref));
+    final selected =
+        options.contains(_selectedPeriod) ? _selectedPeriod : options.last;
     return SizedBox(
       width: context.getRSize(140),
       child: AppDropdown<String>(
-        value: _selectedPeriod,
-        items: _periods
+        value: selected,
+        items: options
             .map((p) => DropdownMenuItem(value: p, child: Text(p)))
             .toList(),
         onChanged: (v) =>

--- a/lib/features/dashboard/screens/profit_report_screen.dart
+++ b/lib/features/dashboard/screens/profit_report_screen.dart
@@ -90,13 +90,18 @@ class _ProfitReportScreenState extends ConsumerState<ProfitReportScreen> {
   }
 
   Future<void> _exportCsv(_ProfitData data) async {
+    // Mirror the on-screen gate: omit the raw Cost-of-goods column unless the
+    // viewer holds `reports.see_cost_prices`.
+    final canSeeCost = ref
+        .read(currentUserPermissionsProvider)
+        .contains('reports.see_cost_prices');
     final rows = <List<String>>[
       for (final p in data.products)
         [
           p.name,
           '${p.qty}',
           (p.revenueKobo / 100.0).toStringAsFixed(2),
-          (p.cogsKobo / 100.0).toStringAsFixed(2),
+          if (canSeeCost) (p.cogsKobo / 100.0).toStringAsFixed(2),
           (p.profitKobo / 100.0).toStringAsFixed(2),
           p.marginPct.toStringAsFixed(1),
         ],
@@ -105,15 +110,18 @@ class _ProfitReportScreenState extends ConsumerState<ProfitReportScreen> {
       'TOTAL',
       '',
       (data.revenueKobo / 100.0).toStringAsFixed(2),
-      (data.cogsKobo / 100.0).toStringAsFixed(2),
+      if (canSeeCost) (data.cogsKobo / 100.0).toStringAsFixed(2),
       (data.profitKobo / 100.0).toStringAsFixed(2),
       data.marginPct.toStringAsFixed(1),
     ]);
     try {
       await shareCsv(
         csv: buildCsv(
-          ['Product', 'Qty sold', 'Revenue', 'Cost of goods', 'Gross profit',
-            'Margin %'],
+          [
+            'Product', 'Qty sold', 'Revenue',
+            if (canSeeCost) 'Cost of goods',
+            'Gross profit', 'Margin %',
+          ],
           rows,
         ),
         fileName: 'profit_report_${_period.replaceAll(' ', '_')}',
@@ -132,6 +140,11 @@ class _ProfitReportScreenState extends ConsumerState<ProfitReportScreen> {
   Widget build(BuildContext context) {
     ref.watch(currencySymbolProvider); // rebuild money displays when currency changes
     final theme = Theme.of(context);
+    // `reports.see_cost_prices` ("See buying prices in reports") gates the raw
+    // Cost-of-goods figure on top of the screen's upstream `reports.see_profit`
+    // gate — so a CEO can grant someone the Profit Report yet withhold the raw
+    // cost. Revenue / Gross Profit / Margin stay (they're `reports.see_profit`).
+    final canSeeCost = hasPermission(ref, 'reports.see_cost_prices');
     final orders = ref.watch(allOrdersProvider).valueOrNull ?? const [];
     final data = _compute(orders, _period);
     final hasCostedData = data.products.isNotEmpty;
@@ -177,7 +190,7 @@ class _ProfitReportScreenState extends ConsumerState<ProfitReportScreen> {
                 bottom: context.spacingM + context.deviceBottomInset,
               ),
               children: [
-                if (hasCostedData) _headline(theme, data),
+                if (hasCostedData) _headline(theme, data, canSeeCost),
                 if (data.uncostedItems > 0) ...[
                   if (hasCostedData) SizedBox(height: context.spacingM),
                   _uncostedNote(theme, data.uncostedItems,
@@ -236,7 +249,7 @@ class _ProfitReportScreenState extends ConsumerState<ProfitReportScreen> {
     );
   }
 
-  Widget _headline(ThemeData theme, _ProfitData data) {
+  Widget _headline(ThemeData theme, _ProfitData data, bool canSeeCost) {
     final profit = data.profitKobo;
     final color = profit >= 0 ? const Color(0xFF22C55E) : theme.colorScheme.error;
     return Container(
@@ -272,8 +285,9 @@ class _ProfitReportScreenState extends ConsumerState<ProfitReportScreen> {
             runSpacing: context.spacingS,
             children: [
               _chip(theme, 'Revenue', formatCurrency(data.revenueKobo / 100.0)),
-              _chip(theme, 'Cost of goods',
-                  formatCurrency(data.cogsKobo / 100.0)),
+              if (canSeeCost)
+                _chip(theme, 'Cost of goods',
+                    formatCurrency(data.cogsKobo / 100.0)),
               _chip(theme, 'Margin', '${data.marginPct.toStringAsFixed(1)}%'),
             ],
           ),

--- a/lib/features/dashboard/screens/reports_hub_screen.dart
+++ b/lib/features/dashboard/screens/reports_hub_screen.dart
@@ -10,6 +10,7 @@ import 'package:reebaplus_pos/shared/widgets/app_dropdown.dart';
 import 'package:reebaplus_pos/features/dashboard/screens/sales_detail_screen.dart';
 import 'package:reebaplus_pos/features/dashboard/screens/profit_report_screen.dart';
 import 'package:reebaplus_pos/features/dashboard/screens/daily_reconciliation_list_screen.dart';
+import 'package:reebaplus_pos/features/dashboard/screens/stock_approvals_screen.dart';
 import 'package:reebaplus_pos/features/expenses/screens/expenses_screen.dart';
 import 'package:reebaplus_pos/features/dashboard/screens/customer_ledger_screen.dart';
 import 'package:reebaplus_pos/features/funds/screens/funds_register_report_screen.dart';
@@ -35,6 +36,10 @@ class _ReportsHubScreenState extends ConsumerState<ReportsHubScreen> {
     // card is additionally guarded so it is hidden (never greyed — rule #7) for
     // any role lacking it. The CEO-only Profit card lands in the §25 Profit pass.
     final isMgrUp = isManagerOrAbove(ref);
+    // §16.6.1 — count of stock-keeper adjustments awaiting this viewer's
+    // approval (a CEO sees all stores; a Manager only their assigned store(s)).
+    final pendingApprovals =
+        ref.watch(viewerScopedPendingStockRequestsProvider).length;
     return SharedScaffold(
       activeRoute: 'dashboard',
       appBar: AppBar(
@@ -69,6 +74,25 @@ class _ReportsHubScreenState extends ConsumerState<ReportsHubScreen> {
           mainAxisSpacing: context.spacingM,
           crossAxisSpacing: context.spacingM,
           children: [
+            // Pending Stock Approvals (§16.6.1) — stock-keeper Add/Remove
+            // requests await the affected store's Manager / the CEO here. Shown
+            // first as an action item; the badge counts what's outstanding.
+            if (isMgrUp)
+              _buildReportCard(
+                context,
+                title: 'Stock Approvals',
+                subtitle: 'Approve Stock Changes',
+                icon: FontAwesomeIcons.clipboardList,
+                color: Colors.orange,
+                locked: false,
+                badgeCount: pendingApprovals,
+                onTap: () {
+                  Navigator.push(
+                    context,
+                    slideDownRoute(const StockApprovalsScreen()),
+                  );
+                },
+              ),
             if (isMgrUp && hasPermission(ref, 'reports.see_sales'))
               _buildReportCard(
                 context,
@@ -216,6 +240,7 @@ class _ReportsHubScreenState extends ConsumerState<ReportsHubScreen> {
     required Color color,
     required VoidCallback onTap,
     bool locked = false,
+    int badgeCount = 0,
   }) {
     return Material(
       color: Colors.transparent,
@@ -287,6 +312,27 @@ class _ReportsHubScreenState extends ConsumerState<ReportsHubScreen> {
                           .colorScheme
                           .onSurface
                           .withValues(alpha: 0.3),
+                    ),
+                  ),
+                ),
+              if (badgeCount > 0)
+                Positioned(
+                  top: 0,
+                  right: 0,
+                  child: Container(
+                    padding:
+                        const EdgeInsets.symmetric(horizontal: 7, vertical: 3),
+                    decoration: BoxDecoration(
+                      color: color,
+                      borderRadius: BorderRadius.circular(10),
+                    ),
+                    child: Text(
+                      '$badgeCount',
+                      style: const TextStyle(
+                        color: Colors.white,
+                        fontSize: 11,
+                        fontWeight: FontWeight.w800,
+                      ),
                     ),
                   ),
                 ),

--- a/lib/features/dashboard/screens/stock_approvals_screen.dart
+++ b/lib/features/dashboard/screens/stock_approvals_screen.dart
@@ -1,0 +1,411 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+import 'package:reebaplus_pos/core/database/app_database.dart';
+import 'package:reebaplus_pos/core/providers/app_providers.dart';
+import 'package:reebaplus_pos/core/providers/stream_providers.dart';
+import 'package:reebaplus_pos/core/theme/design_tokens.dart';
+import 'package:reebaplus_pos/core/utils/notifications.dart';
+import 'package:reebaplus_pos/core/utils/responsive.dart';
+import 'package:reebaplus_pos/shared/widgets/app_button.dart';
+
+/// Pending Stock Approvals (master plan §16.6.1). Lists the stock-keeper
+/// adjustment requests the current viewer may approve — a CEO sees every store,
+/// a Manager only their assigned store(s) (scoping in
+/// [viewerScopedPendingStockRequestsProvider]). Each request is a tappable card
+/// that expands to the full detail and Approve / Reject actions. Approving
+/// applies the real inventory change; rejecting discards it. Both notify the
+/// stock keeper who submitted.
+class StockApprovalsScreen extends ConsumerWidget {
+  const StockApprovalsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final requests = ref.watch(viewerScopedPendingStockRequestsProvider);
+    final stores = ref.watch(allStoresProvider).valueOrNull ?? const [];
+    final usersById =
+        ref.watch(usersByBusinessProvider).valueOrNull ?? const {};
+    final storeNames = {for (final s in stores) s.id: s.name};
+
+    return Scaffold(
+      backgroundColor: context.backgroundColor,
+      appBar: AppBar(
+        title: Text(
+          'Stock Approvals',
+          style: context.h3.copyWith(fontWeight: FontWeight.bold),
+        ),
+        elevation: 0,
+        backgroundColor: context.backgroundColor,
+        leading: BackButton(color: context.primaryColor),
+      ),
+      body: requests.isEmpty
+          ? _EmptyState()
+          : ListView.separated(
+              padding: EdgeInsets.fromLTRB(
+                context.spacingM,
+                context.spacingM,
+                context.spacingM,
+                context.spacingM + context.deviceBottomInset,
+              ),
+              itemCount: requests.length,
+              separatorBuilder: (_, __) => SizedBox(height: context.spacingS),
+              itemBuilder: (_, i) {
+                final r = requests[i];
+                return _ApprovalCard(
+                  request: r,
+                  storeName: storeNames[r.storeId] ?? 'Unknown store',
+                  requesterName:
+                      usersById[r.requestedBy]?.name ?? 'A stock keeper',
+                );
+              },
+            ),
+    );
+  }
+}
+
+class _EmptyState extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(
+            FontAwesomeIcons.clipboardCheck,
+            size: 40,
+            color: Theme.of(context).hintColor,
+          ),
+          const SizedBox(height: 12),
+          Text(
+            'No pending approvals',
+            style: context.bodyMedium.copyWith(
+              color: Theme.of(context).hintColor,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ApprovalCard extends ConsumerStatefulWidget {
+  const _ApprovalCard({
+    required this.request,
+    required this.storeName,
+    required this.requesterName,
+  });
+
+  final StockAdjustmentRequestData request;
+  final String storeName;
+  final String requesterName;
+
+  @override
+  ConsumerState<_ApprovalCard> createState() => _ApprovalCardState();
+}
+
+class _ApprovalCardState extends ConsumerState<_ApprovalCard> {
+  bool _busy = false;
+
+  Color get _accent =>
+      widget.request.quantityDiff < 0 ? Colors.red.shade600 : Colors.green.shade600;
+
+  Future<void> _decide({required bool approve}) async {
+    final approverId = ref.read(authProvider).currentUser?.id;
+    if (approverId == null) return;
+
+    // Rejecting: ask for an optional reason first. A null result means the
+    // approver cancelled — leave the request pending. An empty string means
+    // reject with no reason (the DAO omits it from the notice + log).
+    String? reason;
+    if (!approve) {
+      final result = await showDialog<String?>(
+        context: context,
+        builder: (_) => const _RejectReasonDialog(),
+      );
+      if (!mounted || result == null) return;
+      reason = result;
+    }
+
+    setState(() => _busy = true);
+    final dao = ref.read(databaseProvider).stockAdjustmentRequestsDao;
+    try {
+      if (approve) {
+        await dao.approveRequest(
+          requestId: widget.request.id,
+          approverId: approverId,
+        );
+      } else {
+        await dao.rejectRequest(
+          requestId: widget.request.id,
+          approverId: approverId,
+          reason: reason,
+        );
+      }
+      if (!mounted) return;
+      // The card disappears as the request leaves the pending stream; the
+      // toast confirms which way it went.
+      AppNotification.showSuccess(
+        context,
+        approve ? 'Approved — stock updated.' : 'Request rejected.',
+      );
+    } catch (e) {
+      if (!mounted) return;
+      setState(() => _busy = false);
+      AppNotification.showError(
+        context,
+        approve
+            ? 'Could not approve: ${_friendly(e)}'
+            : 'Could not reject: $e',
+      );
+    }
+  }
+
+  // Surface the common "not enough stock to remove" case in plain English.
+  String _friendly(Object e) {
+    final s = e.toString();
+    if (s.contains('InsufficientStock') || s.contains('insufficient_stock')) {
+      return 'not enough stock in this store to remove that amount.';
+    }
+    return s;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final r = widget.request;
+    final isRemove = r.quantityDiff < 0;
+    final qtyLabel = '${isRemove ? '−' : '+'}${r.quantityDiff.abs()}';
+
+    return Container(
+      decoration: BoxDecoration(
+        color: context.surfaceColor,
+        borderRadius: BorderRadius.circular(context.radiusL),
+        border: Border.all(color: _accent.withValues(alpha: 0.25)),
+      ),
+      clipBehavior: Clip.antiAlias,
+      child: Theme(
+        // Strip the default ExpansionTile dividers so it reads as one card.
+        data: Theme.of(context).copyWith(dividerColor: Colors.transparent),
+        child: ExpansionTile(
+          tilePadding: EdgeInsets.symmetric(
+            horizontal: context.spacingM,
+            vertical: context.spacingXs,
+          ),
+          childrenPadding: EdgeInsets.fromLTRB(
+            context.spacingM,
+            0,
+            context.spacingM,
+            context.spacingM,
+          ),
+          leading: Container(
+            width: 40,
+            height: 40,
+            decoration: BoxDecoration(
+              color: _accent.withValues(alpha: 0.12),
+              shape: BoxShape.circle,
+            ),
+            child: Icon(
+              isRemove ? Icons.arrow_downward : Icons.arrow_upward,
+              color: _accent,
+              size: 20,
+            ),
+          ),
+          title: Text(
+            r.summary,
+            style: context.bodyMedium.copyWith(fontWeight: FontWeight.w600),
+          ),
+          subtitle: Padding(
+            padding: const EdgeInsets.only(top: 4),
+            child: Row(
+              children: [
+                _pendingChip(context),
+                const SizedBox(width: 8),
+                Text(
+                  _timeAgo(r.createdAt),
+                  style: context.bodySmall.copyWith(
+                    color: Theme.of(context).hintColor,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          trailing: Text(
+            qtyLabel,
+            style: context.bodyLarge.copyWith(
+              fontWeight: FontWeight.w800,
+              color: _accent,
+            ),
+          ),
+          children: [
+            _detailRow(context, 'Requested by', widget.requesterName),
+            _detailRow(context, 'Store', widget.storeName),
+            _detailRow(context, 'Reason', r.reason),
+            _detailRow(context, 'When', _fullStamp(r.createdAt)),
+            SizedBox(height: context.spacingM),
+            if (_busy)
+              const Center(
+                child: Padding(
+                  padding: EdgeInsets.all(8),
+                  child: SizedBox(
+                    width: 22,
+                    height: 22,
+                    child: CircularProgressIndicator(strokeWidth: 2.5),
+                  ),
+                ),
+              )
+            else
+              Row(
+                children: [
+                  Expanded(
+                    child: AppButton(
+                      text: 'Reject',
+                      variant: AppButtonVariant.outline,
+                      onPressed: () => _decide(approve: false),
+                    ),
+                  ),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: AppButton(
+                      text: 'Approve',
+                      variant: AppButtonVariant.success,
+                      onPressed: () => _decide(approve: true),
+                    ),
+                  ),
+                ],
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _pendingChip(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+      decoration: BoxDecoration(
+        color: Colors.amber.withValues(alpha: 0.15),
+        borderRadius: BorderRadius.circular(6),
+      ),
+      child: Text(
+        'PENDING',
+        style: context.bodySmall.copyWith(
+          fontSize: context.getRFontSize(10),
+          fontWeight: FontWeight.w800,
+          letterSpacing: 0.6,
+          color: Colors.amber.shade800,
+        ),
+      ),
+    );
+  }
+
+  Widget _detailRow(BuildContext context, String label, String value) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 4),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          SizedBox(
+            width: context.getRSize(96),
+            child: Text(
+              label,
+              style: context.bodySmall.copyWith(
+                color: Theme.of(context).hintColor,
+              ),
+            ),
+          ),
+          Expanded(
+            child: Text(
+              value,
+              style: context.bodySmall.copyWith(fontWeight: FontWeight.w500),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  String _timeAgo(DateTime dt) {
+    final d = DateTime.now().difference(dt);
+    if (d.inMinutes < 1) return 'just now';
+    if (d.inMinutes < 60) return '${d.inMinutes}m ago';
+    if (d.inHours < 24) return '${d.inHours}h ago';
+    if (d.inDays < 7) return '${d.inDays}d ago';
+    return _fullStamp(dt);
+  }
+
+  String _fullStamp(DateTime dt) {
+    String two(int n) => n.toString().padLeft(2, '0');
+    return '${two(dt.day)}/${two(dt.month)}/${dt.year} '
+        '${two(dt.hour)}:${two(dt.minute)}';
+  }
+}
+
+/// Asks the approver for an optional reason before rejecting a stock request.
+/// Owns its own `TextEditingController` and disposes it in `dispose()` (never
+/// after an `await`) — the controller-lifecycle rule from the Update Stock
+/// crash fix. Pops the typed reason on Reject (may be empty), `null` on Cancel.
+class _RejectReasonDialog extends StatefulWidget {
+  const _RejectReasonDialog();
+
+  @override
+  State<_RejectReasonDialog> createState() => _RejectReasonDialogState();
+}
+
+class _RejectReasonDialogState extends State<_RejectReasonDialog> {
+  final _ctrl = TextEditingController();
+
+  @override
+  void dispose() {
+    _ctrl.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      backgroundColor: context.surfaceColor,
+      title: Text(
+        'Reject request',
+        style: context.h3.copyWith(fontWeight: FontWeight.bold),
+      ),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Optionally tell the stock keeper why their request was rejected.',
+            style: context.bodySmall.copyWith(
+              color: Theme.of(context).hintColor,
+            ),
+          ),
+          const SizedBox(height: 12),
+          TextField(
+            controller: _ctrl,
+            autofocus: true,
+            maxLines: 2,
+            textCapitalization: TextCapitalization.sentences,
+            decoration: InputDecoration(
+              hintText: 'Reason (optional)',
+              border: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(10),
+              ),
+            ),
+          ),
+        ],
+      ),
+      actions: [
+        AppButton(
+          text: 'Cancel',
+          variant: AppButtonVariant.ghost,
+          isFullWidth: false,
+          onPressed: () => Navigator.pop(context),
+        ),
+        AppButton(
+          text: 'Reject',
+          variant: AppButtonVariant.danger,
+          isFullWidth: false,
+          onPressed: () => Navigator.pop(context, _ctrl.text),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/expenses/screens/expenses_screen.dart
+++ b/lib/features/expenses/screens/expenses_screen.dart
@@ -50,7 +50,7 @@ class ExpensesScreen extends ConsumerStatefulWidget {
 class _ExpensesScreenState extends ConsumerState<ExpensesScreen>
     with SingleTickerProviderStateMixin {
   late TabController _tabController;
-  String _periodFilter = 'Last 30 days'; // §20.1/§30.6 default
+  String _periodFilter = 'This Month'; // §20.1/§30.6 default
   Color get _bg => Theme.of(context).scaffoldBackgroundColor;
   Color get _surface => Theme.of(context).colorScheme.surface;
   Color get _text => Theme.of(context).colorScheme.onSurface;
@@ -77,6 +77,17 @@ class _ExpensesScreenState extends ConsumerState<ExpensesScreen>
   bool _isInPeriod(DateTime date, String period) =>
       datePeriodFromLabel(period).includes(date);
 
+  /// Period labels this viewer may choose (§19.2/§30.11 — roles below Manager
+  /// are capped to Today/This Week/This Month).
+  List<String> get _periodOptions =>
+      datePeriodLabelsForRole(managerUp: isManagerOrAbove(ref));
+
+  /// [_periodFilter] clamped into [_periodOptions], so the dropdown value and
+  /// the list filter agree for capped viewers.
+  String get _effectivePeriod => _periodOptions.contains(_periodFilter)
+      ? _periodFilter
+      : _periodOptions.last;
+
   /// Resolves a recordedBy user id to a name; never shows a raw UUID (rule #4).
   String _recordedByName(String? userId, Map<String, UserData> users) {
     if (userId == null) return '—';
@@ -88,6 +99,31 @@ class _ExpensesScreenState extends ConsumerState<ExpensesScreen>
   @override
   Widget build(BuildContext context) {
     ref.watch(currencySymbolProvider); // rebuild money displays when currency changes
+    // Hard rule #6 (load-bearing): the Expenses screen IS the expense
+    // report/list, so it requires `reports.see_expenses`. The drawer item and
+    // the Home "Total Expenses" card are gated on the same key, but guard the
+    // screen body too so no alternate route exposes the report. The Add-Expense
+    // FAB additionally checks `expenses.create`.
+    if (!hasPermission(ref, 'reports.see_expenses')) {
+      return Scaffold(
+        backgroundColor: _bg,
+        drawer: const AppDrawer(activeRoute: 'expenses'),
+        appBar: _buildAppBar(context),
+        body: Center(
+          child: Padding(
+            padding: const EdgeInsets.all(32),
+            child: Text(
+              'You don’t have access to expense reports.',
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                color: _subtext,
+                fontSize: context.getRFontSize(14),
+              ),
+            ),
+          ),
+        ),
+      );
+    }
     return Scaffold(
       backgroundColor: _bg,
       drawer: const AppDrawer(activeRoute: 'expenses'),
@@ -106,7 +142,7 @@ class _ExpensesScreenState extends ConsumerState<ExpensesScreen>
           final periodApproved = allExpenses
               .where((e) =>
                   e.expense.status == 'approved' &&
-                  _isInPeriod(e.expense.expenseDate, _periodFilter))
+                  _isInPeriod(e.expense.expenseDate, _effectivePeriod))
               .toList();
           final approvedTotal = periodApproved.fold<int>(
             0,
@@ -117,7 +153,7 @@ class _ExpensesScreenState extends ConsumerState<ExpensesScreen>
           // reflects the last-30-days window, independent of the period
           // selector above the list.
           final monthly = allExpenses
-              .where((e) => _isInPeriod(e.expense.expenseDate, 'Last 30 days'))
+              .where((e) => _isInPeriod(e.expense.expenseDate, 'This Month'))
               .toList();
           final budgetSpentKobo = monthly
               .where((e) => e.expense.status == 'approved')
@@ -336,9 +372,9 @@ class _ExpensesScreenState extends ConsumerState<ExpensesScreen>
                   ],
                 ),
                 AppDropdown<String>(
-                  value: _periodFilter,
+                  value: _effectivePeriod,
                   width: context.getRSize(130),
-                  items: kDatePeriodLabels.map((String val) {
+                  items: _periodOptions.map((String val) {
                     return DropdownMenuItem<String>(
                         value: val, child: Text(val));
                   }).toList(),
@@ -350,7 +386,7 @@ class _ExpensesScreenState extends ConsumerState<ExpensesScreen>
             ),
           ),
           // §20.1/§20.3: monthly budget bar — always visible; reflects the
-          // last-30-days window regardless of the selected period.
+          // current calendar month regardless of the selected period.
           _buildBudgetBar(
             context,
             spentKobo: budgetSpentKobo,
@@ -643,7 +679,7 @@ class _ExpensesScreenState extends ConsumerState<ExpensesScreen>
 
     // Period-filtered list (all statuses) for the main grouped section.
     final periodList = allExpenses
-        .where((e) => _isInPeriod(e.expense.expenseDate, _periodFilter))
+        .where((e) => _isInPeriod(e.expense.expenseDate, _effectivePeriod))
         .toList();
 
     if (pending.isEmpty && periodList.isEmpty) {
@@ -683,13 +719,16 @@ class _ExpensesScreenState extends ConsumerState<ExpensesScreen>
                 child: Row(
                   mainAxisAlignment: MainAxisAlignment.spaceBetween,
                   children: [
-                    Text(
-                      cat.toUpperCase(),
-                      style: TextStyle(
-                        color: _subtext,
-                        fontSize: context.getRFontSize(12),
-                        fontWeight: FontWeight.bold,
-                        letterSpacing: 1.2,
+                    Expanded(
+                      child: Text(
+                        cat.toUpperCase(),
+                        overflow: TextOverflow.ellipsis,
+                        style: TextStyle(
+                          color: _subtext,
+                          fontSize: context.getRFontSize(12),
+                          fontWeight: FontWeight.bold,
+                          letterSpacing: 1.2,
+                        ),
                       ),
                     ),
                     Text(

--- a/lib/features/funds/screens/funds_register_screen.dart
+++ b/lib/features/funds/screens/funds_register_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+import 'package:intl/intl.dart';
 
 import 'package:reebaplus_pos/core/database/app_database.dart';
 import 'package:reebaplus_pos/core/providers/app_providers.dart';
@@ -64,6 +65,11 @@ class _FundsRegisterScreenState extends ConsumerState<FundsRegisterScreen> {
   ) async {
     final userId = ref.read(authProvider).currentUser?.id;
     if (userId == null) return;
+    // Defense-in-depth (hard rule #6): re-check at the write boundary in case
+    // `funds.open_day` was revoked while the form was open.
+    if (!ref.read(currentUserPermissionsProvider).contains('funds.open_day')) {
+      return;
+    }
     final perAccount = <String, int>{};
     for (final a in accounts) {
       final naira = parseCurrency(_opening[a.id]?.text ?? '');
@@ -260,8 +266,13 @@ class _FundsRegisterScreenState extends ConsumerState<FundsRegisterScreen> {
             _openDayBalances(storeId, today, accounts)
           else if (status == 'closed')
             _closedDaySummary(storeId, today, accounts)
+          // Opening the day is gated on `funds.open_day` (hard rule #6). A
+          // `funds.view`-only viewer reaches this screen (OR-clause guard) but
+          // must not see the open-day form — show a wait note instead.
+          else if (hasPermission(ref, 'funds.open_day'))
+            _openDayForm(storeId, today, accounts)
           else
-            _openDayForm(storeId, today, accounts),
+            _openDayLockedNote(),
           const SizedBox(height: 20),
         ],
         if (isCeo) _accountsSection(storeId, accounts),
@@ -401,6 +412,26 @@ class _FundsRegisterScreenState extends ConsumerState<FundsRegisterScreen> {
     );
   }
 
+  /// Shown to a `funds.view`-only viewer (no `funds.open_day`) when today's day
+  /// isn't open yet — they may watch balances but not open the day (hard rule
+  /// #6/#7: no open-day form, no Open Day button).
+  Widget _openDayLockedNote() {
+    return _card(
+      title: 'Day not opened',
+      children: [
+        Text(
+          'The day hasn’t been opened yet. A Manager or CEO needs to open it '
+          'before sales can start.',
+          style: TextStyle(
+            fontSize: 13,
+            color:
+                Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.6),
+          ),
+        ),
+      ],
+    );
+  }
+
   Widget _openDayBalances(
     String storeId,
     String today,
@@ -437,14 +468,18 @@ class _FundsRegisterScreenState extends ConsumerState<FundsRegisterScreen> {
             child: Row(
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [
-                Text(
-                  _accountLabel(a),
-                  style: TextStyle(
-                    fontSize: 14,
-                    fontWeight: FontWeight.w600,
-                    color: theme.colorScheme.onSurface,
+                Expanded(
+                  child: Text(
+                    _accountLabel(a),
+                    overflow: TextOverflow.ellipsis,
+                    style: TextStyle(
+                      fontSize: 14,
+                      fontWeight: FontWeight.w600,
+                      color: theme.colorScheme.onSurface,
+                    ),
                   ),
                 ),
+                const SizedBox(width: 8),
                 Text(
                   formatCurrency((balances[a.id] ?? 0) / 100.0),
                   style: TextStyle(
@@ -765,8 +800,41 @@ class _CloseDaySheetState extends ConsumerState<_CloseDaySheet> {
   String _label(FundsAccountData a) =>
       a.accountType == 'cash_till' ? 'Cash Till' : a.name;
 
+  String _prettyDate(String date) {
+    final d = DateTime.tryParse(date);
+    return d == null ? date : DateFormat('EEE, d MMM yyyy').format(d);
+  }
+
   Future<void> _close() async {
     if (_saving) return;
+    final theme = Theme.of(context);
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        backgroundColor: theme.colorScheme.surface,
+        title: const Text('Close the day?'),
+        content: Text(
+          'This closes ${_prettyDate(widget.businessDate)} for this store. '
+          'You won\'t be able to record more sales for this day, and a new day '
+          'must be opened to continue. Make sure the counts above are correct.',
+        ),
+        actions: [
+          AppButton(
+            text: 'Cancel',
+            variant: AppButtonVariant.ghost,
+            isFullWidth: false,
+            onPressed: () => Navigator.pop(ctx, false),
+          ),
+          AppButton(
+            text: 'Close Day',
+            variant: AppButtonVariant.primary,
+            isFullWidth: false,
+            onPressed: () => Navigator.pop(ctx, true),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true || !mounted) return;
     final userId = ref.read(authProvider).currentUser?.id;
     if (userId == null) return;
     setState(() => _saving = true);
@@ -860,14 +928,18 @@ class _CloseDaySheetState extends ConsumerState<_CloseDaySheet> {
                     Row(
                       mainAxisAlignment: MainAxisAlignment.spaceBetween,
                       children: [
-                        Text(
-                          _label(a),
-                          style: TextStyle(
-                            fontSize: 14,
-                            fontWeight: FontWeight.w700,
-                            color: theme.colorScheme.onSurface,
+                        Expanded(
+                          child: Text(
+                            _label(a),
+                            overflow: TextOverflow.ellipsis,
+                            style: TextStyle(
+                              fontSize: 14,
+                              fontWeight: FontWeight.w700,
+                              color: theme.colorScheme.onSurface,
+                            ),
                           ),
                         ),
+                        const SizedBox(width: 8),
                         Text(
                           'Expected ${formatCurrency((balances[a.id] ?? 0) / 100.0)}',
                           style: TextStyle(

--- a/lib/features/inventory/screens/inventory_screen.dart
+++ b/lib/features/inventory/screens/inventory_screen.dart
@@ -837,6 +837,20 @@ class _InventoryScreenState extends ConsumerState<InventoryScreen>
   }
 
   Widget _buildSupplierFilter(BuildContext context) {
+    // §16.7: roles below Manager (and a Manager without the all-stores grant)
+    // are confined to their assigned store(s). Mirrors the Home filter lock.
+    final lock = _storeLock();
+    if (lock.locked &&
+        lock.lockedStores.isNotEmpty &&
+        !lock.lockedStores.any((s) => s.id == _selectedStoreId)) {
+      // Pin a locked user's filter to an allowed store, re-subscribing once.
+      final id = lock.lockedStores.first.id;
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted || _selectedStoreId == id) return;
+        setState(() => _selectedStoreId = id);
+        _subscribeToProducts();
+      });
+    }
     return Container(
       padding: EdgeInsets.fromLTRB(
         context.getRSize(16),
@@ -850,8 +864,37 @@ class _InventoryScreenState extends ConsumerState<InventoryScreen>
           Expanded(
             child: _isFirstLoad
                 ? const SizedBox.shrink()
-                : (ref.read(navigationProvider).storeLocked.value
-                      ? _buildLockedStoreChip()
+                : (lock.locked
+                      // One assigned store → a locked chip; several → a dropdown
+                      // limited to those stores (no "All Stores").
+                      ? (lock.lockedStores.length > 1
+                            ? AppDropdown<String>(
+                                value: lock.lockedStores
+                                        .any((s) => s.id == _selectedStoreId)
+                                    ? _selectedStoreId
+                                    : lock.lockedStores.first.id,
+                                labelText: 'Store',
+                                items: lock.lockedStores
+                                    .map(
+                                      (w) => DropdownMenuItem(
+                                        value: w.id.toString(),
+                                        child: Text(
+                                          w.name,
+                                          style: TextStyle(color: _text),
+                                        ),
+                                      ),
+                                    )
+                                    .toList(),
+                                onChanged: (val) {
+                                  if (val != null) {
+                                    setState(() => _selectedStoreId = val);
+                                    _subscribeToProducts();
+                                  }
+                                },
+                              )
+                            : _buildLockedStoreChip(
+                                lock.lockedStores.firstOrNull,
+                              ))
                       : AppDropdown<String>(
                           value: _selectedStoreId,
                           labelText: 'Store',
@@ -940,9 +983,7 @@ class _InventoryScreenState extends ConsumerState<InventoryScreen>
     );
   }
 
-  Widget _buildLockedStoreChip() {
-    final lockedId = ref.read(navigationProvider).lockedStoreId.value;
-    final store = _stores.where((w) => w.id == lockedId).firstOrNull;
+  Widget _buildLockedStoreChip(StoreData? store) {
     final label = store?.name ?? 'My Store';
     return Container(
       padding: EdgeInsets.symmetric(

--- a/lib/features/inventory/screens/inventory_screen.dart
+++ b/lib/features/inventory/screens/inventory_screen.dart
@@ -115,7 +115,11 @@ class _InventoryScreenState extends ConsumerState<InventoryScreen>
     final businessesAsync = ref.watch(localBusinessesProvider);
     if (!grantsAsync.hasValue || !businessesAsync.hasValue) return null;
 
-    final perms = grantsAsync.value!.map((g) => g.permissionKey).toSet();
+    // Use the EFFECTIVE permission set (role grants ± this user's overrides), not
+    // the raw role grants — otherwise a CEO's per-staff override of
+    // `suppliers.manage` wouldn't change the visible tabs. The grants watch above
+    // stays only as the load-gate so the tab bar still reveals in one shot.
+    final perms = ref.watch(currentUserPermissionsProvider);
     final businessId = ref.read(authProvider).currentUser?.businessId;
     final businessType = businessesAsync.value!
         .where((b) => b.id == businessId)
@@ -362,6 +366,9 @@ class _InventoryScreenState extends ConsumerState<InventoryScreen>
       appBar: _buildAppBar(context),
       floatingActionButton: (onProductsTab && canAddProduct)
           ? AppFAB(
+              // Stock is a bottom-nav tab root — the visible bottom bar already
+              // lifts the FAB above the system nav; don't add the inset.
+              reserveBottomInset: false,
               onPressed: _showAddProductSheet,
               icon: FontAwesomeIcons.plus,
               label: 'Add Product',
@@ -420,10 +427,12 @@ class _InventoryScreenState extends ConsumerState<InventoryScreen>
             }),
           ),
         // Stock Take icon (§16.1) → Daily Stock Count. §17.4 access: Stock
-        // keeper, Manager, CEO. Cashier blocked — hide the icon entirely (hard
-        // rule #7: hide, don't disable).
+        // keeper, Manager, CEO — AND the `stock.adjust` permission, since the
+        // count/damage actions decrement stock and the key is independently
+        // revocable. Otherwise hide the icon entirely (hard rule #7).
         if (const {'ceo', 'manager', 'stock_keeper'}
-            .contains(ref.watch(currentUserRoleProvider)?.slug))
+                .contains(ref.watch(currentUserRoleProvider)?.slug) &&
+            hasPermission(ref, 'stock.adjust'))
           IconButton(
             tooltip: 'Daily Stock Count',
             icon: const Icon(Icons.fact_check_outlined),
@@ -836,6 +845,28 @@ class _InventoryScreenState extends ConsumerState<InventoryScreen>
     }).toList()..sort((a, b) => a.manufacturer.compareTo(b.manufacturer));
   }
 
+  /// §16.7 store confinement for the Inventory filter. The CEO — and a Manager
+  /// the CEO has granted all-stores — may view every store; Cashier and Stock
+  /// keeper (and a Manager without the grant) are locked to their assigned
+  /// store(s). Mirrors the Home filter rule. `lockedStores` is empty while the
+  /// assignments are still resolving.
+  ({bool locked, List<StoreData> lockedStores}) _storeLock() {
+    final slug = ref.watch(currentUserRoleProvider)?.slug;
+    final canViewAllStores = slug == 'ceo' ||
+        (slug == 'manager' && ref.watch(managerCanViewAllStoresProvider));
+    final locked = slug != null && !canViewAllStores;
+    final userId = ref.read(authProvider).currentUser?.id;
+    final assignedStoreIds = (userId == null
+            ? const <UserStoreData>[]
+            : (ref.watch(myUserStoresProvider(userId)).valueOrNull ??
+                const <UserStoreData>[]))
+        .map((s) => s.storeId)
+        .toSet();
+    final lockedStores =
+        _stores.where((s) => assignedStoreIds.contains(s.id)).toList();
+    return (locked: locked, lockedStores: lockedStores);
+  }
+
   Widget _buildSupplierFilter(BuildContext context) {
     // §16.7: roles below Manager (and a Manager without the all-stores grant)
     // are confined to their assigned store(s). Mirrors the Home filter lock.
@@ -1158,18 +1189,24 @@ class _InventoryScreenState extends ConsumerState<InventoryScreen>
         : Theme.of(context).colorScheme.primary;
 
     return GestureDetector(
-      onLongPress: () {
-        showModalBottomSheet(
-          context: context,
-          isScrollControlled: true,
-          backgroundColor: Colors.transparent,
-          builder: (ctx) => UpdateProductSheet(
-            product: product,
-            totalStock: currentStock,
-            onProductUpdated: () => setState(() {}),
-          ),
-        );
-      },
+      // Long-press opens the full product editor (name/prices/details), so it
+      // is gated on `products.edit_price` (hard rule #6/#7 — hide, don't
+      // disable). Stock-only roles add stock via the product-detail Update
+      // Stock sheet instead, never this editor.
+      onLongPress: hasPermission(ref, 'products.edit_price')
+          ? () {
+              showModalBottomSheet(
+                context: context,
+                isScrollControlled: true,
+                backgroundColor: Colors.transparent,
+                builder: (ctx) => UpdateProductSheet(
+                  product: product,
+                  totalStock: currentStock,
+                  onProductUpdated: () => setState(() {}),
+                ),
+              );
+            }
+          : null,
       onTap: () {
         final inventoryItem = InventoryItem(
           id: product.id.toString(),
@@ -1822,12 +1859,15 @@ class _InventoryScreenState extends ConsumerState<InventoryScreen>
                 Row(
                   mainAxisAlignment: MainAxisAlignment.spaceBetween,
                   children: [
-                    Text(
-                      'Update ${mfr.name}',
-                      style: TextStyle(
-                        fontSize: 20,
-                        fontWeight: FontWeight.w900,
-                        color: _text,
+                    Expanded(
+                      child: Text(
+                        'Update ${mfr.name}',
+                        overflow: TextOverflow.ellipsis,
+                        style: TextStyle(
+                          fontSize: 20,
+                          fontWeight: FontWeight.w900,
+                          color: _text,
+                        ),
                       ),
                     ),
                     IconButton(

--- a/lib/features/inventory/screens/product_detail_screen.dart
+++ b/lib/features/inventory/screens/product_detail_screen.dart
@@ -114,43 +114,6 @@ class _ProductDetailScreenState extends ConsumerState<ProductDetailScreen> {
   bool get _canSeeSuppliers =>
       ref.read(currentUserPermissionsProvider).contains('suppliers.manage');
 
-  /// §26.4: when a **stock keeper** adds or removes stock, notify the CEO and
-  /// the Manager(s) of the **affected store** so they see the movement (and the
-  /// reason, on a removal). No-op for any other actor — a Manager/CEO adjusting
-  /// their own stock shouldn't notify themselves.
-  ///
-  /// CEOs are always included (they aren't store-assigned). Managers are
-  /// narrowed to those assigned to [storeId]; if none resolve (e.g. a Manager
-  /// invited without a store), we fall back to all Managers so the leadership
-  /// audience is never silently dropped.
-  Future<void> _notifyLeadershipOfStockAdjustment({
-    required String summary,
-    required bool isRemove,
-    required String productId,
-    required String storeId,
-  }) async {
-    if (ref.read(currentUserRoleProvider)?.slug != 'stock_keeper') return;
-    final db = ref.read(databaseProvider);
-    final ceoIds = await db.userBusinessesDao.getUserIdsForRoleSlugs(['ceo']);
-    final managerIds =
-        await db.userBusinessesDao.getUserIdsForRoleSlugs(['manager']);
-    final storeUserIds =
-        (await db.userStoresDao.getUserIdsForStore(storeId)).toSet();
-    final storeManagerIds = managerIds.where(storeUserIds.contains).toList();
-    final effectiveManagers =
-        storeManagerIds.isEmpty ? managerIds : storeManagerIds;
-    final recipients = <String>{...ceoIds, ...effectiveManagers};
-    for (final uid in recipients) {
-      await db.notificationsDao.fireNotification(
-        type: 'stock_adjustment',
-        message: summary,
-        severity: isRemove ? 'warning' : 'info',
-        linkedRecordId: productId,
-        recipientUserId: uid,
-      );
-    }
-  }
-
   @override
   void initState() {
     super.initState();
@@ -1189,34 +1152,21 @@ class _ProductDetailScreenState extends ConsumerState<ProductDetailScreen> {
                 borderRadius: BorderRadius.circular(16),
                 border: Border.all(color: _border),
               ),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.center,
                 children: [
-                  Row(
-                    children: [
-                      Icon(
-                        Icons.lock_outline,
-                        size: context.getRSize(14),
-                        color: _subtext,
-                      ),
-                      SizedBox(width: context.getRSize(6)),
-                      Text(
-                        'VIEW ONLY',
-                        style: TextStyle(
-                          fontSize: context.getRFontSize(11),
-                          fontWeight: FontWeight.w800,
-                          letterSpacing: 0.8,
-                          color: _subtext,
-                        ),
-                      ),
-                    ],
+                  Icon(
+                    Icons.lock_outline,
+                    size: context.getRSize(14),
+                    color: _subtext,
                   ),
-                  SizedBox(height: context.getRSize(6)),
+                  SizedBox(width: context.getRSize(6)),
                   Text(
-                    "Your role can view this product but can't edit it or "
-                    'adjust its stock.',
+                    'VIEW ONLY',
                     style: TextStyle(
-                      fontSize: context.getRFontSize(13),
+                      fontSize: context.getRFontSize(12),
+                      fontWeight: FontWeight.w800,
+                      letterSpacing: 0.8,
                       color: _subtext,
                     ),
                   ),
@@ -1732,10 +1682,12 @@ class _ProductDetailScreenState extends ConsumerState<ProductDetailScreen> {
     );
   }
 
-  /// Stock keeper "Update Stock" modal (master plan §16.6): add / remove a
-  /// quantity against a store, with a required reason on removal, optional
-  /// notes. Writes through `adjustStock` (so the cloud delta envelope is
-  /// enqueued) and logs to History.
+  /// "Update Stock" modal (master plan §16.6): add / remove a quantity against
+  /// a store, with a required reason on removal, optional notes. A **stock
+  /// keeper**'s change is queued for Manager/CEO approval (§16.6.1) via
+  /// `requestStockAdjustment` — inventory is untouched until approved. A
+  /// Manager/CEO applies it directly through `adjustStock` (cloud delta
+  /// envelope enqueued) and logs to History.
   Future<void> _showUpdateStockModal() async {
     final product = _productData;
     if (product == null) return;
@@ -1751,6 +1703,9 @@ class _ProductDetailScreenState extends ConsumerState<ProductDetailScreen> {
     // State.dispose() (matches every other sheet in the app). Disposing them
     // here, after `await showModalBottomSheet`, raced the closing animation and
     // threw "TextEditingController used after being disposed".
+    // Flipped by onSave when a stock keeper's change is queued for approval
+    // (§16.6.1) rather than applied directly — drives the confirmation toast.
+    var sentForApproval = false;
     await showModalBottomSheet<void>(
       context: context,
       isScrollControlled: true,
@@ -1779,7 +1734,30 @@ class _ProductDetailScreenState extends ConsumerState<ProductDetailScreen> {
           final note = isRemove
               ? '${reason!}${notes.isEmpty ? '' : ': $notes'}'
               : (notes.isEmpty ? 'Stock added by $actorName' : notes);
+          final summary = '$actorName ${isRemove ? 'removed' : 'added'} $qty '
+              '${product.unit}(s) of ${product.name} '
+              '(${store.name})'
+              '${isRemove ? ' — ${reason!}' : ''}';
+          final isStockKeeper =
+              ref.read(currentUserRoleProvider)?.slug == 'stock_keeper';
           try {
+            if (isStockKeeper) {
+              // §16.6.1 — a stock keeper's change needs Manager/CEO approval.
+              // Record a pending request; inventory stays untouched until it is
+              // approved in the Reports hub. The DAO fires the approval-request
+              // notification to the CEO + the affected store's Manager(s).
+              await db.stockAdjustmentRequestsDao.requestStockAdjustment(
+                productId: product.id,
+                storeId: store.id,
+                quantityDiff: delta,
+                reason: note,
+                summary: summary,
+                requestedBy: auth.currentUser?.id,
+              );
+              sentForApproval = true;
+              return null;
+            }
+            // Manager / CEO adjust directly — no approval needed.
             await db.inventoryDao.adjustStock(
               product.id,
               store.id,
@@ -1787,35 +1765,33 @@ class _ProductDetailScreenState extends ConsumerState<ProductDetailScreen> {
               note,
               auth.currentUser?.id,
             );
-            final summary = '$actorName ${isRemove ? 'removed' : 'added'} $qty '
-                '${product.unit}(s) of ${product.name} '
-                '(${store.name})'
-                '${isRemove ? ' — ${reason!}' : ''}';
             await ref.read(activityLogProvider).logAction(
                   'stock_adjustment',
                   summary,
                   productId: product.id,
                   storeId: store.id,
                 );
-            // §26.4: tell the CEO + the affected store's Managers when a stock
-            // keeper moves stock.
-            await _notifyLeadershipOfStockAdjustment(
-              summary: summary,
-              isRemove: isRemove,
-              productId: product.id,
-              storeId: store.id,
-            );
             widget.onUpdateStock();
             // Reflect the change on this screen immediately (#1).
             await _refreshLiveStock();
             return null;
           } catch (e) {
             debugPrint('UpdateStock modal save error: $e');
-            return 'Could not update stock: $e';
+            return isStockKeeper
+                ? 'Could not send for approval: $e'
+                : 'Could not update stock: $e';
           }
         },
       ),
     );
+    if (!mounted) return;
+    if (sentForApproval) {
+      AppNotification.showSuccess(
+        context,
+        'Sent for approval. A manager or the CEO must approve before the '
+        'stock changes.',
+      );
+    }
   }
 
   /// Bordered inline text/number field used as an `_infoRow` trailing. Editable
@@ -2006,9 +1982,10 @@ class _ProductDetailScreenState extends ConsumerState<ProductDetailScreen> {
 // framework tears the fields down before the controllers go away. The previous
 // inline version created the controllers in the caller and disposed them right
 // after `await showModalBottomSheet`, which raced the closing animation and
-// threw "TextEditingController used after being disposed". The DB write,
-// activity log, leadership notification and screen refresh stay on the screen
-// (private members) and run via [onSave].
+// threw "TextEditingController used after being disposed". The save side
+// effects — a stock keeper's approval request, or a Manager/CEO's direct
+// adjustment + activity log + screen refresh — stay on the screen (private
+// members) and run via [onSave].
 // ─────────────────────────────────────────────────────────────────────────────
 class _UpdateStockSheet extends ConsumerStatefulWidget {
   const _UpdateStockSheet({
@@ -2168,13 +2145,14 @@ class _UpdateStockSheetState extends ConsumerState<_UpdateStockSheet> {
           color: _bg,
           borderRadius: const BorderRadius.vertical(top: Radius.circular(28)),
         ),
-        padding: EdgeInsets.fromLTRB(
-          20,
-          16,
-          20,
-          20 + context.deviceBottomInset,
-        ),
-        child: Column(
+        child: SingleChildScrollView(
+          padding: EdgeInsets.fromLTRB(
+            20,
+            16,
+            20,
+            20 + context.deviceBottomInset,
+          ),
+          child: Column(
           mainAxisSize: MainAxisSize.min,
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
@@ -2283,6 +2261,7 @@ class _UpdateStockSheetState extends ConsumerState<_UpdateStockSheet> {
               onPressed: _doSave,
             ),
           ],
+        ),
         ),
       ),
     );

--- a/lib/features/inventory/screens/product_detail_screen.dart
+++ b/lib/features/inventory/screens/product_detail_screen.dart
@@ -114,19 +114,32 @@ class _ProductDetailScreenState extends ConsumerState<ProductDetailScreen> {
   bool get _canSeeSuppliers =>
       ref.read(currentUserPermissionsProvider).contains('suppliers.manage');
 
-  /// §26.4: when a **stock keeper** adds or removes stock, notify every CEO +
-  /// Manager so they see the movement (and the reason, on a removal). No-op for
-  /// any other actor — a Manager/CEO adjusting their own stock shouldn't notify
-  /// themselves. Mirrors the CEO+Manager fan-out used by the stock-count screen.
+  /// §26.4: when a **stock keeper** adds or removes stock, notify the CEO and
+  /// the Manager(s) of the **affected store** so they see the movement (and the
+  /// reason, on a removal). No-op for any other actor — a Manager/CEO adjusting
+  /// their own stock shouldn't notify themselves.
+  ///
+  /// CEOs are always included (they aren't store-assigned). Managers are
+  /// narrowed to those assigned to [storeId]; if none resolve (e.g. a Manager
+  /// invited without a store), we fall back to all Managers so the leadership
+  /// audience is never silently dropped.
   Future<void> _notifyLeadershipOfStockAdjustment({
     required String summary,
     required bool isRemove,
     required String productId,
+    required String storeId,
   }) async {
     if (ref.read(currentUserRoleProvider)?.slug != 'stock_keeper') return;
     final db = ref.read(databaseProvider);
-    final recipients =
-        await db.userBusinessesDao.getUserIdsForRoleSlugs(['ceo', 'manager']);
+    final ceoIds = await db.userBusinessesDao.getUserIdsForRoleSlugs(['ceo']);
+    final managerIds =
+        await db.userBusinessesDao.getUserIdsForRoleSlugs(['manager']);
+    final storeUserIds =
+        (await db.userStoresDao.getUserIdsForStore(storeId)).toSet();
+    final storeManagerIds = managerIds.where(storeUserIds.contains).toList();
+    final effectiveManagers =
+        storeManagerIds.isEmpty ? managerIds : storeManagerIds;
+    final recipients = <String>{...ceoIds, ...effectiveManagers};
     for (final uid in recipients) {
       await db.notificationsDao.fireNotification(
         type: 'stock_adjustment',
@@ -1176,23 +1189,35 @@ class _ProductDetailScreenState extends ConsumerState<ProductDetailScreen> {
                 borderRadius: BorderRadius.circular(16),
                 border: Border.all(color: _border),
               ),
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.center,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  Icon(
-                    Icons.lock_outline,
-                    size: context.getRSize(16),
-                    color: _subtext,
-                  ),
-                  SizedBox(width: context.getRSize(8)),
-                  Flexible(
-                    child: Text(
-                      'View only — this product is not in your store',
-                      overflow: TextOverflow.ellipsis,
-                      style: TextStyle(
-                        fontSize: context.getRFontSize(13),
+                  Row(
+                    children: [
+                      Icon(
+                        Icons.lock_outline,
+                        size: context.getRSize(14),
                         color: _subtext,
                       ),
+                      SizedBox(width: context.getRSize(6)),
+                      Text(
+                        'VIEW ONLY',
+                        style: TextStyle(
+                          fontSize: context.getRFontSize(11),
+                          fontWeight: FontWeight.w800,
+                          letterSpacing: 0.8,
+                          color: _subtext,
+                        ),
+                      ),
+                    ],
+                  ),
+                  SizedBox(height: context.getRSize(6)),
+                  Text(
+                    "Your role can view this product but can't edit it or "
+                    'adjust its stock.',
+                    style: TextStyle(
+                      fontSize: context.getRFontSize(13),
+                      color: _subtext,
                     ),
                   ),
                 ],
@@ -1722,276 +1747,75 @@ class _ProductDetailScreenState extends ConsumerState<ProductDetailScreen> {
       return;
     }
 
-    final qtyCtrl = TextEditingController();
-    final notesCtrl = TextEditingController();
-    // Add and Remove are gated separately (stock.add vs stock.adjust). The modal
-    // only opened because the viewer holds at least one; start in whichever mode
-    // is allowed (Add by default).
-    final canAdd = _canAddStock;
-    final canRemove = _canAdjustStock;
-    var isRemove = !canAdd && canRemove;
-    const reasons = ['Damage', 'Theft', 'Expired', 'Other'];
-    String? reason;
-    StoreData selectedStore = stores.cast<StoreData?>().firstWhere(
-          (s) => s?.id == widget.selectedStoreId,
-          orElse: () => stores.first,
-        )!;
-    var saving = false;
-
+    // The sheet owns its own text controllers and disposes them in its
+    // State.dispose() (matches every other sheet in the app). Disposing them
+    // here, after `await showModalBottomSheet`, raced the closing animation and
+    // threw "TextEditingController used after being disposed".
     await showModalBottomSheet<void>(
       context: context,
       isScrollControlled: true,
       backgroundColor: Colors.transparent,
-      builder: (sheetCtx) {
-        return StatefulBuilder(
-          builder: (sheetCtx, setSheet) {
-            Future<void> doSave() async {
-              final qty = int.tryParse(qtyCtrl.text.trim()) ?? 0;
-              if (qty <= 0) {
-                AppNotification.showError(
-                  sheetCtx,
-                  'Quantity must be greater than 0.',
-                );
-                return;
-              }
-              if (isRemove && reason == null) {
-                AppNotification.showError(
-                  sheetCtx,
-                  'A reason is required when removing stock.',
-                );
-                return;
-              }
-              // Defense-in-depth (hard rule #6): re-check the mode's permission
-              // live, in case it was revoked while the sheet was open.
-              if (isRemove && !_canAdjustStock) {
-                AppNotification.showError(
-                    sheetCtx, 'You don\'t have permission to remove stock.');
-                return;
-              }
-              if (!isRemove && !_canAddStock) {
-                AppNotification.showError(
-                    sheetCtx, 'You don\'t have permission to add stock.');
-                return;
-              }
-              setSheet(() => saving = true);
-              final auth = ref.read(authProvider);
-              final actorName = auth.currentUser?.name ?? 'Unknown';
-              final notes = notesCtrl.text.trim();
-              final delta = isRemove ? -qty : qty;
-              final note = isRemove
-                  ? '${reason!}${notes.isEmpty ? '' : ': $notes'}'
-                  : (notes.isEmpty ? 'Stock added by $actorName' : notes);
-              try {
-                await db.inventoryDao.adjustStock(
-                  product.id,
-                  selectedStore.id,
-                  delta,
-                  note,
-                  auth.currentUser?.id,
-                );
-                final summary =
-                    '$actorName ${isRemove ? 'removed' : 'added'} $qty '
-                    '${product.unit}(s) of ${product.name} '
-                    '(${selectedStore.name})'
-                    '${isRemove ? ' — ${reason!}' : ''}';
-                await ref.read(activityLogProvider).logAction(
-                      'stock_adjustment',
-                      summary,
-                      productId: product.id,
-                      storeId: selectedStore.id,
-                    );
-                // §26.4: tell CEO + Managers when a stock keeper moves stock.
-                await _notifyLeadershipOfStockAdjustment(
-                  summary: summary,
-                  isRemove: isRemove,
-                  productId: product.id,
-                );
-                if (sheetCtx.mounted) Navigator.pop(sheetCtx);
-                widget.onUpdateStock();
-                // Reflect the change on this screen immediately (#1).
-                await _refreshLiveStock();
-              } catch (e) {
-                debugPrint('UpdateStock modal save error: $e');
-                if (sheetCtx.mounted) {
-                  AppNotification.showError(
-                    sheetCtx,
-                    'Could not update stock: $e',
-                  );
-                }
-                setSheet(() => saving = false);
-              }
-            }
-
-            Widget modeChip(String label, bool removeMode) {
-              final selected = isRemove == removeMode;
-              final color = removeMode ? danger : success;
-              return Expanded(
-                child: GestureDetector(
-                  onTap: () => setSheet(() {
-                    isRemove = removeMode;
-                    if (!removeMode) reason = null;
-                  }),
-                  child: Container(
-                    padding: const EdgeInsets.symmetric(vertical: 12),
-                    decoration: BoxDecoration(
-                      color: selected
-                          ? color.withValues(alpha: 0.15)
-                          : _surface,
-                      borderRadius: BorderRadius.circular(12),
-                      border: Border.all(
-                        color: selected ? color : _border,
-                        width: selected ? 1.5 : 1,
-                      ),
-                    ),
-                    child: Center(
-                      child: Text(
-                        label,
-                        style: TextStyle(
-                          fontSize: 14,
-                          fontWeight: FontWeight.w700,
-                          color: selected ? color : _subtext,
-                        ),
-                      ),
-                    ),
-                  ),
-                ),
-              );
-            }
-
-            return Padding(
-              padding: EdgeInsets.only(
-                bottom: MediaQuery.of(sheetCtx).viewInsets.bottom,
-              ),
-              child: Container(
-                decoration: BoxDecoration(
-                  color: _bg,
-                  borderRadius:
-                      const BorderRadius.vertical(top: Radius.circular(28)),
-                ),
-                padding: EdgeInsets.fromLTRB(
-                  20,
-                  16,
-                  20,
-                  20 + sheetCtx.deviceBottomInset,
-                ),
-                child: Column(
-                  mainAxisSize: MainAxisSize.min,
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Center(
-                      child: Container(
-                        width: 40,
-                        height: 4,
-                        decoration: BoxDecoration(
-                          color: _border,
-                          borderRadius: BorderRadius.circular(2),
-                        ),
-                      ),
-                    ),
-                    const SizedBox(height: 16),
-                    Text(
-                      'Update Stock',
-                      style: TextStyle(
-                        fontSize: 18,
-                        fontWeight: FontWeight.w800,
-                        color: _text,
-                      ),
-                    ),
-                    Text(
-                      product.name,
-                      style: TextStyle(fontSize: 13, color: _subtext),
-                    ),
-                    const SizedBox(height: 16),
-                    Row(
-                      children: [
-                        if (canAdd) modeChip('Add stock', false),
-                        if (canAdd && canRemove) const SizedBox(width: 10),
-                        if (canRemove) modeChip('Remove stock', true),
-                      ],
-                    ),
-                    const SizedBox(height: 14),
-                    if (stores.length > 1) ...[
-                      Text(
-                        'STORE',
-                        style: TextStyle(
-                          fontSize: 11,
-                          fontWeight: FontWeight.w700,
-                          color: _subtext,
-                          letterSpacing: 0.8,
-                        ),
-                      ),
-                      const SizedBox(height: 8),
-                      AppDropdown<StoreData>(
-                        value: selectedStore,
-                        items: stores
-                            .map(
-                              (s) => DropdownMenuItem(
-                                value: s,
-                                child: Text(
-                                  s.name,
-                                  overflow: TextOverflow.ellipsis,
-                                ),
-                              ),
-                            )
-                            .toList(),
-                        onChanged: (v) =>
-                            setSheet(() => selectedStore = v ?? selectedStore),
-                      ),
-                      const SizedBox(height: 14),
-                    ],
-                    AppInput(
-                      controller: qtyCtrl,
-                      labelText: 'Quantity *',
-                      hintText: '0',
-                      keyboardType: TextInputType.number,
-                    ),
-                    if (isRemove) ...[
-                      const SizedBox(height: 14),
-                      Text(
-                        'REASON *',
-                        style: TextStyle(
-                          fontSize: 11,
-                          fontWeight: FontWeight.w700,
-                          color: _subtext,
-                          letterSpacing: 0.8,
-                        ),
-                      ),
-                      const SizedBox(height: 8),
-                      AppDropdown<String?>(
-                        value: reason,
-                        hintText: 'Select a reason',
-                        items: reasons
-                            .map(
-                              (r) =>
-                                  DropdownMenuItem(value: r, child: Text(r)),
-                            )
-                            .toList(),
-                        onChanged: (v) => setSheet(() => reason = v),
-                      ),
-                    ],
-                    const SizedBox(height: 14),
-                    AppInput(
-                      controller: notesCtrl,
-                      labelText: 'Notes (optional)',
-                      hintText: 'Any extra detail…',
-                    ),
-                    const SizedBox(height: 20),
-                    AppButton(
-                      text: isRemove ? 'Remove Stock' : 'Add Stock',
-                      variant: AppButtonVariant.primary,
-                      isLoading: saving,
-                      onPressed: doSave,
-                    ),
-                  ],
-                ),
-              ),
+      builder: (_) => _UpdateStockSheet(
+        product: product,
+        stores: stores,
+        initialStoreId: widget.selectedStoreId,
+        // Add and Remove are gated separately (stock.add vs stock.adjust).
+        canAdd: _canAddStock,
+        canRemove: _canAdjustStock,
+        // Re-checked live at save time (hard rule #6) in case a permission is
+        // revoked while the sheet is open — these getters read live perms.
+        canAddNow: () => _canAddStock,
+        canRemoveNow: () => _canAdjustStock,
+        onSave: ({
+          required bool isRemove,
+          required int qty,
+          required StoreData store,
+          String? reason,
+          required String notes,
+        }) async {
+          final auth = ref.read(authProvider);
+          final actorName = auth.currentUser?.name ?? 'Unknown';
+          final delta = isRemove ? -qty : qty;
+          final note = isRemove
+              ? '${reason!}${notes.isEmpty ? '' : ': $notes'}'
+              : (notes.isEmpty ? 'Stock added by $actorName' : notes);
+          try {
+            await db.inventoryDao.adjustStock(
+              product.id,
+              store.id,
+              delta,
+              note,
+              auth.currentUser?.id,
             );
-          },
-        );
-      },
+            final summary = '$actorName ${isRemove ? 'removed' : 'added'} $qty '
+                '${product.unit}(s) of ${product.name} '
+                '(${store.name})'
+                '${isRemove ? ' — ${reason!}' : ''}';
+            await ref.read(activityLogProvider).logAction(
+                  'stock_adjustment',
+                  summary,
+                  productId: product.id,
+                  storeId: store.id,
+                );
+            // §26.4: tell the CEO + the affected store's Managers when a stock
+            // keeper moves stock.
+            await _notifyLeadershipOfStockAdjustment(
+              summary: summary,
+              isRemove: isRemove,
+              productId: product.id,
+              storeId: store.id,
+            );
+            widget.onUpdateStock();
+            // Reflect the change on this screen immediately (#1).
+            await _refreshLiveStock();
+            return null;
+          } catch (e) {
+            debugPrint('UpdateStock modal save error: $e');
+            return 'Could not update stock: $e';
+          }
+        },
+      ),
     );
-    qtyCtrl.dispose();
-    notesCtrl.dispose();
   }
 
   /// Bordered inline text/number field used as an `_infoRow` trailing. Editable
@@ -2170,6 +1994,296 @@ class _ProductDetailScreenState extends ConsumerState<ProductDetailScreen> {
             },
           ),
         ],
+      ),
+    );
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// _UpdateStockSheet — the Stock keeper's "Update Stock" bottom sheet (§16.6).
+//
+// Owns its own text controllers and disposes them in State.dispose(), so the
+// framework tears the fields down before the controllers go away. The previous
+// inline version created the controllers in the caller and disposed them right
+// after `await showModalBottomSheet`, which raced the closing animation and
+// threw "TextEditingController used after being disposed". The DB write,
+// activity log, leadership notification and screen refresh stay on the screen
+// (private members) and run via [onSave].
+// ─────────────────────────────────────────────────────────────────────────────
+class _UpdateStockSheet extends ConsumerStatefulWidget {
+  const _UpdateStockSheet({
+    required this.product,
+    required this.stores,
+    required this.initialStoreId,
+    required this.canAdd,
+    required this.canRemove,
+    required this.canAddNow,
+    required this.canRemoveNow,
+    required this.onSave,
+  });
+
+  final ProductData product;
+  final List<StoreData> stores;
+  final String? initialStoreId;
+  final bool canAdd;
+  final bool canRemove;
+  // Live permission re-checks evaluated at save time (hard rule #6).
+  final bool Function() canAddNow;
+  final bool Function() canRemoveNow;
+  // Performs the movement on the screen. Returns null on success, or an error
+  // message to surface in the sheet (the sheet stays open on error).
+  final Future<String?> Function({
+    required bool isRemove,
+    required int qty,
+    required StoreData store,
+    String? reason,
+    required String notes,
+  }) onSave;
+
+  @override
+  ConsumerState<_UpdateStockSheet> createState() => _UpdateStockSheetState();
+}
+
+class _UpdateStockSheetState extends ConsumerState<_UpdateStockSheet> {
+  final _qtyCtrl = TextEditingController();
+  final _notesCtrl = TextEditingController();
+  static const _reasons = ['Damage', 'Theft', 'Expired', 'Other'];
+
+  late bool _isRemove;
+  String? _reason;
+  late StoreData _selectedStore;
+  bool _saving = false;
+
+  Color get _bg => Theme.of(context).scaffoldBackgroundColor;
+  Color get _surface => Theme.of(context).colorScheme.surface;
+  Color get _text => Theme.of(context).colorScheme.onSurface;
+  Color get _subtext =>
+      Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.6);
+  Color get _border => Theme.of(context).dividerColor;
+
+  @override
+  void initState() {
+    super.initState();
+    // Start in whichever mode is allowed (Add by default).
+    _isRemove = !widget.canAdd && widget.canRemove;
+    _selectedStore = widget.stores.cast<StoreData?>().firstWhere(
+          (s) => s?.id == widget.initialStoreId,
+          orElse: () => widget.stores.first,
+        )!;
+  }
+
+  @override
+  void dispose() {
+    _qtyCtrl.dispose();
+    _notesCtrl.dispose();
+    super.dispose();
+  }
+
+  Future<void> _doSave() async {
+    final qty = int.tryParse(_qtyCtrl.text.trim()) ?? 0;
+    if (qty <= 0) {
+      AppNotification.showError(context, 'Quantity must be greater than 0.');
+      return;
+    }
+    if (_isRemove && _reason == null) {
+      AppNotification.showError(
+        context,
+        'A reason is required when removing stock.',
+      );
+      return;
+    }
+    // Defense-in-depth (hard rule #6): re-check the mode's permission live, in
+    // case it was revoked while the sheet was open.
+    if (_isRemove && !widget.canRemoveNow()) {
+      AppNotification.showError(
+          context, 'You don\'t have permission to remove stock.');
+      return;
+    }
+    if (!_isRemove && !widget.canAddNow()) {
+      AppNotification.showError(
+          context, 'You don\'t have permission to add stock.');
+      return;
+    }
+    setState(() => _saving = true);
+    final error = await widget.onSave(
+      isRemove: _isRemove,
+      qty: qty,
+      store: _selectedStore,
+      reason: _reason,
+      notes: _notesCtrl.text.trim(),
+    );
+    if (!mounted) return;
+    if (error == null) {
+      Navigator.pop(context);
+    } else {
+      AppNotification.showError(context, error);
+      setState(() => _saving = false);
+    }
+  }
+
+  Widget _modeChip(String label, bool removeMode) {
+    final selected = _isRemove == removeMode;
+    final color = removeMode ? danger : success;
+    return Expanded(
+      child: GestureDetector(
+        onTap: () => setState(() {
+          _isRemove = removeMode;
+          if (!removeMode) _reason = null;
+        }),
+        child: Container(
+          padding: const EdgeInsets.symmetric(vertical: 12),
+          decoration: BoxDecoration(
+            color: selected ? color.withValues(alpha: 0.15) : _surface,
+            borderRadius: BorderRadius.circular(12),
+            border: Border.all(
+              color: selected ? color : _border,
+              width: selected ? 1.5 : 1,
+            ),
+          ),
+          child: Center(
+            child: Text(
+              label,
+              style: TextStyle(
+                fontSize: 14,
+                fontWeight: FontWeight.w700,
+                color: selected ? color : _subtext,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final product = widget.product;
+    final stores = widget.stores;
+    return Padding(
+      padding: EdgeInsets.only(
+        bottom: MediaQuery.of(context).viewInsets.bottom,
+      ),
+      child: Container(
+        decoration: BoxDecoration(
+          color: _bg,
+          borderRadius: const BorderRadius.vertical(top: Radius.circular(28)),
+        ),
+        padding: EdgeInsets.fromLTRB(
+          20,
+          16,
+          20,
+          20 + context.deviceBottomInset,
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Center(
+              child: Container(
+                width: 40,
+                height: 4,
+                decoration: BoxDecoration(
+                  color: _border,
+                  borderRadius: BorderRadius.circular(2),
+                ),
+              ),
+            ),
+            const SizedBox(height: 16),
+            Text(
+              'Update Stock',
+              style: TextStyle(
+                fontSize: 18,
+                fontWeight: FontWeight.w800,
+                color: _text,
+              ),
+            ),
+            Text(
+              product.name,
+              style: TextStyle(fontSize: 13, color: _subtext),
+            ),
+            const SizedBox(height: 16),
+            Row(
+              children: [
+                if (widget.canAdd) _modeChip('Add stock', false),
+                if (widget.canAdd && widget.canRemove)
+                  const SizedBox(width: 10),
+                if (widget.canRemove) _modeChip('Remove stock', true),
+              ],
+            ),
+            const SizedBox(height: 14),
+            if (stores.length > 1) ...[
+              Text(
+                'STORE',
+                style: TextStyle(
+                  fontSize: 11,
+                  fontWeight: FontWeight.w700,
+                  color: _subtext,
+                  letterSpacing: 0.8,
+                ),
+              ),
+              const SizedBox(height: 8),
+              AppDropdown<StoreData>(
+                value: _selectedStore,
+                items: stores
+                    .map(
+                      (s) => DropdownMenuItem(
+                        value: s,
+                        child: Text(
+                          s.name,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ),
+                    )
+                    .toList(),
+                onChanged: (v) =>
+                    setState(() => _selectedStore = v ?? _selectedStore),
+              ),
+              const SizedBox(height: 14),
+            ],
+            AppInput(
+              controller: _qtyCtrl,
+              labelText: 'Quantity *',
+              hintText: '0',
+              keyboardType: TextInputType.number,
+            ),
+            if (_isRemove) ...[
+              const SizedBox(height: 14),
+              Text(
+                'REASON *',
+                style: TextStyle(
+                  fontSize: 11,
+                  fontWeight: FontWeight.w700,
+                  color: _subtext,
+                  letterSpacing: 0.8,
+                ),
+              ),
+              const SizedBox(height: 8),
+              AppDropdown<String?>(
+                value: _reason,
+                hintText: 'Select a reason',
+                items: _reasons
+                    .map(
+                      (r) => DropdownMenuItem(value: r, child: Text(r)),
+                    )
+                    .toList(),
+                onChanged: (v) => setState(() => _reason = v),
+              ),
+            ],
+            const SizedBox(height: 14),
+            AppInput(
+              controller: _notesCtrl,
+              labelText: 'Notes (optional)',
+              hintText: 'Any extra detail…',
+            ),
+            const SizedBox(height: 20),
+            AppButton(
+              text: _isRemove ? 'Remove Stock' : 'Add Stock',
+              variant: AppButtonVariant.primary,
+              isLoading: _saving,
+              onPressed: _doSave,
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/features/inventory/screens/stock_count_screen.dart
+++ b/lib/features/inventory/screens/stock_count_screen.dart
@@ -962,9 +962,19 @@ class _StockCountScreenState extends ConsumerState<StockCountScreen> {
     // mutating UI (Save / Record Damages / table) until an allowed role is
     // confirmed — show a spinner while the role is still resolving (null), and
     // the no-access state once it resolves to a disallowed role.
+    // §17.4 access is by role, but the count/damage actions decrement stock, so
+    // gate on the `stock.adjust` permission too (hard rule #6) — it is
+    // independently revocable from a Manager/Stock keeper. `perms` is empty
+    // while the role's grants are still loading; treat that as "resolving" so we
+    // show a spinner rather than flashing the no-access state for a legit role.
     final role = ref.watch(currentUserRoleProvider);
+    final perms = ref.watch(currentUserPermissionsProvider);
     const allowed = {'ceo', 'manager', 'stock_keeper'};
-    if (role == null || !allowed.contains(role.slug)) {
+    final blocked = role == null ||
+        perms.isEmpty ||
+        !allowed.contains(role.slug) ||
+        !perms.contains('stock.adjust');
+    if (blocked) {
       return Scaffold(
         backgroundColor: _bg,
         appBar: AppBar(
@@ -984,7 +994,7 @@ class _StockCountScreenState extends ConsumerState<StockCountScreen> {
           ),
         ),
         body: Center(
-          child: role == null
+          child: (role == null || perms.isEmpty)
               ? const CircularProgressIndicator()
               : Text(
                   'You don’t have access to stock counts.',

--- a/lib/features/inventory/screens/supplier_detail_screen.dart
+++ b/lib/features/inventory/screens/supplier_detail_screen.dart
@@ -28,7 +28,18 @@ class SupplierDetailScreen extends ConsumerStatefulWidget {
 }
 
 class _SupplierDetailScreenState extends ConsumerState<SupplierDetailScreen> {
-  String _timeFilter = 'Last 30 days'; // §30.6/§30.11 default
+  String _timeFilter = 'This Month'; // §30.6/§30.11 default
+
+  /// Period labels this viewer may choose (§19.2/§30.11 — roles below Manager
+  /// are capped to Today/This Week/This Month).
+  List<String> get _periodOptions =>
+      datePeriodLabelsForRole(managerUp: isManagerOrAbove(ref));
+
+  /// [_timeFilter] clamped into [_periodOptions], so the active chip and the
+  /// log filter agree for capped viewers.
+  String get _effectivePeriod => _periodOptions.contains(_timeFilter)
+      ? _timeFilter
+      : _periodOptions.last;
   Color get _bg => Theme.of(context).scaffoldBackgroundColor;
   Color get _surface => Theme.of(context).colorScheme.surface;
   Color get _cardBg => Theme.of(context).cardColor;
@@ -253,12 +264,12 @@ class _SupplierDetailScreenState extends ConsumerState<SupplierDetailScreen> {
   }
 
   Widget _buildFilterTabs(BuildContext context) {
-    const filters = kDatePeriodLabels;
+    final filters = _periodOptions;
     return SingleChildScrollView(
       scrollDirection: Axis.horizontal,
       child: Row(
         children: filters.map((f) {
-          final active = _timeFilter == f;
+          final active = _effectivePeriod == f;
           return Padding(
             padding: EdgeInsets.only(right: context.getRSize(8)),
             child: GestureDetector(
@@ -296,7 +307,7 @@ class _SupplierDetailScreenState extends ConsumerState<SupplierDetailScreen> {
     );
     final itemIds = itemsForSupplier.map((e) => e.id).toSet();
 
-    final window = datePeriodFromLabel(_timeFilter);
+    final window = datePeriodFromLabel(_effectivePeriod);
 
     return kInventoryLogs.where((log) {
       if (log.action != 'restock' && log.action != 'new_product') return false;
@@ -339,12 +350,15 @@ class _SupplierDetailScreenState extends ConsumerState<SupplierDetailScreen> {
         Row(
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: [
-            Text(
-              'Goods Received',
-              style: TextStyle(
-                fontSize: context.getRFontSize(16),
-                fontWeight: FontWeight.w800,
-                color: _text,
+            Flexible(
+              child: Text(
+                'Goods Received',
+                overflow: TextOverflow.ellipsis,
+                style: TextStyle(
+                  fontSize: context.getRFontSize(16),
+                  fontWeight: FontWeight.w800,
+                  color: _text,
+                ),
               ),
             ),
             Text(

--- a/lib/features/inventory/widgets/update_product_sheet.dart
+++ b/lib/features/inventory/widgets/update_product_sheet.dart
@@ -79,6 +79,16 @@ class _UpdateProductSheetState extends ConsumerState<UpdateProductSheet> {
       .read(currentUserPermissionsProvider)
       .contains('products.edit_buying_price');
 
+  /// Whether the current role may edit product details/prices (§16.7). This
+  /// editor's primary purpose; re-checked at save time (hard rule #6).
+  bool get _canEditPrice =>
+      ref.read(currentUserPermissionsProvider).contains('products.edit_price');
+
+  /// Whether the current role may add stock to an existing product (§16.7).
+  /// Gates the in-sheet "quantity to add" field and its save branch.
+  bool get _canAddStock =>
+      ref.read(currentUserPermissionsProvider).contains('stock.add');
+
   /// Empty-crate value in kobo, or null when not tracking empties / left blank.
   int? get _emptyCrateValueKobo {
     if (!(_trackEmpties && _unit.toLowerCase() == 'bottle')) return null;
@@ -335,6 +345,14 @@ class _UpdateProductSheetState extends ConsumerState<UpdateProductSheet> {
     final auth = ref.read(authProvider);
     setState(() => _errorMessage = null);
 
+    // Defense-in-depth (hard rule #6): this editor mutates product details, so
+    // bail if `products.edit_price` was revoked while the sheet was open.
+    if (!_canEditPrice) {
+      setState(() =>
+          _errorMessage = 'You no longer have permission to edit products.');
+      return;
+    }
+
     final canEditBuying = _canEditBuying;
     final name = _nameCtrl.text.trim();
     String? missingField;
@@ -429,15 +447,35 @@ class _UpdateProductSheetState extends ConsumerState<UpdateProductSheet> {
         );
       }
 
-      // 3. Add stock if quantity entered
-      if (qtyToAdd > 0) {
-        await db.inventoryDao.adjustStock(
-          widget.product.id,
-          _selectedStore!.id,
-          qtyToAdd,
-          'Restock by ${auth.currentUser?.name ?? 'Unknown'}',
-          auth.currentUser?.id,
-        );
+      // 3. Add stock if a quantity was entered — gated on `stock.add` (hard
+      //    rule #6). A stock keeper's add needs Manager/CEO approval (§16.6.1),
+      //    so route it to a pending request rather than touching inventory.
+      var stockRequested = false;
+      final adding = qtyToAdd > 0 && _canAddStock;
+      if (adding) {
+        final actorName = auth.currentUser?.name ?? 'Unknown';
+        final isStockKeeper =
+            ref.read(currentUserRoleProvider)?.slug == 'stock_keeper';
+        if (isStockKeeper) {
+          await db.stockAdjustmentRequestsDao.requestStockAdjustment(
+            productId: widget.product.id,
+            storeId: _selectedStore!.id,
+            quantityDiff: qtyToAdd,
+            reason: 'Restock by $actorName',
+            summary: '$actorName requested +$qtyToAdd ${widget.product.unit}(s) '
+                'of $name (${_selectedStore!.name})',
+            requestedBy: auth.currentUser?.id,
+          );
+          stockRequested = true;
+        } else {
+          await db.inventoryDao.adjustStock(
+            widget.product.id,
+            _selectedStore!.id,
+            qtyToAdd,
+            'Restock by $actorName',
+            auth.currentUser?.id,
+          );
+        }
       }
 
       // 4. Log the update
@@ -446,7 +484,7 @@ class _UpdateProductSheetState extends ConsumerState<UpdateProductSheet> {
           .logAction(
             'update_product',
             '${auth.currentUser?.name ?? 'Unknown'} updated product: $name'
-                '${qtyToAdd > 0 ? ', added $qtyToAdd units' : ''}',
+                '${adding ? (stockRequested ? ', requested +$qtyToAdd units' : ', added $qtyToAdd units') : ''}',
             productId: widget.product.id,
           );
 
@@ -972,31 +1010,36 @@ class _UpdateProductSheetState extends ConsumerState<UpdateProductSheet> {
                     const SizedBox(height: 16),
 
                     // ── STOCK SECTION ────────────────────────────────────────
-                    Text(
-                      'Stock Management',
-                      style: TextStyle(
-                        fontWeight: FontWeight.bold,
-                        color: textColor,
-                        fontSize: 15,
+                    // Add-stock is gated on `stock.add` (hard rule #6/#7). The
+                    // entry already requires `products.edit_price`, so this
+                    // hides the field when add-stock specifically is revoked.
+                    if (_canAddStock) ...[
+                      Text(
+                        'Stock Management',
+                        style: TextStyle(
+                          fontWeight: FontWeight.bold,
+                          color: textColor,
+                          fontSize: 15,
+                        ),
                       ),
-                    ),
-                    const SizedBox(height: 6),
-                    Text(
-                      'Current total stock: ${widget.totalStock}',
-                      style: TextStyle(fontSize: 13, color: subtext),
-                    ),
-                    const SizedBox(height: 14),
-                    AppInput(
-                      controller: _qtyToAddCtrl,
-                      labelText: 'QUANTITY TO ADD',
-                      hintText: '0',
-                      keyboardType: TextInputType.number,
-                    ),
-                    const SizedBox(height: 4),
-                    Text(
-                      'This amount will be added to the existing stock',
-                      style: TextStyle(fontSize: 11, color: subtext),
-                    ),
+                      const SizedBox(height: 6),
+                      Text(
+                        'Current total stock: ${widget.totalStock}',
+                        style: TextStyle(fontSize: 13, color: subtext),
+                      ),
+                      const SizedBox(height: 14),
+                      AppInput(
+                        controller: _qtyToAddCtrl,
+                        labelText: 'QUANTITY TO ADD',
+                        hintText: '0',
+                        keyboardType: TextInputType.number,
+                      ),
+                      const SizedBox(height: 4),
+                      Text(
+                        'This amount will be added to the existing stock',
+                        style: TextStyle(fontSize: 11, color: subtext),
+                      ),
+                    ],
                     const SizedBox(height: 14),
 
                     // ── STORE ────────────────────────────────────────────

--- a/lib/features/orders/screens/orders_screen.dart
+++ b/lib/features/orders/screens/orders_screen.dart
@@ -405,8 +405,8 @@ class _OrdersScreenState extends ConsumerState<OrdersScreen>
   /// Period options. Roles below Manager are capped at a Month maximum (§19.1);
   /// `managerUp` (Manager-or-above) is exactly that gate.
   List<String> _periodOptions(bool managerUp) {
-    // §30.11 canonical chip set. Lower roles get the three shortest windows.
-    return managerUp ? kDatePeriodLabels : kDatePeriodLabels.sublist(0, 3);
+    // §30.11 canonical chip set. Lower roles get Today/This Week/This Month only.
+    return datePeriodLabelsForRole(managerUp: managerUp);
   }
 
   // ─────────────────────────── TABS ───────────────────────────────────────

--- a/lib/features/payments/screens/payments_screen.dart
+++ b/lib/features/payments/screens/payments_screen.dart
@@ -34,7 +34,18 @@ class PaymentsScreen extends ConsumerStatefulWidget {
 class _PaymentsScreenState extends ConsumerState<PaymentsScreen>
     with SingleTickerProviderStateMixin {
   late TabController _tabController;
-  String _periodFilter = 'Last 30 days'; // §30.6/§30.11 default
+  String _periodFilter = 'This Month'; // §30.6/§30.11 default
+
+  /// Period labels this viewer may choose (§19.2/§30.11 — roles below Manager
+  /// are capped to Today/This Week/This Month).
+  List<String> get _periodOptions =>
+      datePeriodLabelsForRole(managerUp: isManagerOrAbove(ref));
+
+  /// [_periodFilter] clamped into [_periodOptions], so the dropdown value and
+  /// the list filter agree for capped viewers.
+  String get _effectivePeriod => _periodOptions.contains(_periodFilter)
+      ? _periodFilter
+      : _periodOptions.last;
   String _supplierFilter = 'All';
   Color get _bg => Theme.of(context).scaffoldBackgroundColor;
   Color get _surface => Theme.of(context).colorScheme.surface;
@@ -58,6 +69,31 @@ class _PaymentsScreenState extends ConsumerState<PaymentsScreen>
   @override
   Widget build(BuildContext context) {
     ref.watch(currencySymbolProvider); // rebuild money displays when currency changes
+    // §22 access: Supplier Accounts is gated by `suppliers.manage` (CEO + Manager
+    // by default; independently revocable per staff via override). The drawer
+    // entry is already gated, but guard the screen too (CLAUDE.md coding rule #1)
+    // so a programmatic tab switch can't bypass it — and so a per-user override
+    // takes effect. Fail CLOSED: `perms` is empty while grants load → show a
+    // spinner rather than flashing no-access for a legitimate user.
+    final perms = ref.watch(currentUserPermissionsProvider);
+    if (!perms.contains('suppliers.manage')) {
+      return Scaffold(
+        backgroundColor: _bg,
+        drawer: const AppDrawer(activeRoute: 'supplier_accounts'),
+        appBar: _buildAppBar(context),
+        body: Center(
+          child: perms.isEmpty
+              ? const CircularProgressIndicator()
+              : Text(
+                  'You don’t have access to Supplier Accounts.',
+                  style: TextStyle(
+                    color: _subtext,
+                    fontSize: context.getRFontSize(14),
+                  ),
+                ),
+        ),
+      );
+    }
     return Scaffold(
           backgroundColor: _bg,
           drawer: const AppDrawer(activeRoute: 'supplier_accounts'),
@@ -225,9 +261,9 @@ class _PaymentsScreenState extends ConsumerState<PaymentsScreen>
             ],
           ),
             AppDropdown<String>(
-              value: _periodFilter,
+              value: _effectivePeriod,
               width: context.getRSize(130),
-              items: kDatePeriodLabels.map((String val) {
+              items: _periodOptions.map((String val) {
                 return DropdownMenuItem<String>(value: val, child: Text(val));
               }).toList(),
               onChanged: (val) {
@@ -313,7 +349,7 @@ class _PaymentsScreenState extends ConsumerState<PaymentsScreen>
     return Builder(
       builder: (context) {
         final paymentSvc = ref.watch(paymentServiceProvider);
-        final periodPayments = paymentSvc.getByPeriod(_periodFilter);
+        final periodPayments = paymentSvc.getByPeriod(_effectivePeriod);
 
         // Compute unique suppliers for chips
         final Set<String> supplierNames = {};

--- a/lib/features/pos/screens/cart_screen.dart
+++ b/lib/features/pos/screens/cart_screen.dart
@@ -366,32 +366,39 @@ class _CartScreenState extends ConsumerState<CartScreen>
                                 Row(
                                   mainAxisSize: MainAxisSize.min,
                                   children: [
-                                    AppButton(
-                                      text: 'New',
-                                      variant: AppButtonVariant.secondary,
-                                      isFullWidth: false,
-                                      height: modalCtx.getRSize(36),
-                                      icon: FontAwesomeIcons.userPlus,
-                                      onPressed: () {
-                                        Navigator.pop(modalCtx);
-                                        AddCustomerSheet.show(
-                                          context,
-                                          onCustomerAdded: (newCustomer) {
-                                            setState(
-                                              () =>
-                                                  _activeCustomer = newCustomer,
-                                            );
-                                            widget.onCustomerChanged(
-                                              newCustomer,
-                                            );
-                                            ref
-                                                .read(cartProvider)
-                                                .setActiveCustomer(newCustomer);
-                                          },
-                                        );
-                                      },
-                                    ),
-                                    SizedBox(width: modalCtx.getRSize(8)),
+                                    // Creating a customer needs `customers.add`
+                                    // (hard rule #6/#7) — hide "New" otherwise.
+                                    // The AddCustomerSheet save handler re-checks
+                                    // the same key at the write boundary.
+                                    if (hasPermission(ref, 'customers.add')) ...[
+                                      AppButton(
+                                        text: 'New',
+                                        variant: AppButtonVariant.secondary,
+                                        isFullWidth: false,
+                                        height: modalCtx.getRSize(36),
+                                        icon: FontAwesomeIcons.userPlus,
+                                        onPressed: () {
+                                          Navigator.pop(modalCtx);
+                                          AddCustomerSheet.show(
+                                            context,
+                                            onCustomerAdded: (newCustomer) {
+                                              setState(
+                                                () => _activeCustomer =
+                                                    newCustomer,
+                                              );
+                                              widget.onCustomerChanged(
+                                                newCustomer,
+                                              );
+                                              ref
+                                                  .read(cartProvider)
+                                                  .setActiveCustomer(
+                                                      newCustomer);
+                                            },
+                                          );
+                                        },
+                                      ),
+                                      SizedBox(width: modalCtx.getRSize(8)),
+                                    ],
                                     IconButton(
                                       onPressed: () => Navigator.pop(modalCtx),
                                       icon: Icon(Icons.close, color: _subtext),
@@ -1488,7 +1495,8 @@ class _CartScreenState extends ConsumerState<CartScreen>
                                                       MainAxisAlignment
                                                           .spaceBetween,
                                                   children: [
-                                                    Row(
+                                                    Expanded(
+                                                      child: Row(
                                                       children: [
                                                         Container(
                                                           width: context
@@ -1507,8 +1515,10 @@ class _CartScreenState extends ConsumerState<CartScreen>
                                                           width: context
                                                               .getRSize(8),
                                                         ),
-                                                        Text(
+                                                        Flexible(
+                                                          child: Text(
                                                           '${line.label}  ×${line.qty.toStringAsFixed(1)}',
+                                                          overflow: TextOverflow.ellipsis,
                                                           style: TextStyle(
                                                             fontSize: context
                                                                 .getRFontSize(
@@ -1519,7 +1529,9 @@ class _CartScreenState extends ConsumerState<CartScreen>
                                                             color: _subtext,
                                                           ),
                                                         ),
+                                                        ),
                                                       ],
+                                                    ),
                                                     ),
                                                     Text(
                                                       formatCurrency(

--- a/lib/features/pos/screens/pos_home_screen.dart
+++ b/lib/features/pos/screens/pos_home_screen.dart
@@ -384,8 +384,10 @@ class _PosHomeScreenState extends ConsumerState<PosHomeScreen> {
   /// The POS Opening-Cash block (§23.4 / hard rule #10). Manager/CEO can tap
   /// through to the Funds Register Open Day; Cashier is told to wait.
   Widget _buildDayNotOpenBlock(BuildContext context) {
-    final slug = ref.watch(currentUserRoleProvider)?.slug;
-    final canOpen = slug == 'ceo' || slug == 'manager';
+    // Tap-through to Open Day is gated on the `funds.open_day` permission (hard
+    // rule #6), not the role slug — so a CEO-revoked Manager is told to wait,
+    // consistent with the Funds Register form.
+    final canOpen = hasPermission(ref, 'funds.open_day');
     final theme = Theme.of(context);
     final onSurface = theme.colorScheme.onSurface;
 
@@ -455,6 +457,9 @@ class _PosHomeScreenState extends ConsumerState<PosHomeScreen> {
             : totalQty.toStringAsFixed(1);
 
         return AppFAB(
+          // POS is a bottom-nav tab root — the visible bottom bar already lifts
+          // the FAB above the system nav; don't add the inset.
+          reserveBottomInset: false,
           onPressed: () {
             ref.read(navigationProvider).setIndex(8); // 8 = CartScreen (9 is Deliveries)
           },
@@ -658,7 +663,9 @@ class _PosHomeScreenState extends ConsumerState<PosHomeScreen> {
               Flexible(
                 child: GridView.builder(
                   shrinkWrap: true,
-                  physics: const NeverScrollableScrollPhysics(),
+                  // Scrolls within the sheet when there are more stores than
+                  // fit — otherwise the fixed grid overflows the bottom.
+                  physics: const ClampingScrollPhysics(),
                   gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
                     crossAxisCount: 2,
                     crossAxisSpacing: 16,

--- a/lib/features/pos/widgets/edit_item_modal.dart
+++ b/lib/features/pos/widgets/edit_item_modal.dart
@@ -222,12 +222,6 @@ class _EditItemModalState extends ConsumerState<EditItemModal> {
     }
 
     return Container(
-      padding: EdgeInsets.fromLTRB(
-        context.getRSize(24),
-        context.getRSize(16),
-        context.getRSize(24),
-        context.deviceBottomInset + context.getRSize(24),
-      ),
       decoration: BoxDecoration(
         color: t.colorScheme.surface,
         borderRadius: const BorderRadius.vertical(top: Radius.circular(32)),
@@ -239,7 +233,17 @@ class _EditItemModalState extends ConsumerState<EditItemModal> {
           ),
         ],
       ),
-      child: Column(
+      // Scrolls so the fixed-height content never overflows when the keyboard
+      // shrinks the sheet. Bottom padding (incl. keyboard via deviceBottomInset)
+      // lives on the scroll view so the last field can clear the keyboard.
+      child: SingleChildScrollView(
+        padding: EdgeInsets.fromLTRB(
+          context.getRSize(24),
+          context.getRSize(16),
+          context.getRSize(24),
+          context.deviceBottomInset + context.getRSize(24),
+        ),
+        child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
           // Drag Handle
@@ -525,6 +529,7 @@ class _EditItemModalState extends ConsumerState<EditItemModal> {
               ],
             ),
         ],
+      ),
       ),
     );
   }

--- a/lib/features/pos/widgets/quick_sale_modal.dart
+++ b/lib/features/pos/widgets/quick_sale_modal.dart
@@ -51,7 +51,10 @@ class _QuickSaleModalState extends ConsumerState<QuickSaleModal> {
         'Quick Sale ⚡',
         style: TextStyle(color: widget.textCol, fontWeight: FontWeight.bold),
       ),
-      content: Column(
+      // Scrolls so the three fields + actions never overflow the dialog when
+      // the keyboard shrinks the available height on small screens.
+      content: SingleChildScrollView(
+        child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
           AppInput(
@@ -82,6 +85,7 @@ class _QuickSaleModalState extends ConsumerState<QuickSaleModal> {
             inputFormatters: [CurrencyInputFormatter()],
           ),
         ],
+      ),
       ),
       actions: [
         AppButton(

--- a/lib/features/staff/screens/staff_detail_screen.dart
+++ b/lib/features/staff/screens/staff_detail_screen.dart
@@ -10,6 +10,7 @@ import 'package:reebaplus_pos/core/providers/stream_providers.dart';
 import 'package:reebaplus_pos/core/utils/notifications.dart';
 import 'package:reebaplus_pos/core/utils/number_format.dart';
 import 'package:reebaplus_pos/core/utils/responsive.dart';
+import 'package:reebaplus_pos/features/staff/screens/staff_permissions_screen.dart';
 import 'package:reebaplus_pos/shared/utils/role_display.dart';
 import 'package:reebaplus_pos/shared/widgets/app_button.dart';
 
@@ -314,13 +315,14 @@ class _StaffDetailScreenState extends ConsumerState<StaffDetailScreen> {
                           .format(membership.lastLoginAt!),
                 ),
                 // Permission access (§10.2.1) — only a permissions manager sees
-                // it, and never on the own (read-only) card. User-scope
-                // overrides are a Phase-1 placeholder; this person currently
-                // uses their role's permissions.
+                // it, and never on the own (read-only) card. Opens the per-user
+                // override editor; this person inherits their role's
+                // permissions until the CEO overrides specific ones.
                 if (!widget.readOnly &&
+                    role != null &&
                     hasPermission(ref, 'settings.manage')) ...[
                   SizedBox(height: context.getRSize(4)),
-                  _PermissionAccessCard(roleName: role?.name ?? 'their'),
+                  _PermissionAccessCard(user: user, role: role),
                 ],
                 // Manage actions — hidden in view-only (own card). Each action
                 // has its OWN permission (§9): Change role -> staff.change_role,
@@ -440,19 +442,44 @@ class _InfoRow extends StatelessWidget {
   }
 }
 
-/// Per-user permission scope (§10.2.1). This member uses their role's
-/// permissions today; a per-person override is a Phase-1 placeholder, disabled
-/// until multi-store ships. Nothing is stored or enforced here yet.
-class _PermissionAccessCard extends StatelessWidget {
-  final String roleName;
-  const _PermissionAccessCard({required this.roleName});
+/// Per-user permission scope (§10.2.1). This member inherits their role's
+/// permissions; the CEO can override specific ones from here. The CEO target
+/// is never overridable (full access), so it shows a static note instead of an
+/// editor entry.
+class _PermissionAccessCard extends ConsumerWidget {
+  final UserData user;
+  final RoleData role;
+  const _PermissionAccessCard({required this.user, required this.role});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final t = Theme.of(context);
-    final text = t.colorScheme.onSurface;
     final subtext = t.textTheme.bodySmall?.color ?? t.iconTheme.color!;
-    return Container(
+    final isCeo = role.slug == 'ceo';
+    final overrideCount = isCeo
+        ? 0
+        : (ref.watch(userPermissionOverridesProvider(user.id)).valueOrNull ??
+                const [])
+            .length;
+
+    // One clean line, matching the info rows above (icon · label · state ·
+    // chevron). CEO is full-access and not tappable; everyone else shows
+    // whether they inherit the role or carry overrides, and taps through to the
+    // per-user editor (§10.2.1).
+    final String state;
+    final Color stateColor;
+    if (isCeo) {
+      state = 'Full access';
+      stateColor = subtext;
+    } else if (overrideCount == 0) {
+      state = 'Role default';
+      stateColor = subtext;
+    } else {
+      state = '$overrideCount override${overrideCount == 1 ? '' : 's'}';
+      stateColor = t.colorScheme.primary;
+    }
+
+    final row = Container(
       margin: EdgeInsets.only(bottom: context.getRSize(10)),
       padding: EdgeInsets.all(context.getRSize(14)),
       decoration: BoxDecoration(
@@ -460,71 +487,53 @@ class _PermissionAccessCard extends StatelessWidget {
         borderRadius: BorderRadius.circular(14),
         border: Border.all(color: t.dividerColor),
       ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
+      child: Row(
         children: [
-          Row(
-            children: [
-              Icon(FontAwesomeIcons.userShield,
-                  size: context.getRSize(15), color: subtext),
-              SizedBox(width: context.getRSize(12)),
-              Text(
-                'Permission access',
-                style: TextStyle(
-                  color: subtext,
-                  fontSize: context.getRFontSize(13),
-                  fontWeight: FontWeight.w600,
-                ),
-              ),
-            ],
-          ),
-          SizedBox(height: context.getRSize(10)),
+          Icon(FontAwesomeIcons.userShield,
+              size: context.getRSize(15), color: subtext),
+          SizedBox(width: context.getRSize(12)),
           Text(
-            'Uses the $roleName role’s permissions, set in Roles & Permissions.',
+            'Permission access',
             style: TextStyle(
-              color: text,
+              color: subtext,
               fontSize: context.getRFontSize(13),
-              height: 1.4,
+              fontWeight: FontWeight.w600,
             ),
           ),
-          SizedBox(height: context.getRSize(12)),
-          // Per-user override — disabled placeholder (§10.2.1).
-          Opacity(
-            opacity: 0.5,
-            child: Row(
-              children: [
-                Icon(FontAwesomeIcons.sliders,
-                    size: context.getRSize(14), color: subtext),
-                SizedBox(width: context.getRSize(10)),
-                Expanded(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text(
-                        'Customize this staff’s permissions',
-                        style: TextStyle(
-                          color: text,
-                          fontSize: context.getRFontSize(13),
-                          fontWeight: FontWeight.w600,
-                        ),
-                      ),
-                      SizedBox(height: context.getRSize(2)),
-                      Text(
-                        'Coming with multi-store',
-                        style: TextStyle(
-                          color: subtext,
-                          fontSize: context.getRFontSize(11),
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-                Icon(Icons.lock_outline,
-                    size: context.getRSize(15), color: subtext),
-              ],
+          const Spacer(),
+          Flexible(
+            child: Text(
+              state,
+              textAlign: TextAlign.right,
+              style: TextStyle(
+                color: stateColor,
+                fontSize: context.getRFontSize(14),
+                fontWeight: FontWeight.bold,
+              ),
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
             ),
           ),
+          if (!isCeo) ...[
+            SizedBox(width: context.getRSize(6)),
+            Icon(Icons.chevron_right,
+                size: context.getRSize(18), color: subtext),
+          ],
         ],
+      ),
+    );
+
+    if (isCeo) return row;
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        borderRadius: BorderRadius.circular(14),
+        onTap: () => Navigator.of(context).push(
+          MaterialPageRoute(
+            builder: (_) => StaffPermissionsScreen(user: user, role: role),
+          ),
+        ),
+        child: row,
       ),
     );
   }

--- a/lib/features/staff/screens/staff_detail_screen.dart
+++ b/lib/features/staff/screens/staff_detail_screen.dart
@@ -313,6 +313,15 @@ class _StaffDetailScreenState extends ConsumerState<StaffDetailScreen> {
                       : DateFormat('MMM d, y • h:mm a')
                           .format(membership.lastLoginAt!),
                 ),
+                // Permission access (§10.2.1) — only a permissions manager sees
+                // it, and never on the own (read-only) card. User-scope
+                // overrides are a Phase-1 placeholder; this person currently
+                // uses their role's permissions.
+                if (!widget.readOnly &&
+                    hasPermission(ref, 'settings.manage')) ...[
+                  SizedBox(height: context.getRSize(4)),
+                  _PermissionAccessCard(roleName: role?.name ?? 'their'),
+                ],
                 // Manage actions — hidden in view-only (own card). Each action
                 // has its OWN permission (§9): Change role -> staff.change_role,
                 // Suspend/Reactivate -> staff.suspend (both CEO + Manager by
@@ -423,6 +432,96 @@ class _InfoRow extends StatelessWidget {
               ),
               maxLines: 1,
               overflow: TextOverflow.ellipsis,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Per-user permission scope (§10.2.1). This member uses their role's
+/// permissions today; a per-person override is a Phase-1 placeholder, disabled
+/// until multi-store ships. Nothing is stored or enforced here yet.
+class _PermissionAccessCard extends StatelessWidget {
+  final String roleName;
+  const _PermissionAccessCard({required this.roleName});
+
+  @override
+  Widget build(BuildContext context) {
+    final t = Theme.of(context);
+    final text = t.colorScheme.onSurface;
+    final subtext = t.textTheme.bodySmall?.color ?? t.iconTheme.color!;
+    return Container(
+      margin: EdgeInsets.only(bottom: context.getRSize(10)),
+      padding: EdgeInsets.all(context.getRSize(14)),
+      decoration: BoxDecoration(
+        color: t.cardColor,
+        borderRadius: BorderRadius.circular(14),
+        border: Border.all(color: t.dividerColor),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Icon(FontAwesomeIcons.userShield,
+                  size: context.getRSize(15), color: subtext),
+              SizedBox(width: context.getRSize(12)),
+              Text(
+                'Permission access',
+                style: TextStyle(
+                  color: subtext,
+                  fontSize: context.getRFontSize(13),
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ],
+          ),
+          SizedBox(height: context.getRSize(10)),
+          Text(
+            'Uses the $roleName role’s permissions, set in Roles & Permissions.',
+            style: TextStyle(
+              color: text,
+              fontSize: context.getRFontSize(13),
+              height: 1.4,
+            ),
+          ),
+          SizedBox(height: context.getRSize(12)),
+          // Per-user override — disabled placeholder (§10.2.1).
+          Opacity(
+            opacity: 0.5,
+            child: Row(
+              children: [
+                Icon(FontAwesomeIcons.sliders,
+                    size: context.getRSize(14), color: subtext),
+                SizedBox(width: context.getRSize(10)),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        'Customize this staff’s permissions',
+                        style: TextStyle(
+                          color: text,
+                          fontSize: context.getRFontSize(13),
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                      SizedBox(height: context.getRSize(2)),
+                      Text(
+                        'Coming with multi-store',
+                        style: TextStyle(
+                          color: subtext,
+                          fontSize: context.getRFontSize(11),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                Icon(Icons.lock_outline,
+                    size: context.getRSize(15), color: subtext),
+              ],
             ),
           ),
         ],

--- a/lib/features/staff/screens/staff_management_screen.dart
+++ b/lib/features/staff/screens/staff_management_screen.dart
@@ -72,6 +72,45 @@ class _StaffManagementScreenState extends ConsumerState<StaffManagementScreen>
 
   @override
   Widget build(BuildContext context) {
+    // §9 access: Staff Management is gated by `staff.invite` (CEO + Manager by
+    // default; revocable per staff via override). The drawer entry is already
+    // permission-gated (hard rule #7), but guard the screen too (coding rule #1)
+    // so an alternate/stale entry can't bypass it and a per-user override takes
+    // effect. The FAB below builds only past this gate. Fail CLOSED: `perms` is
+    // empty while grants load → spinner, not a flash of no-access.
+    final perms = ref.watch(currentUserPermissionsProvider);
+    if (!perms.contains('staff.invite')) {
+      return Scaffold(
+        backgroundColor: Theme.of(context).scaffoldBackgroundColor,
+        appBar: AppBar(
+          backgroundColor: _surface,
+          elevation: 0,
+          leading: IconButton(
+            icon: Icon(Icons.arrow_back_ios_new, color: _text, size: 20),
+            onPressed: () => Navigator.pop(context),
+          ),
+          title: Text(
+            'Staff',
+            style: TextStyle(
+              color: _text,
+              fontSize: context.getRFontSize(16),
+              fontWeight: FontWeight.w800,
+            ),
+          ),
+        ),
+        body: Center(
+          child: perms.isEmpty
+              ? const CircularProgressIndicator()
+              : Text(
+                  'You don’t have access to Staff Management.',
+                  style: TextStyle(
+                    color: _subtext,
+                    fontSize: context.getRFontSize(14),
+                  ),
+                ),
+        ),
+      );
+    }
     return Scaffold(
       backgroundColor: Theme.of(context).scaffoldBackgroundColor,
       appBar: _buildAppBar(context),

--- a/lib/features/staff/screens/staff_permissions_screen.dart
+++ b/lib/features/staff/screens/staff_permissions_screen.dart
@@ -1,0 +1,358 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+
+import 'package:reebaplus_pos/core/database/app_database.dart';
+import 'package:reebaplus_pos/core/permissions/permission_dependencies.dart';
+import 'package:reebaplus_pos/core/providers/app_providers.dart';
+import 'package:reebaplus_pos/core/providers/stream_providers.dart';
+import 'package:reebaplus_pos/core/settings/role_permissions_detail_screen.dart'
+    show kHiddenPermissionKeys;
+import 'package:reebaplus_pos/core/settings/settings_widgets.dart';
+import 'package:reebaplus_pos/core/theme/app_decorations.dart';
+import 'package:reebaplus_pos/core/utils/notifications.dart';
+import 'package:reebaplus_pos/core/utils/responsive.dart';
+import 'package:reebaplus_pos/shared/widgets/app_button.dart';
+
+/// Permission categories in master-plan order (mirrors the per-role screen).
+/// `allPermissionsProvider` returns them alphabetically, so the order is
+/// imposed here; unknown categories fall to the end.
+const _categoryOrder = [
+  'Stores',
+  'Sales',
+  'Products',
+  'Stock',
+  'Expenses',
+  'Reports',
+  'Customers',
+  'Suppliers',
+  'Staff',
+  'System',
+  'Funds',
+];
+
+/// Per-staff permission overrides (master plan §10.2.1). Reached from a staff
+/// member's profile (Staff Management → staff → Permission access → Customize).
+/// Each toggle shows the **effective** value (the role default, unless this
+/// person has an override); flipping it away from the role default stores an
+/// override, flipping it back clears the override (inherit). The CEO is never
+/// overridable (locked all-on, read-only).
+class StaffPermissionsScreen extends ConsumerStatefulWidget {
+  final UserData user;
+  final RoleData role;
+  const StaffPermissionsScreen({
+    super.key,
+    required this.user,
+    required this.role,
+  });
+
+  @override
+  ConsumerState<StaffPermissionsScreen> createState() =>
+      _StaffPermissionsScreenState();
+}
+
+class _StaffPermissionsScreenState
+    extends ConsumerState<StaffPermissionsScreen> {
+  late final AppDatabase _db = ref.read(databaseProvider);
+
+  UserData get user => widget.user;
+  RoleData get role => widget.role;
+  bool get _isCeo => role.slug == 'ceo';
+
+  /// Re-check the manage permission at write time (mirrors the per-role screen).
+  bool _guard() {
+    if (!ref.read(currentUserPermissionsProvider).contains('settings.manage')) {
+      AppNotification.showError(
+          context, 'You don\'t have permission to do that.');
+      return false;
+    }
+    return true;
+  }
+
+  /// Force [key] to [target] for this user. Stores an override only when
+  /// [target] differs from the role default; when they match, the override is
+  /// cleared so the permission inherits the role again.
+  Future<void> _setEffective(String key, bool target, bool roleDefault) async {
+    await _db.userPermissionOverridesDao
+        .setOverride(user.id, key, target == roleDefault ? null : target);
+  }
+
+  Future<void> _toggle(
+    String key,
+    bool enable,
+    Set<String> roleDefaults,
+    Set<String> effective,
+  ) async {
+    if (!_guard()) return;
+    bool roleDefaultOf(String k) => roleDefaults.contains(k);
+
+    if (enable) {
+      await _setEffective(key, true, roleDefaultOf(key));
+      await _db.activityLogDao.log(
+        action: 'settings.user_permission.override',
+        description: 'Granted "$key" for ${user.name} (override)',
+        staffId: _db.currentUserId,
+      );
+      return;
+    }
+
+    // Turning a permission off also forces off any effectively-granted
+    // permission that depends on it (§10.2.1 dependency gating) — a child can't
+    // stay on once its parent is off. Mirrors the per-role cascade.
+    final cascaded =
+        descendantsOf(key).where(effective.contains).toList()..sort();
+    await _setEffective(key, false, roleDefaultOf(key));
+    for (final dep in cascaded) {
+      await _setEffective(dep, false, roleDefaultOf(dep));
+    }
+    final suffix =
+        cascaded.isEmpty ? '' : ' (also revoked: ${cascaded.join(', ')})';
+    await _db.activityLogDao.log(
+      action: 'settings.user_permission.override',
+      description: 'Revoked "$key" for ${user.name} (override)$suffix',
+      staffId: _db.currentUserId,
+    );
+  }
+
+  /// Restore defaults — clear every override for this staff member so all
+  /// permissions revert to their role's defaults. Confirmed first (a two-step
+  /// gate so a stray tap can't wipe overrides), then re-guarded after the await.
+  Future<void> _restoreDefaults(int overrideCount) async {
+    if (!_guard()) return;
+    final t = Theme.of(context);
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        backgroundColor: t.colorScheme.surface,
+        title: const Text('Restore defaults?'),
+        content: Text(
+          'This removes all $overrideCount custom permission '
+          'override${overrideCount == 1 ? '' : 's'} for ${user.name} and '
+          'returns them to the ${role.name} role defaults.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, false),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            style: TextButton.styleFrom(foregroundColor: t.colorScheme.error),
+            child: const Text('Restore'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true) return;
+    if (!_guard()) return; // re-check after the await (permission may have changed)
+
+    final cleared =
+        await _db.userPermissionOverridesDao.clearAllForUser(user.id);
+    await _db.activityLogDao.log(
+      action: 'settings.user_permission.restore_defaults',
+      description: 'Restored ${role.name} defaults for ${user.name} '
+          '(cleared $cleared override${cleared == 1 ? '' : 's'})',
+      staffId: _db.currentUserId,
+    );
+    if (mounted) {
+      AppNotification.showSuccess(
+          context, 'Restored ${role.name} defaults for ${user.name}.');
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final t = Theme.of(context);
+    final canManage = hasPermission(ref, 'settings.manage');
+
+    return Scaffold(
+      backgroundColor: t.scaffoldBackgroundColor,
+      appBar: AppBar(
+        title: Text(
+          user.name,
+          style: const TextStyle(fontWeight: FontWeight.bold),
+        ),
+        backgroundColor: Colors.transparent,
+        elevation: 0,
+        centerTitle: true,
+      ),
+      body: !canManage
+          ? const SettingsNoAccess()
+          : ref.watch(allPermissionsProvider).when(
+                loading: () => const SizedBox.shrink(),
+                error: (_, __) => Center(
+                  child: Text(
+                    'Couldn\'t load permissions.',
+                    style: TextStyle(
+                      color: t.colorScheme.onSurface.withValues(alpha: 0.6),
+                    ),
+                  ),
+                ),
+                data: (perms) => _buildBody(t, perms),
+              ),
+    );
+  }
+
+  Widget _buildBody(ThemeData t, List<PermissionData> permsRaw) {
+    final perms = permsRaw
+        .where((p) => !kHiddenPermissionKeys.contains(p.key))
+        .toList();
+
+    // Role default grants for this person's role.
+    final roleDefaults =
+        (ref.watch(rolePermissionsProvider(role.id)).valueOrNull ??
+                const <RolePermissionData>[])
+            .map((g) => g.permissionKey)
+            .toSet();
+
+    // This person's overrides, keyed for lookup.
+    final overrides =
+        ref.watch(userPermissionOverridesProvider(user.id)).valueOrNull ??
+            const <UserPermissionOverrideData>[];
+    final overrideByKey = {for (final o in overrides) o.permissionKey: o};
+
+    // Effective set = role defaults ± overrides (same as the runtime resolver).
+    final effective = roleDefaults.toSet();
+    for (final o in overrides) {
+      if (o.isGranted) {
+        effective.add(o.permissionKey);
+      } else {
+        effective.remove(o.permissionKey);
+      }
+    }
+
+    final byKey = {for (final p in perms) p.key: p};
+
+    // Group by category in master-plan order; append any unknown categories.
+    final groups = <String, List<PermissionData>>{};
+    for (final cat in _categoryOrder) {
+      final items = perms.where((p) => p.category == cat).toList();
+      if (items.isNotEmpty) groups[cat] = items;
+    }
+    for (final p in perms) {
+      if (!_categoryOrder.contains(p.category)) {
+        groups.putIfAbsent(p.category, () => []).add(p);
+      }
+    }
+
+    return SettingsFadeIn(
+      child: ListView(
+        padding:
+            EdgeInsets.fromLTRB(24, 24, 24, 24 + context.deviceBottomInset),
+        children: [
+          Text(
+            _isCeo
+                ? 'The CEO always has full access — these can\'t be changed.'
+                : 'Overrides the ${role.name} role defaults for ${user.name}. '
+                    'Flip a toggle to override; flip it back to the role default '
+                    'to inherit again.',
+            style: TextStyle(
+              fontSize: 13,
+              height: 1.4,
+              color: t.colorScheme.onSurface.withValues(alpha: 0.6),
+            ),
+          ),
+          const SizedBox(height: 20),
+          for (final entry in groups.entries) ...[
+            SettingsSectionTitle(entry.key),
+            const SizedBox(height: 8),
+            _permissionGroupCard(
+                t, entry.value, roleDefaults, effective, overrideByKey, byKey),
+            const SizedBox(height: 20),
+          ],
+          if (!_isCeo) ...[
+            const SizedBox(height: 4),
+            AppButton(
+              text: 'Restore defaults',
+              icon: FontAwesomeIcons.arrowRotateLeft,
+              variant: AppButtonVariant.outline,
+              onPressed: overrides.isEmpty
+                  ? null
+                  : () => _restoreDefaults(overrides.length),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              overrides.isEmpty
+                  ? '${user.name} is already on the ${role.name} defaults.'
+                  : 'Clears all ${overrides.length} '
+                      'override${overrides.length == 1 ? '' : 's'} and returns '
+                      '${user.name} to the ${role.name} defaults.',
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                fontSize: 12,
+                color: t.colorScheme.onSurface.withValues(alpha: 0.5),
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  Widget _permissionGroupCard(
+    ThemeData t,
+    List<PermissionData> perms,
+    Set<String> roleDefaults,
+    Set<String> effective,
+    Map<String, UserPermissionOverrideData> overrideByKey,
+    Map<String, PermissionData> byKey,
+  ) {
+    return Container(
+      decoration: AppDecorations.glassCard(context, radius: 16),
+      child: Column(
+        children: [
+          for (final perm in perms)
+            () {
+              final parent = parentOf(perm.key);
+              final parentOff = !_isCeo &&
+                  parent != null &&
+                  !effective.contains(parent);
+              final isOverridden = overrideByKey.containsKey(perm.key);
+              final roleDefault = roleDefaults.contains(perm.key);
+
+              String? subtitle;
+              if (parentOff) {
+                subtitle =
+                    'Requires "${byKey[parent]?.description ?? parent}"';
+              } else if (!_isCeo && isOverridden) {
+                subtitle =
+                    'Overridden — role default is ${roleDefault ? 'on' : 'off'}';
+              }
+
+              return SwitchListTile(
+                title: Text(
+                  perm.description,
+                  style: TextStyle(
+                    fontSize: 14,
+                    color: t.colorScheme.onSurface,
+                  ),
+                ),
+                subtitle: subtitle == null
+                    ? null
+                    : Text(
+                        subtitle,
+                        style: TextStyle(
+                          fontSize: 12,
+                          color: t.colorScheme.onSurface.withValues(
+                            alpha: parentOff ? 0.5 : 0.7,
+                          ),
+                          fontWeight: (!parentOff && !_isCeo && isOverridden)
+                              ? FontWeight.w600
+                              : FontWeight.normal,
+                        ),
+                      ),
+                value: _isCeo
+                    ? true
+                    : !parentOff && effective.contains(perm.key),
+                onChanged: (_isCeo || parentOff)
+                    ? null
+                    : (v) => _toggle(perm.key, v, roleDefaults, effective),
+                activeThumbColor: t.colorScheme.primary,
+                contentPadding: const EdgeInsets.symmetric(horizontal: 16),
+              );
+            }(),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/staff/widgets/invite_staff_sheet.dart
+++ b/lib/features/staff/widgets/invite_staff_sheet.dart
@@ -182,15 +182,15 @@ class _InviteStaffSheetState extends ConsumerState<InviteStaffSheet> {
     final surface = t.colorScheme.surface;
     final text = t.colorScheme.onSurface;
 
-    return Padding(
-      padding: EdgeInsets.only(
-        bottom: MediaQuery.of(context).viewInsets.bottom,
+    // deviceBottomInset already includes the keyboard inset (and works under
+    // MainLayout, unlike MediaQuery.viewInsets.bottom which reads 0 here), so a
+    // single SingleChildScrollView handles both keyboard avoidance and overflow.
+    return Container(
+      decoration: BoxDecoration(
+        color: surface,
+        borderRadius: const BorderRadius.vertical(top: Radius.circular(24)),
       ),
-      child: Container(
-        decoration: BoxDecoration(
-          color: surface,
-          borderRadius: const BorderRadius.vertical(top: Radius.circular(24)),
-        ),
+      child: SingleChildScrollView(
         padding: EdgeInsets.fromLTRB(
           context.getRSize(20),
           context.getRSize(16),

--- a/lib/features/staff/widgets/invite_staff_sheet.dart
+++ b/lib/features/staff/widgets/invite_staff_sheet.dart
@@ -76,6 +76,14 @@ class _InviteStaffSheetState extends ConsumerState<InviteStaffSheet> {
 
   Future<void> _generate() async {
     if (!_formKey.currentState!.validate()) return;
+    // Write-boundary re-check (§10.2.1): the screen + drawer entry are gated on
+    // `staff.invite`, but re-check the effective permission before writing the
+    // invite so a revoked per-user override is honored at the action too.
+    if (!ref.read(currentUserPermissionsProvider).contains('staff.invite')) {
+      AppNotification.showError(
+          context, 'You don\'t have permission to do that.');
+      return;
+    }
     if (_roleId == null || _storeId == null) {
       AppNotification.showError(context, 'Pick a role and a store.');
       return;

--- a/lib/features/stores/screens/stock_transfer_screen.dart
+++ b/lib/features/stores/screens/stock_transfer_screen.dart
@@ -5,6 +5,7 @@ import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:reebaplus_pos/core/utils/responsive.dart';
 import 'package:reebaplus_pos/core/utils/number_format.dart';
 import 'package:reebaplus_pos/core/providers/app_providers.dart';
+import 'package:reebaplus_pos/core/providers/stream_providers.dart';
 import 'package:reebaplus_pos/features/inventory/data/inventory_data.dart';
 import 'package:reebaplus_pos/features/inventory/data/models/inventory_item.dart';
 import 'package:reebaplus_pos/features/inventory/data/models/inventory_log.dart';
@@ -58,6 +59,11 @@ class _StockTransferScreenState extends ConsumerState<StockTransferScreen> {
   }
 
   Future<void> _submit() async {
+    // Re-check at the write boundary (hard rule #6): stock transfer is reached
+    // from the CEO-only Stores tab, so it needs `settings.manage`.
+    if (!ref.read(currentUserPermissionsProvider).contains('settings.manage')) {
+      return;
+    }
     final qty = double.tryParse(_qtyCtrl.text) ?? 0;
 
     if (_sourceStore == null || _destinationStore == null) {

--- a/lib/features/stores/screens/stores_screen.dart
+++ b/lib/features/stores/screens/stores_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:reebaplus_pos/core/providers/app_providers.dart';
+import 'package:reebaplus_pos/core/providers/stream_providers.dart';
 import 'package:reebaplus_pos/core/widgets/app_fab.dart';
 import 'package:reebaplus_pos/shared/widgets/shared_scaffold.dart';
 import 'package:reebaplus_pos/shared/widgets/menu_button.dart';
@@ -189,6 +190,14 @@ class _StoresScreenState extends ConsumerState<StoresScreen> {
                           ? null
                           : () async {
                               if (!formKey.currentState!.validate()) return;
+                              // Re-check at the write boundary (hard rule #6) in
+                              // case `settings.manage` was revoked while the
+                              // sheet was open.
+                              if (!ref
+                                  .read(currentUserPermissionsProvider)
+                                  .contains('settings.manage')) {
+                                return;
+                              }
                               setSheet(() => saving = true);
                               try {
                                 final db = ref.read(databaseProvider);
@@ -364,6 +373,12 @@ class _StoresScreenState extends ConsumerState<StoresScreen> {
                           ? null
                           : () async {
                               if (!formKey.currentState!.validate()) return;
+                              // Re-check at the write boundary (hard rule #6).
+                              if (!ref
+                                  .read(currentUserPermissionsProvider)
+                                  .contains('settings.manage')) {
+                                return;
+                              }
                               setSheet(() => saving = true);
                               final db = ref.read(databaseProvider);
                               final combinedLocation =
@@ -478,6 +493,13 @@ class _StoresScreenState extends ConsumerState<StoresScreen> {
             size: AppButtonSize.small,
             onPressed: () async {
               Navigator.pop(ctx);
+              // Re-check at the write boundary (hard rule #6) — deleting a
+              // store needs `settings.manage`.
+              if (!ref
+                  .read(currentUserPermissionsProvider)
+                  .contains('settings.manage')) {
+                return;
+              }
               // Soft-delete the store: hard-delete would orphan
               // inventory and ledger FKs. The cloud-side cascade in 0001
               // is ON DELETE CASCADE for inventory, but realtime DELETE
@@ -510,6 +532,12 @@ class _StoresScreenState extends ConsumerState<StoresScreen> {
   // ── Build ──────────────────────────────────────────────────────────────────
   @override
   Widget build(BuildContext context) {
+    // Stores management is CEO-only — `settings.manage` (hard rule #6/#7). The
+    // drawer entry is gated, but this tab is persistently mounted, so guard the
+    // screen reactively too: if the grant is revoked live, the Add / Stock
+    // Transfer entry points, the store cards' Edit/Delete, and the list all
+    // disappear at once.
+    final canManage = hasPermission(ref, 'settings.manage');
     return SharedScaffold(
       activeRoute: 'store',
       backgroundColor: _bg,
@@ -523,46 +551,63 @@ class _StoresScreenState extends ConsumerState<StoresScreen> {
           subtitle: 'Manage Storage Locations',
         ),
         actions: [
-          IconButton(
-            tooltip: 'Stock Transfer',
-            icon: const Icon(Icons.swap_horiz_rounded),
-            onPressed: () => Navigator.push(
-              context,
-              MaterialPageRoute(
-                builder: (_) => const StockTransferScreen(),
+          if (canManage)
+            IconButton(
+              tooltip: 'Stock Transfer',
+              icon: const Icon(Icons.swap_horiz_rounded),
+              onPressed: () => Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (_) => const StockTransferScreen(),
+                ),
               ),
             ),
-          ),
           const NotificationBell(),
           SizedBox(width: rSize(context, 8)),
         ],
       ),
-      floatingActionButton: AppFAB(
-        onPressed: () => _showAddSheet(context),
-        icon: Icons.add_rounded,
-        label: 'Add Store',
-      ),
-      body: Builder(
-        builder: (context) {
-          final stores = _stores;
+      floatingActionButton: canManage
+          ? AppFAB(
+              onPressed: () => _showAddSheet(context),
+              icon: Icons.add_rounded,
+              label: 'Add Store',
+            )
+          : null,
+      body: !canManage
+          ? Center(
+              child: Padding(
+                padding: EdgeInsets.all(rSize(context, 32)),
+                child: Text(
+                  'You don’t have access to Stores.',
+                  textAlign: TextAlign.center,
+                  style: TextStyle(
+                    color: _subtext,
+                    fontSize: rFontSize(context, 14),
+                  ),
+                ),
+              ),
+            )
+          : Builder(
+              builder: (context) {
+                final stores = _stores;
 
-          if (stores.isEmpty) {
-            return _buildEmptyState(context);
-          }
+                if (stores.isEmpty) {
+                  return _buildEmptyState(context);
+                }
 
-          return ListView.builder(
-            padding: EdgeInsets.fromLTRB(
-              rSize(context, 16),
-              rSize(context, 16),
-              rSize(context, 16),
-              rSize(context, 100) + context.deviceBottomInset,
+                return ListView.builder(
+                  padding: EdgeInsets.fromLTRB(
+                    rSize(context, 16),
+                    rSize(context, 16),
+                    rSize(context, 16),
+                    rSize(context, 100) + context.deviceBottomInset,
+                  ),
+                  itemCount: stores.length,
+                  itemBuilder: (context, index) =>
+                      _buildStoreCard(context, stores[index]),
+                );
+              },
             ),
-            itemCount: stores.length,
-            itemBuilder: (context, index) =>
-                _buildStoreCard(context, stores[index]),
-          );
-        },
-      ),
     );
   }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -232,10 +232,20 @@ class _ReebaplusPosAppState extends ConsumerState<ReebaplusPosApp> {
           title: 'Reebaplus POS',
           debugShowCheckedModeBanner: false,
           builder: (context, child) {
-            return GestureDetector(
-              onTap: () => FocusManager.instance.primaryFocus?.unfocus(),
-              behavior: HitTestBehavior.opaque,
-              child: child,
+            // Cap OS font-scaling so large system-text settings can't overflow
+            // the dense POS layouts. responsive.dart already scales type by
+            // screen width; this bounds the per-device accessibility multiplier
+            // on top of that. Raise the cap if larger text is needed.
+            final mq = MediaQuery.of(context);
+            return MediaQuery(
+              data: mq.copyWith(
+                textScaler: mq.textScaler.clamp(maxScaleFactor: 1.3),
+              ),
+              child: GestureDetector(
+                onTap: () => FocusManager.instance.primaryFocus?.unfocus(),
+                behavior: HitTestBehavior.opaque,
+                child: child,
+              ),
             );
           },
           themeMode: theme.themeMode,

--- a/lib/shared/services/auth_service.dart
+++ b/lib/shared/services/auth_service.dart
@@ -120,6 +120,8 @@ class AuthService extends ValueNotifier<UserData?> {
   /// the users table. PIN unlock is device-local; the hashed PIN columns
   /// (pin_hash / pin_salt / pin_iterations) live on the users row.
   Future<void> setUserPin(String userId, String plaintext) async {
+    // sync-exempt: §5 #4 — pin/pinHash/pinSalt/pinIterations are local-only
+    // columns by schema design; they do not exist in Supabase.
     debugPrint('[AuthService] setUserPin: userId=$userId');
     final salt = PinHasher.generateSaltBase64();
     final hash = PinHasher.hashBase64(
@@ -312,6 +314,8 @@ class AuthService extends ValueNotifier<UserData?> {
   /// add yet another. We now query cloud `public.users` for the
   /// canonical id and reuse it locally.
   Future<UserData?> upsertLocalUserFromProfile() async {
+    // sync-exempt: §5 #5 — mirrors a users row just read FROM the cloud;
+    // pushing it back is a no-op round trip.
     final authUser = _supabase.auth.currentUser;
     if (authUser == null || authUser.email == null) return null;
 
@@ -1003,6 +1007,8 @@ class AuthService extends ValueNotifier<UserData?> {
     //    requireBusinessId() would throw. Payloads carry businessId
     //    explicitly so cross-tenant safety is enforced by the values, not
     //    by the resolver.
+    // sync-exempt: §5 #6 — onboarding mirror; the cloud RPC above already
+    // wrote canonical state, and AuthService isn't bound yet (resolver null).
     try {
       await _db.transaction(() async {
         await (_db.delete(_db.users)

--- a/lib/shared/services/order_service.dart
+++ b/lib/shared/services/order_service.dart
@@ -167,6 +167,8 @@ class OrderService {
     String orderId,
     List<OrderItemsCompanion> items,
   ) async {
+    // sync-exempt: §5 #3 — local-only reversal of writes the cloud's RPC
+    // already rolled back (insufficient_stock etc.); nothing to push.
     await _db.transaction(() async {
       // 1. Mark order cancelled.
       await (_db.update(_db.orders)

--- a/lib/shared/widgets/app_drawer.dart
+++ b/lib/shared/widgets/app_drawer.dart
@@ -356,9 +356,10 @@ class AppDrawer extends ConsumerWidget {
                 activeRoute == 'supplier_accounts' || activeRoute == 'payments',
             onTap: () => _navigateTo(context, ref, 'supplier_accounts'),
           ),
-        // Expenses — CEO/Manager only (§27.3). expenses.create not held by
-        // Cashier or Stock keeper.
-        if (hasPermission(ref, 'expenses.create'))
+        // Expenses — opens the expense report/list, so gate on the viewing key
+        // `reports.see_expenses` (hard rule #6), not `expenses.create` (that's
+        // only the Add-Expense action). Neither is held by Cashier/Stock keeper.
+        if (hasPermission(ref, 'reports.see_expenses'))
           _navItem(
             context,
             FontAwesomeIcons.fileInvoiceDollar,

--- a/lib/shared/widgets/notifications_modal.dart
+++ b/lib/shared/widgets/notifications_modal.dart
@@ -403,6 +403,12 @@ class _NotificationCard extends ConsumerWidget {
         return FontAwesomeIcons.circleCheck;
       case 'crate_return_rejected':
         return FontAwesomeIcons.circleXmark;
+      case 'stock_approval.requested':
+        return FontAwesomeIcons.clipboardList;
+      case 'stock_approval.approved':
+        return FontAwesomeIcons.circleCheck;
+      case 'stock_approval.rejected':
+        return FontAwesomeIcons.circleXmark;
       default:
         return FontAwesomeIcons.bell;
     }
@@ -427,6 +433,12 @@ class _NotificationCard extends ConsumerWidget {
       case 'crate_return_approved':
         return success;
       case 'crate_return_rejected':
+        return danger;
+      case 'stock_approval.requested':
+        return const Color(0xFFF5A623);
+      case 'stock_approval.approved':
+        return success;
+      case 'stock_approval.rejected':
         return danger;
       default:
         return blueMain;

--- a/lib/shared/widgets/receipt_widget.dart
+++ b/lib/shared/widgets/receipt_widget.dart
@@ -329,11 +329,14 @@ class ReceiptWidget extends StatelessWidget {
                           child: Row(
                             mainAxisAlignment: MainAxisAlignment.spaceBetween,
                             children: [
-                              Text(
-                                '$mfrName (${e.value.toStringAsFixed(0)} crates)',
-                                style: TextStyle(
-                                  fontSize: context.getRFontSize(12),
-                                  color: sub,
+                              Expanded(
+                                child: Text(
+                                  '$mfrName (${e.value.toStringAsFixed(0)} crates)',
+                                  overflow: TextOverflow.ellipsis,
+                                  style: TextStyle(
+                                    fontSize: context.getRFontSize(12),
+                                    color: sub,
+                                  ),
                                 ),
                               ),
                             ],

--- a/reebaplus_master_plan.md
+++ b/reebaplus_master_plan.md
@@ -63,6 +63,7 @@ The agent should design these tables (names are illustrative — match your exis
 - `permissions` — id, key, description, category
 - `role_permissions` — role_id, permission_id
 - `role_settings` — role_id, setting_key, setting_value
+- `user_permission_overrides` — id, business_id, user_id, permission_key, is_granted (per-staff override of the role default; §10.2.1)
 - `user_businesses` — user_id, business_id, role_id, status, last_login_at
 - `invite_codes` — id, business_id, role_id, code, generated_by_user_id, expires_at, used_by_user_id, revoked_at, email, store_id
 - `stores` — id, business_id, name, address, state, country
@@ -364,11 +365,11 @@ Permission settings are layered by scope, most-specific wins: **User > Store > B
 
 - **Business (default).** For each role, the CEO sets its permission toggles on the Roles & Permissions sub-page (everything described above). These apply to **every store** in the business — they are the default.
 - **Store (default for users in that store).** A store can override a role's permissions just for that store; that becomes the default for every user working in that store. Reached from the role's page via a scope selector (Business / Store).
-- **User (override the rest).** The CEO opens an **individual staff member's profile** (Staff Management → tap a staff member → **Permission access**) and adjusts *that one person's* permission access. A user override wins over both the store and business defaults. This lives on the staff profile, **not** the per-role Roles & Permissions page (which is by role, not by person).
+- **User (override the rest) — BUILT (Phase 1).** The CEO opens an **individual staff member's profile** (Staff Management → tap a staff member → **Permission access → Customize**) and adjusts *that one person's* permission access. Each permission toggle shows the **effective** value (the role default, unless overridden); flipping it away from the role default stores an override, flipping it back to the role default clears the override (inherit). A user override wins over both the store and business defaults. This lives on the staff profile, **not** the per-role Roles & Permissions page (which is by role, not by person). The CEO is never overridable (always all-on). Per-user overrides do **not** depend on multi-store, so they ship in Phase 1; they cover the boolean permission toggles only (the per-role limits — discount %, expense approval — stay role-level). A **Restore defaults** button at the bottom of this screen clears *all* of the staff member's overrides at once and returns them to the role defaults; it asks for confirmation first (so a stray tap can't wipe them) and is disabled when the person has no overrides. (Not shown for the CEO, who has none.)
 
-**Phase 1 ships the Business scope fully** (it is the existing Roles & Permissions behaviour). The **Store** selector on the role page and the **Permission access** section on the staff profile are **visible placeholders in Phase 1, disabled and labelled "coming with multi-store"** — multi-store UI itself is Phase 2 (§2.2). They are surfaced now so the hierarchy is visible and the CEO knows where each scope will be set; no per-store or per-user override is stored or enforced yet, so effective permissions remain role-based business-wide.
+**Phase 1 ships Business and User scopes fully.** The **Store** selector on the role page is a **visible placeholder, disabled and labelled "coming with multi-store"** — per-store overrides need the multi-store UI, which is Phase 2 (§2.2). Until then, effective permissions = the role default ± the staff member's own overrides.
 
-**Forward note (Phase 2 schema — do not build yet):** the Store and User layers will introduce two synced tenant tables following the same business→store fallback pattern already used by `expense_budgets` (§20.6): `store_role_permissions` (`business_id`, `store_id`, `role_id`, `permission_key`) and `user_permission_overrides` (`business_id`, `user_id`, `permission_key`, `is_granted`). When built, both follow the §5 sync contract (added to `_syncedTenantTables`, routed through a DAO that enqueues, stream provider added), and a runtime resolver merges the three layers in User > Store > Business order.
+**Storage & resolution.** Per-user overrides live in the synced tenant table `user_permission_overrides` (`business_id`, `user_id`, `permission_key`, `is_granted`); presence of a row = an override, `is_granted` true/false = force-grant/force-revoke, absence = inherit the role default. It follows the §5 sync contract (in `_syncedTenantTables`, written through a DAO that enqueues, stream provider added). The runtime resolver (`currentUserPermissionsProvider`) merges role grants ± the user's overrides (CEO skips overrides). The future **Store** layer will add `store_role_permissions` (`business_id`, `store_id`, `role_id`, `permission_key`) following the same business→store fallback pattern as `expense_budgets` (§20.6), extending the resolver to the full **User > Store > Business** order.
 
 ### 10.3 Delete Business & Account (Danger Zone)
 
@@ -409,7 +410,7 @@ Renamed from Dashboard to match the bottom nav. Role-aware screen showing busine
   - Cashier and Stock keeper: locked to own store (no toggle).
   - A locked user assigned to more than one store gets a dropdown limited to their assigned stores
     (no "All Stores" entry).
-- Period dropdown uses the canonical rolling chip set (§30.11), default Last 24 hours.
+- Period dropdown uses the canonical calendar chip set (§30.11), default Today.
 
 ### 11.3 Reports button
 
@@ -784,8 +785,32 @@ Action buttons by role:
   - Quantity.
   - Reason (required if Remove): Damage / Theft / Expired / Other.
   - Notes (optional).
-  - Save → updates quantity + logs to History.
+  - Save → **submits the change for approval** (§16.6.1); inventory is not
+    touched until a Manager/CEO approves.
 - Cashier: no edit buttons. View-only. Buying price hidden.
+
+### 16.6.1 Stock-keeper adjustment approval (added 2026-06-04, user)
+
+A stock keeper's Add/Remove does **not** change inventory directly. Saving the
+Update Stock modal records a **pending request** and notifies the **CEO and the
+Manager(s) of the affected store** (if no Manager is tied to that store, only the
+CEO). The stock keeper sees a "Sent for approval" confirmation; the stored
+quantity is unchanged until a decision is made.
+
+- The approver opens the **Stock Approvals** card on the Reports hub (§25.2) —
+  CEO sees every store's requests, a Manager only their assigned store(s). Each
+  request is a **tappable card that expands** to the full detail (who, store,
+  reason, when) with **Approve / Reject** actions.
+- **Approve** runs the real adjustment (the same atomic inventory + ledger path a
+  Manager/CEO uses), so the stock number changes only now. If the store no longer
+  has enough stock for a Remove, approval fails and the request stays pending.
+- **Reject** discards the request — no inventory change. The approver may add an
+  **optional reason**; it is shown to the stock keeper in the rejection
+  notification and recorded in the activity log. (Added 2026-06-04, user.)
+- Either decision notifies the stock keeper who submitted (approved / rejected) and
+  is written to the activity log.
+- **Manager/CEO** adjustments are applied **directly** and never enter this queue —
+  approval gates stock-keeper actions only.
 
 ### 16.7 Role access
 
@@ -932,9 +957,9 @@ Stock keeper, Manager, CEO. Cashier blocked.
 ### 19.1 Tabs
 
 - Three tabs: Pending, Completed, Cancelled.
-- Default period filter: Last 24 hours (canonical chip set, §30.11).
+- Default period filter: Today (canonical chip set, §30.11).
 - The period filter is a **dropdown** that sits inline with the search bar (on the Completed and Cancelled tabs). It replaces the old row of filter chips.
-- **Roles below Manager (Cashier, Stock keeper) are capped to a Month maximum** on this filter — they get Day / Week / Month only. Manager and CEO also get Year / To Date / All Time.
+- **Roles below Manager (Cashier, Stock keeper) are capped to a Month maximum** on this filter — they get Today / This Week / This Month only. Manager and CEO also get This Year / To Date.
 
 ### 19.2 Stat cards per tab
 
@@ -1029,9 +1054,9 @@ Wrong items → cancel and create a new order. When an order is in Pending, the 
 
 - Header: Expenses / Manage operating costs / notification bell (with pending approval count badge for CEO).
 - 2 tabs: Expenses, Stats.
-- Total Expenses card with period selector (default "Last 30 days"; canonical chip set, §30.11).
+- Total Expenses card with period selector (default "This Month"; canonical chip set, §30.11).
 - Budget Activity bar (Spent vs Goal) — only counts approved expenses. Small text below shows "₦X pending approval" if any.
-  - **Always visible (2026-06-02, user):** the budget is a **monthly** goal, so the bar is shown on **every** period selection (not gated to the "Last 30 days" view). Its Spent/pending figures always reflect the **last-30-days window**, independent of the period selector above the list (which only filters the expense list and the "Total Expenses" headline).
+  - **Always visible (2026-06-02, user):** the budget is a **monthly** goal, so the bar is shown on **every** period selection (not gated to the "This Month" view). Its Spent/pending figures always reflect the **current calendar month**, independent of the period selector above the list (which only filters the expense list and the "Total Expenses" headline).
   - **Budget scope (2026-06-02, user):** the monthly budget goal is set **overall for the business and, optionally, per store** within the business. A store with no goal of its own falls back to the business-wide goal. The bar resolves the goal by the viewer's scope — CEO viewing all stores sees the business-wide goal; a store-scoped view (Manager, or a CEO filtered to one store) sees that store's goal. Stored in an `expense_budgets` table (`business_id`, nullable `store_id`, `amount_kobo`); set via the CEO-only "Set monthly budget" action (§20.3).
 - Pending Approvals section at top (CEO only, shows when there are pending items).
 - Expense list with status badges (Approved, Pending CEO approval, Rejected).
@@ -1396,7 +1421,7 @@ CSV/PDF export with selectable time frame. Deferred to Phase 3.
 
 ### 25.1 Business Reports screen
 
-- Header: back, "Business Reports", global period filter (defaults to Last 24 hours; canonical chip set, §30.11).
+- Header: back, "Business Reports", global period filter (defaults to Today; canonical chip set, §30.11).
 - Grid of report cards (2-column).
 
 ### 25.2 Reports list
@@ -1409,7 +1434,9 @@ CSV/PDF export with selectable time frame. Deferred to Phase 3.
 - Funds Register Report — daily open/close per account, mismatches flagged.
 - Profit Report — CEO only. Revenue, cost of goods, gross profit, margins.
 
-Note: there is no Pending Approvals card on Reports. Pending approvals live on the Expenses screen and notification bell.
+- Stock Approvals — CEO + Manager. Stock-keeper Add/Remove requests awaiting approval (§16.6.1). A tappable card per request expands to the detail with Approve / Reject; a count badge shows what's outstanding. (Added 2026-06-04, user.)
+
+Note: **expense** pending approvals are not on Reports — they live on the Expenses screen and notification bell (§20.4). The Stock Approvals card above is the one exception, added 2026-06-04 on user request to surface stock-keeper adjustment approvals (§16.6.1) in the Reports tab.
 
 > Removed 2026-06-02 (user) — the standalone **Stock Audit report** (hub card +
 > screen) was dropped from Phase 1. Stock health stays visible in Inventory, and
@@ -1464,16 +1491,16 @@ CSV from day one. PDF in Phase 3.
 
 ### 25.9 Daily Reconciliation drill-down (period cards)
 
-The Daily Reconciliation Report does not open straight to a single detail screen; it opens to a list of **tappable day cards**, driven by the global rolling period filter (§25.5 / §30.11):
+The Daily Reconciliation Report does not open straight to a single detail screen; it opens to a list of **tappable day cards**, driven by the global period filter (§25.5 / §30.11):
 
-- The selected rolling window (Last 24 hours / 7 days / 30 days / year / to date) chooses the **span**; the report lists **one card per calendar day** inside that span that has a Close Day and/or a saved stock count. Tapping a card opens that day's full reconciliation.
+- The selected period (Today / This Week / This Month / This Year / To Date) chooses the **span**; the report lists **one card per calendar day** inside that span that has a Close Day and/or a saved stock count. Tapping a card opens that day's full reconciliation.
 - Each day card shows a headline (items sold, net cash variance) and a **mismatch indicator** when that day had a Close Day shortage / unaccounted funds or a stock shortage.
-- Reconciliation is per **calendar day** (§30.11 keeps the daily reconciliation calendar-bound), so there is no week/month/year aggregation — the rolling window only widens or narrows how many day cards are listed.
+- Reconciliation is per **calendar day** (§30.11 keeps the daily reconciliation calendar-bound), so there is no week/month/year aggregation — the selected period only widens or narrows how many day cards are listed.
 - Role visibility follows §25.3 (Cashier & Stock keeper never see this report). CSV export per §25.6 / §25.7.
 
 This per-day drill-down is specific to the Daily Reconciliation Report; the other reports keep the §25.6 single detail-screen + period-filter model.
 
-> Updated 2026-06-02 (user) — the original Day/Week/Month/Year period-card model predated the §30.11 rolling-window unification; reconciled to **one card per calendar day within the selected rolling window** (no span aggregation), matching §30.11's per-calendar-day rule.
+> Updated 2026-06-02 (user) — the original Day/Week/Month/Year period-card model predated the §30.11 unification; reconciled to **one card per calendar day within the selected period** (no span aggregation), matching §30.11's per-calendar-day rule. (§30.11 was reversed back to calendar periods on 2026-06-04 — the per-calendar-day rule here is unchanged.)
 
 > Confirmed Phase 1 (2026-06-01) — the Daily Reconciliation Report's content roll-up (SKUs sold, closing-day cash audit, empty crates, debts, expenses, fund-shortage flags) and the period-card drill-down were added on user request. The Sales Report card is **kept** (a distinct report). Build order unchanged: this stays a Ring 3 item, after Close Day (Ring 0/1) and Daily Stock Count (Ring 2) produce its data.
 
@@ -1513,7 +1540,8 @@ Opens the relevant screen (Inventory for low stock, Expense for pending approval
 - Out of stock (fires to Stock keeper, Manager, CEO).
 - Stock count saved → daily reconciliation report ready (fires to Manager, CEO).
 - Damage recorded (fires to Manager, CEO).
-- Stock keeper added or removed stock (fires to CEO, Manager — info for an add, warning for a removal, with the reason). Only fires when the actor is a stock keeper.
+- Stock keeper requested a stock change → **approval needed** (fires to the CEO and the Manager(s) of the **affected store** — info for an add, warning for a removal, with the reason). Only fires when the actor is a stock keeper. CEOs always receive it (they aren't store-assigned); Managers are narrowed to those assigned to the store where the stock moved. If no Manager is tied to that store, only the CEO is notified. The approver acts on it via the Stock Approvals card (§16.6.1 / §25.2). (Amended 2026-06-04, user: stock-keeper changes are now approval-gated — the old post-hoc "added/removed stock" notice became this approval request. The audience rule is unchanged; no all-Managers fallback.)
+- Stock change approved / rejected (fires to the stock keeper who submitted; §16.6.1).
 
 **Staff**
 
@@ -1693,7 +1721,7 @@ UI elements a user doesn't have permission to use should not appear at all. Don'
 
 ### 30.6 Smart defaults
 
-Currency auto-fills based on country (editable in Settings). Period filters default to **Last 24 hours** on most screens and **Last 30 days** on the Expenses / Supplier-Accounts totals (the canonical chip set is in §30.11). Country defaults to Nigeria.
+Currency auto-fills based on country (editable in Settings). Period filters default to **Today** on most screens and **This Month** on the Expenses / Supplier-Accounts totals (the canonical chip set is in §30.11). Country defaults to Nigeria.
 
 ### 30.7 Loading animations
 
@@ -1713,24 +1741,33 @@ Destructive or significant actions confirm before proceeding (suspend staff, cha
 
 ### 30.11 Date-range filter chips (canonical)
 
-> Added 2026-06-01 (user). Every browse/report **period filter chip** uses one
-> shared, rolling set so the same chip means the same thing on every screen:
+> Added 2026-06-01 (user). Reversed to calendar periods 2026-06-04 (user).
+> Every browse/report **period filter chip** uses one shared set so the same
+> chip means the same thing on every screen:
 >
-> - **Last 24 hours** — `now − 24h`
-> - **Last 7 days** — `now − 7 days`
-> - **Last 30 days** — `now − 30 days`
-> - **Last year** — `now − 365 days`
-> - **To date** — unbounded (everything up to now)
+> - **Today** — since local midnight today
+> - **This Week** — since local midnight of the most recent **Sunday**
+> - **This Month** — since the 1st of the current month
+> - **This Year** — since Jan 1 of the current year
+> - **To Date** — unbounded (everything up to now)
 >
-> These are **rolling** windows (a span measured back from now), not calendar
-> periods ("this week / this month"). One helper computes them
+> These are **calendar** periods anchored to the start of the current day /
+> week / month / year (not rolling spans measured back from now). Because they
+> are calendar-anchored they are computed from the **local** date parts of now
+> (local-zone dependent). One helper computes them
 > (`lib/core/utils/date_period.dart`); screens must not roll their own date math.
-> Default selection: **Last 24 hours** on most screens; **Last 30 days** on the
-> Expenses and Supplier-Accounts totals (§30.6).
+> Default selection: **Today** on most screens; **This Month** on the Expenses
+> and Supplier-Accounts totals (§30.6).
 >
-> This replaced an earlier mix of per-screen, inconsistent implementations
-> (some rolling, some calendar-bound, with divergent labels — "Day", "Today",
-> "This Week", "All Time", etc.) and a class of off-by-one / fragile date bugs.
+> **Role cap:** roles **below Manager** (Cashier, Stock keeper) may only choose
+> **Today / This Week / This Month** — This Year / To Date are hidden for them.
+> Manager and CEO get all five. Enforced via `datePeriodLabelsForRole(...)` on
+> every selector a non-Manager can reach (Home, Orders, Customer wallet, and
+> the Expenses / Supplier-Accounts totals); the Reports hub and its sub-screens
+> are already CEO/Manager-only (§11.3) so they keep the full set.
+>
+> The label parser still understands every legacy/rolling label ("Day", "Last
+> 24 hours", "30 Days", "All Time", etc.) so any in-flight value resolves.
 >
 > **Scope / exceptions:** This governs Home, Reports, Orders, Expenses, Supplier
 > Accounts (Payments + Supplier detail), and the Customer wallet. It does **not**

--- a/reebaplus_master_plan.md
+++ b/reebaplus_master_plan.md
@@ -358,6 +358,18 @@ Where the CEO tunes everything about the business. Menu screen with tappable sec
 - Other role settings near the toggles:
   - Can change product prices (toggle). Default: Manager ON, others OFF.
 
+#### 10.2.1 Permission scopes (Business → Store → User) (2026-06-04, user)
+
+Permission settings are layered by scope, most-specific wins: **User > Store > Business**.
+
+- **Business (default).** For each role, the CEO sets its permission toggles on the Roles & Permissions sub-page (everything described above). These apply to **every store** in the business — they are the default.
+- **Store (default for users in that store).** A store can override a role's permissions just for that store; that becomes the default for every user working in that store. Reached from the role's page via a scope selector (Business / Store).
+- **User (override the rest).** The CEO opens an **individual staff member's profile** (Staff Management → tap a staff member → **Permission access**) and adjusts *that one person's* permission access. A user override wins over both the store and business defaults. This lives on the staff profile, **not** the per-role Roles & Permissions page (which is by role, not by person).
+
+**Phase 1 ships the Business scope fully** (it is the existing Roles & Permissions behaviour). The **Store** selector on the role page and the **Permission access** section on the staff profile are **visible placeholders in Phase 1, disabled and labelled "coming with multi-store"** — multi-store UI itself is Phase 2 (§2.2). They are surfaced now so the hierarchy is visible and the CEO knows where each scope will be set; no per-store or per-user override is stored or enforced yet, so effective permissions remain role-based business-wide.
+
+**Forward note (Phase 2 schema — do not build yet):** the Store and User layers will introduce two synced tenant tables following the same business→store fallback pattern already used by `expense_budgets` (§20.6): `store_role_permissions` (`business_id`, `store_id`, `role_id`, `permission_key`) and `user_permission_overrides` (`business_id`, `user_id`, `permission_key`, `is_granted`). When built, both follow the §5 sync contract (added to `_syncedTenantTables`, routed through a DAO that enqueues, stream provider added), and a runtime resolver merges the three layers in User > Store > Business order.
+
 ### 10.3 Delete Business & Account (Danger Zone)
 
 The **last Phase 1 item to build** (see §3). A CEO can permanently delete their account, their business, and everything attached to the business. Irreversible. CEO-only — no other role ever sees this section. Gated by the `settings.delete_business` permission, which is locked ON for CEO and unavailable to all other roles.

--- a/supabase/migrations/0088_user_permission_overrides.sql
+++ b/supabase/migrations/0088_user_permission_overrides.sql
@@ -1,0 +1,143 @@
+-- 0088_user_permission_overrides.sql
+--
+-- Reebaplus — per-staff permission overrides (master plan §10.2.1). A row
+-- means a user's effective permission for `permission_key` is forced:
+-- `is_granted` true = force-grant, false = force-revoke. No row = inherit the
+-- role default. The runtime resolver (currentUserPermissionsProvider) applies
+-- these on top of the user's role grants; the CEO is never overridable.
+-- Mirrors the local Drift `UserPermissionOverrides` table (schema v33).
+--
+-- Additive: one new synced tenant table + RLS + realtime + snapshot pull.
+-- DEPLOY ORDER: push this BEFORE the v33 app reaches a device, or the
+-- user_permission_overrides upserts the override editor enqueues would 42P01
+-- (relation does not exist) cloud-side.
+
+-- -----------------------------------------------------------------------------
+-- 1. Table
+-- -----------------------------------------------------------------------------
+CREATE TABLE public.user_permission_overrides (
+  id                uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  business_id       uuid NOT NULL REFERENCES public.businesses(id) ON DELETE CASCADE,
+  user_id           uuid NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  permission_key    text NOT NULL REFERENCES public.permissions(key) ON DELETE RESTRICT,
+  is_granted        boolean NOT NULL,
+  created_at        timestamptz NOT NULL DEFAULT now(),
+  last_updated_at   timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (business_id, user_id, permission_key)
+);
+CREATE INDEX idx_user_permission_overrides_business_lua
+  ON public.user_permission_overrides (business_id, last_updated_at);
+CREATE INDEX idx_user_permission_overrides_user
+  ON public.user_permission_overrides (user_id);
+
+-- -----------------------------------------------------------------------------
+-- 2. Row Level Security — profiles-based tenant scoping. Use
+--    current_user_business_ids() directly (NOT an inline user_businesses
+--    subquery), which avoids the auth_user_id-drift 42501 push failures the
+--    older inline policies hit (see 0050/0051/0075).
+-- -----------------------------------------------------------------------------
+ALTER TABLE public.user_permission_overrides ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "user_permission_overrides_tenant_rw" ON public.user_permission_overrides
+  FOR ALL TO authenticated
+  USING (business_id IN (SELECT public.current_user_business_ids()))
+  WITH CHECK (business_id IN (SELECT public.current_user_business_ids()));
+
+-- -----------------------------------------------------------------------------
+-- 3. last_updated_at bump trigger — rows get UPDATEd when an override flips
+--    grant<->revoke, so keep the heartbeat (mirrors role_permissions, 0042).
+-- -----------------------------------------------------------------------------
+CREATE TRIGGER bump_user_permission_overrides_last_updated_at
+  BEFORE UPDATE ON public.user_permission_overrides
+  FOR EACH ROW EXECUTE FUNCTION public._bump_last_updated_at();
+
+-- -----------------------------------------------------------------------------
+-- 4. Realtime publication — INSERT/UPDATE/DELETE events flow to other devices.
+-- -----------------------------------------------------------------------------
+ALTER PUBLICATION supabase_realtime ADD TABLE public.user_permission_overrides;
+
+-- -----------------------------------------------------------------------------
+-- 5. Snapshot pull — append user_permission_overrides to pos_pull_snapshot so
+--    other devices pull a staff member's overrides (same signature/body as
+--    0072; only v_tenant_tables gains the one new name).
+-- -----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.pos_pull_snapshot(
+  p_business_id uuid,
+  p_since       timestamptz DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+DECLARE
+  v_caller_business uuid;
+  v_result          jsonb := '{}'::jsonb;
+  v_table           text;
+  v_rows            jsonb;
+  v_query           text;
+  v_tenant_tables   text[] := ARRAY[
+    'profiles','users','stores','manufacturers','crate_size_groups',
+    'categories','products','inventory','customers','suppliers',
+    'orders','order_items','shipments','purchase_items',
+    'expenses','expense_categories',
+    'customer_crate_balances','delivery_receipts','drivers',
+    'stock_transfers','stock_adjustments','activity_logs',
+    'notifications','stock_transactions',
+    'customer_wallets','wallet_transactions',
+    'saved_carts','pending_crate_returns',
+    'manufacturer_crate_balances','crate_ledger',
+    'price_lists','payment_transactions','sessions','settings',
+    'roles','role_permissions','role_settings','user_businesses','user_stores',
+    'invite_codes',
+    -- 0060: Funds Register (§23) — accounts, daily open/close header, ledger.
+    'funds_accounts','fund_days','fund_transactions',
+    -- 0068: Close Day per-account reconciliation snapshot (§23.6).
+    'fund_day_closings',
+    -- 0072: Daily Stock Count session snapshot (§17).
+    'stock_counts',
+    -- 0088: per-staff permission overrides (§10.2.1).
+    'user_permission_overrides'
+  ];
+BEGIN
+  v_caller_business := public.business_id();
+  IF v_caller_business IS NULL THEN
+    RAISE EXCEPTION 'no_business_for_caller'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+  IF v_caller_business <> p_business_id THEN
+    RAISE EXCEPTION 'tenant_mismatch'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  SELECT COALESCE(jsonb_agg(to_jsonb(b)), '[]'::jsonb)
+    INTO v_rows
+    FROM public.businesses b
+    WHERE b.id = p_business_id
+      AND (p_since IS NULL OR b.last_updated_at > p_since);
+  v_result := v_result || jsonb_build_object('businesses', v_rows);
+
+  FOREACH v_table IN ARRAY v_tenant_tables LOOP
+    v_query := format(
+      'SELECT COALESCE(jsonb_agg(to_jsonb(t)), ''[]''::jsonb)
+         FROM public.%I t
+         WHERE t.business_id = $1
+           AND ($2::timestamptz IS NULL OR t.last_updated_at > $2)',
+      v_table
+    );
+    EXECUTE v_query INTO v_rows USING p_business_id, p_since;
+    v_result := v_result || jsonb_build_object(v_table, v_rows);
+  END LOOP;
+
+  SELECT COALESCE(jsonb_agg(to_jsonb(s)), '[]'::jsonb)
+    INTO v_rows
+    FROM public.system_config s
+    WHERE (p_since IS NULL OR s.last_updated_at > p_since);
+  v_result := v_result || jsonb_build_object('system_config', v_rows);
+
+  RETURN v_result;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.pos_pull_snapshot(uuid, timestamptz) FROM public;
+GRANT EXECUTE ON FUNCTION public.pos_pull_snapshot(uuid, timestamptz)
+  TO authenticated, service_role;

--- a/supabase/migrations/0089_stock_adjustment_requests.sql
+++ b/supabase/migrations/0089_stock_adjustment_requests.sql
@@ -1,0 +1,152 @@
+-- 0089_stock_adjustment_requests.sql
+--
+-- Reebaplus — stock-keeper adjustment approval queue (master plan §16.6.1). A
+-- stock keeper's Add/Remove does NOT touch inventory directly; it lands here as
+-- a `pending` request. The affected store's Manager(s) and the CEO approve in
+-- the Reports hub; on approval the app runs the real adjustment via the
+-- existing pos_inventory_delta_v2 envelope (this table only records the request
+-- + its review outcome). Mirrors the local Drift `StockAdjustmentRequests`
+-- table (schema v34).
+--
+-- Additive: one new synced tenant table + RLS + realtime + snapshot pull.
+-- DEPLOY ORDER: push this BEFORE the v34 app reaches a device, or the
+-- stock_adjustment_requests upserts the request/approve/reject flow enqueues
+-- would 42P01 (relation does not exist) cloud-side.
+
+-- -----------------------------------------------------------------------------
+-- 1. Table
+-- -----------------------------------------------------------------------------
+CREATE TABLE public.stock_adjustment_requests (
+  id                uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  business_id       uuid NOT NULL REFERENCES public.businesses(id) ON DELETE CASCADE,
+  product_id        uuid NOT NULL REFERENCES public.products(id) ON DELETE CASCADE,
+  store_id          uuid NOT NULL REFERENCES public.stores(id) ON DELETE CASCADE,
+  quantity_diff     integer NOT NULL,
+  reason            text NOT NULL,
+  summary           text NOT NULL,
+  requested_by      uuid REFERENCES public.users(id) ON DELETE SET NULL,
+  status            text NOT NULL DEFAULT 'pending'
+                      CHECK (status IN ('pending','approved','rejected')),
+  approved_by       uuid REFERENCES public.users(id) ON DELETE SET NULL,
+  approved_at       timestamptz,
+  created_at        timestamptz NOT NULL DEFAULT now(),
+  last_updated_at   timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX idx_stock_adjustment_requests_business_lua
+  ON public.stock_adjustment_requests (business_id, last_updated_at);
+CREATE INDEX idx_stock_adjustment_requests_store
+  ON public.stock_adjustment_requests (store_id);
+
+-- -----------------------------------------------------------------------------
+-- 2. Row Level Security — profiles-based tenant scoping. Use
+--    current_user_business_ids() directly (NOT an inline user_businesses
+--    subquery), which avoids the auth_user_id-drift 42501 push failures the
+--    older inline policies hit (see 0050/0051/0075/0088).
+-- -----------------------------------------------------------------------------
+ALTER TABLE public.stock_adjustment_requests ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "stock_adjustment_requests_tenant_rw" ON public.stock_adjustment_requests
+  FOR ALL TO authenticated
+  USING (business_id IN (SELECT public.current_user_business_ids()))
+  WITH CHECK (business_id IN (SELECT public.current_user_business_ids()));
+
+-- -----------------------------------------------------------------------------
+-- 3. last_updated_at bump trigger — rows get UPDATEd when a request is
+--    approved/rejected, so keep the heartbeat (mirrors 0088).
+-- -----------------------------------------------------------------------------
+CREATE TRIGGER bump_stock_adjustment_requests_last_updated_at
+  BEFORE UPDATE ON public.stock_adjustment_requests
+  FOR EACH ROW EXECUTE FUNCTION public._bump_last_updated_at();
+
+-- -----------------------------------------------------------------------------
+-- 4. Realtime publication — INSERT/UPDATE/DELETE events flow to other devices.
+-- -----------------------------------------------------------------------------
+ALTER PUBLICATION supabase_realtime ADD TABLE public.stock_adjustment_requests;
+
+-- -----------------------------------------------------------------------------
+-- 5. Snapshot pull — append stock_adjustment_requests to pos_pull_snapshot so
+--    other devices (the approver's till) pull pending requests (same
+--    signature/body as 0088; only v_tenant_tables gains the one new name).
+-- -----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.pos_pull_snapshot(
+  p_business_id uuid,
+  p_since       timestamptz DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+DECLARE
+  v_caller_business uuid;
+  v_result          jsonb := '{}'::jsonb;
+  v_table           text;
+  v_rows            jsonb;
+  v_query           text;
+  v_tenant_tables   text[] := ARRAY[
+    'profiles','users','stores','manufacturers','crate_size_groups',
+    'categories','products','inventory','customers','suppliers',
+    'orders','order_items','shipments','purchase_items',
+    'expenses','expense_categories',
+    'customer_crate_balances','delivery_receipts','drivers',
+    'stock_transfers','stock_adjustments','activity_logs',
+    'notifications','stock_transactions',
+    -- 0089: stock-keeper adjustment approval queue (§16.6.1).
+    'stock_adjustment_requests',
+    'customer_wallets','wallet_transactions',
+    'saved_carts','pending_crate_returns',
+    'manufacturer_crate_balances','crate_ledger',
+    'price_lists','payment_transactions','sessions','settings',
+    'roles','role_permissions','role_settings','user_businesses','user_stores',
+    'invite_codes',
+    -- 0060: Funds Register (§23) — accounts, daily open/close header, ledger.
+    'funds_accounts','fund_days','fund_transactions',
+    -- 0068: Close Day per-account reconciliation snapshot (§23.6).
+    'fund_day_closings',
+    -- 0072: Daily Stock Count session snapshot (§17).
+    'stock_counts',
+    -- 0088: per-staff permission overrides (§10.2.1).
+    'user_permission_overrides'
+  ];
+BEGIN
+  v_caller_business := public.business_id();
+  IF v_caller_business IS NULL THEN
+    RAISE EXCEPTION 'no_business_for_caller'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+  IF v_caller_business <> p_business_id THEN
+    RAISE EXCEPTION 'tenant_mismatch'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  SELECT COALESCE(jsonb_agg(to_jsonb(b)), '[]'::jsonb)
+    INTO v_rows
+    FROM public.businesses b
+    WHERE b.id = p_business_id
+      AND (p_since IS NULL OR b.last_updated_at > p_since);
+  v_result := v_result || jsonb_build_object('businesses', v_rows);
+
+  FOREACH v_table IN ARRAY v_tenant_tables LOOP
+    v_query := format(
+      'SELECT COALESCE(jsonb_agg(to_jsonb(t)), ''[]''::jsonb)
+         FROM public.%I t
+         WHERE t.business_id = $1
+           AND ($2::timestamptz IS NULL OR t.last_updated_at > $2)',
+      v_table
+    );
+    EXECUTE v_query INTO v_rows USING p_business_id, p_since;
+    v_result := v_result || jsonb_build_object(v_table, v_rows);
+  END LOOP;
+
+  SELECT COALESCE(jsonb_agg(to_jsonb(s)), '[]'::jsonb)
+    INTO v_rows
+    FROM public.system_config s
+    WHERE (p_since IS NULL OR s.last_updated_at > p_since);
+  v_result := v_result || jsonb_build_object('system_config', v_rows);
+
+  RETURN v_result;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.pos_pull_snapshot(uuid, timestamptz) FROM public;
+GRANT EXECUTE ON FUNCTION public.pos_pull_snapshot(uuid, timestamptz)
+  TO authenticated, service_role;

--- a/supabase/migrations/0090_user_permission_overrides_replica_identity_full.sql
+++ b/supabase/migrations/0090_user_permission_overrides_replica_identity_full.sql
@@ -1,0 +1,41 @@
+-- 0090_user_permission_overrides_replica_identity_full.sql
+--
+-- Live realtime DELETE propagation for `user_permission_overrides` — the fourth
+-- hard-delete table, added in 0088 AFTER 0064 and missed by it.
+--
+-- Problem (identical to 0064)
+-- ---------------------------
+-- Supabase Realtime authorizes every change against the row's RLS SELECT policy
+-- before broadcasting it. For a DELETE, the only columns available in the old
+-- record are those in the table's REPLICA IDENTITY. `user_permission_overrides`
+-- carries a business-scoped RLS policy:
+--
+--   user_permission_overrides -> user_permission_overrides_tenant_rw
+--                                (USING business_id IN (current_user_business_ids()))
+--
+-- but its replica identity is the Postgres DEFAULT = primary key (`id`) only.
+-- So `business_id` is absent from a delete's old record, the RLS check runs
+-- against a NULL business_id, fails, and Realtime DROPS the DELETE event before
+-- it reaches subscribed clients.
+--
+-- Net effect on a multi-device business: when a CEO turns a per-staff override
+-- OFF, that *clears* the override row (hard delete via `enqueueDelete`, since a
+-- stock keeper's role default for the key is already off). The grant that the
+-- INSERT/UPSERT delivered live never disappears on the staff member's other
+-- device — it only clears on the next full snapshot reconcile (app restart /
+-- re-login). The user-visible bug: toggling a permission ON propagates, but
+-- toggling it OFF does not revert.
+--
+-- This is the only hard-delete table (the `enqueueDelete` call sites +
+-- `_hardDeleteReconcileTables`) still on the default replica identity; the other
+-- three (role_permissions, saved_carts, notifications) were fixed in 0064.
+--
+-- Fix
+-- ---
+-- REPLICA IDENTITY FULL makes the old record carry every column, so Realtime can
+-- authorize the DELETE against the real `business_id` and deliver it live. Cost
+-- is a little extra WAL volume on UPDATE/DELETE — negligible for this small,
+-- low-write table. Idempotent: re-running is a no-op. The client already applies
+-- the realtime DELETE (`_deleteLocalRowById` case 'user_permission_overrides').
+
+ALTER TABLE public.user_permission_overrides REPLICA IDENTITY FULL;

--- a/test/permissions/permission_enforcement_test.dart
+++ b/test/permissions/permission_enforcement_test.dart
@@ -1,0 +1,112 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// Permission-enforcement guardrail (CLAUDE.md hard rules #6/#7, §10.2.1).
+///
+/// The per-staff override editor turns every non-hidden catalogue permission
+/// into an on/off toggle. A toggle is only meaningful if *some* feature gates on
+/// the EFFECTIVE permission — `hasPermission(ref, '<key>')` or
+/// `currentUserPermissionsProvider…contains('<key>')`. A key that no feature
+/// checks is a dead toggle (the CEO flips it and nothing changes); a feature
+/// gated only on `role.slug` is override-blind. Both were the "toggles don't
+/// work" bug this test exists to prevent regressing.
+///
+/// Rule: every catalogue key NOT in `kHiddenPermissionKeys` must appear as a
+/// quoted string literal somewhere in `lib/` OUTSIDE the catalogue definition
+/// (`app_database.dart`) and the dependency map (`permission_dependencies.dart`)
+/// — i.e. in an actual enforcement reference. Hidden keys are exempt: their
+/// feature isn't built, so hiding the inert toggle is the documented choice.
+///
+/// This is the permission analogue of the Layer-C sync raw-write leak scanner
+/// (`test/sync/sync_raw_write_leak_test.dart`): a pure source scan, no Flutter
+/// binding. If it goes red, either wire the key with `hasPermission` or add it
+/// to `kHiddenPermissionKeys` (with a comment) until its feature ships.
+void main() {
+  test('every non-hidden permission key is enforced via hasPermission in lib/',
+      () {
+    final catalogue = _catalogueKeys();
+    expect(catalogue, isNotEmpty,
+        reason: 'Failed to parse _defaultPermissionRows from app_database.dart');
+
+    final hidden = _hiddenKeys();
+    expect(hidden, contains('sales.discount.give'),
+        reason: 'Failed to parse kHiddenPermissionKeys '
+            '(expected the known hidden key to be present)');
+
+    // Concatenate every scanned lib source once. Exclude the two files where a
+    // key literal is NOT an enforcement reference (the catalogue + the
+    // dependency map) and generated code.
+    final buf = StringBuffer();
+    for (final f in _dartFilesUnder('lib')) {
+      final path = f.path.replaceAll(r'\', '/');
+      if (path.endsWith('.g.dart')) continue;
+      if (path.endsWith('/core/database/app_database.dart')) continue;
+      if (path.endsWith('/core/permissions/permission_dependencies.dart')) {
+        continue;
+      }
+      buf.write(f.readAsStringSync());
+      buf.write('\n');
+    }
+    final scanned = buf.toString();
+
+    final unenforced = <String>[
+      for (final key in catalogue)
+        if (!hidden.contains(key) && !scanned.contains("'$key'")) key,
+    ]..sort();
+
+    expect(
+      unenforced,
+      isEmpty,
+      reason: 'Catalogue permission key(s) with NO enforcement reference in '
+          'lib/ — the per-staff toggle for each does nothing (CLAUDE.md hard '
+          'rule #6):\n  ${unenforced.join('\n  ')}\n\nFix by gating the feature '
+          "on hasPermission(ref, '<key>') / "
+          "currentUserPermissionsProvider.contains('<key>'), or — if the "
+          'feature is not built yet — add the key to kHiddenPermissionKeys in '
+          'role_permissions_detail_screen.dart with a comment.',
+    );
+  });
+}
+
+/// First string of each row in the `_defaultPermissionRows` literal in
+/// `app_database.dart` — the canonical permission catalogue.
+Set<String> _catalogueKeys() {
+  final src = File('lib/core/database/app_database.dart').readAsStringSync();
+  final start = src.indexOf('_defaultPermissionRows = [');
+  if (start < 0) return const {};
+  final end = src.indexOf('\n];', start);
+  if (end < 0) return const {};
+  final block = src.substring(start, end);
+  // Each row opens with `[` then (optionally across newlines) the key literal.
+  return RegExp(r"\[\s*'([^']+)'")
+      .allMatches(block)
+      .map((m) => m.group(1)!)
+      .toSet();
+}
+
+/// The quoted entries of the `kHiddenPermissionKeys` set literal in
+/// `role_permissions_detail_screen.dart`.
+Set<String> _hiddenKeys() {
+  final src = File('lib/core/settings/role_permissions_detail_screen.dart')
+      .readAsStringSync();
+  final start = src.indexOf('kHiddenPermissionKeys = {');
+  if (start < 0) return const {};
+  final end = src.indexOf('}', start);
+  if (end < 0) return const {};
+  final block = src.substring(start, end);
+  return RegExp(r"'([^']+)'")
+      .allMatches(block)
+      .map((m) => m.group(1)!)
+      .toSet();
+}
+
+List<File> _dartFilesUnder(String dir) {
+  final root = Directory(dir);
+  if (!root.existsSync()) return const [];
+  return root
+      .listSync(recursive: true)
+      .whereType<File>()
+      .where((f) => f.path.endsWith('.dart'))
+      .toList();
+}

--- a/test/permissions/user_permission_overrides_dao_test.dart
+++ b/test/permissions/user_permission_overrides_dao_test.dart
@@ -1,0 +1,78 @@
+import 'package:drift/drift.dart' show Value;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reebaplus_pos/core/database/app_database.dart';
+import 'package:reebaplus_pos/core/database/uuid_v7.dart';
+
+import '../helpers/dispatch_test_utils.dart';
+
+/// `UserPermissionOverridesDao.clearAllForUser` — the "Restore defaults" button
+/// on the per-staff permission screen (§10.2.1). Clearing must remove ONLY that
+/// staff member's overrides and tombstone each one so other devices drop it too
+/// (the live-revert path fixed by migration 0090).
+void main() {
+  late AppDatabase db;
+  late String businessId;
+  const userA = 'user-aaaa';
+  const userB = 'user-bbbb';
+
+  setUp(() async {
+    final boot = await bootstrapTestDb();
+    db = boot.db;
+    businessId = boot.businessId;
+    for (final u in const [(userA, 'Ada'), (userB, 'Bob')]) {
+      await db.into(db.users).insert(
+            UsersCompanion.insert(
+              id: Value(u.$1),
+              businessId: businessId,
+              name: u.$2,
+              pin: '0000',
+            ),
+          );
+    }
+  });
+
+  tearDown(() async => db.close());
+
+  // Seed overrides directly (as if pulled from the cloud / already synced), so
+  // the clear produces clean delete tombstones with no pending upsert to
+  // coalesce away.
+  Future<void> seedOverride(String userId, String key, bool granted) async {
+    await db.into(db.userPermissionOverrides).insert(
+          UserPermissionOverridesCompanion.insert(
+            id: Value(UuidV7.generate()),
+            businessId: businessId,
+            userId: userId,
+            permissionKey: key,
+            isGranted: granted,
+          ),
+        );
+  }
+
+  test('clears only that user\'s overrides, returns the count, tombstones each',
+      () async {
+    final dao = db.userPermissionOverridesDao;
+    await seedOverride(userA, 'activity_logs.view', true);
+    await seedOverride(userA, 'settings.manage', false);
+    await seedOverride(userB, 'sync.view', true);
+
+    final cleared = await dao.clearAllForUser(userA);
+
+    expect(cleared, 2, reason: 'returns the number of overrides removed');
+    expect(await dao.getForUser(userA), isEmpty);
+    expect((await dao.getForUser(userB)).length, 1,
+        reason: 'another staff member\'s overrides are untouched');
+
+    final deletes = (await getPendingQueue(db))
+        .where((q) => q.actionType == 'user_permission_overrides:delete')
+        .toList();
+    expect(deletes.length, 2,
+        reason: 'each cleared override enqueues a hard-delete so the removal '
+            'propagates live to other devices (0090)');
+  });
+
+  test('on a user with no overrides is a no-op returning 0', () async {
+    final dao = db.userPermissionOverridesDao;
+    expect(await dao.clearAllForUser(userA), 0);
+    expect(await dao.getForUser(userA), isEmpty);
+  });
+}

--- a/test/sync/replica_identity_full_test.dart
+++ b/test/sync/replica_identity_full_test.dart
@@ -1,0 +1,73 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// Sync safeguard — realtime DELETE propagation for hard-delete tables.
+///
+/// Supabase Realtime authorizes a DELETE against the row's RLS SELECT policy
+/// using only the columns in the table's REPLICA IDENTITY. Every hard-delete
+/// table here carries a `business_id`-scoped RLS policy, so unless the table is
+/// `REPLICA IDENTITY FULL`, `business_id` is absent from a delete's old record,
+/// the RLS check fails, and Realtime DROPS the DELETE — so a row the client
+/// hard-deletes never disappears live on other devices (it only clears on the
+/// next full snapshot reconcile). This was the per-staff-override "toggle ON
+/// propagates but toggle OFF doesn't revert" bug (migration 0090), and the
+/// `role_permissions` / `saved_carts` / `notifications` bug before it (0064).
+///
+/// Rule: every table the client hard-deletes — `_hardDeleteReconcileTables` in
+/// `supabase_sync_service.dart` (the `enqueueDelete` + realtime-DELETE +
+/// snapshot-reconcile set) — must have an `ALTER TABLE … REPLICA IDENTITY FULL`
+/// in some migration. Add a new hard-delete table and forget the migration and
+/// this goes red.
+void main() {
+  test('every hard-delete table is REPLICA IDENTITY FULL in a migration', () {
+    final tables = _hardDeleteTables();
+    expect(tables, isNotEmpty,
+        reason: 'Failed to parse _hardDeleteReconcileTables from '
+            'supabase_sync_service.dart');
+
+    final migrations = StringBuffer();
+    final dir = Directory('supabase/migrations');
+    if (dir.existsSync()) {
+      for (final f in dir.listSync().whereType<File>()) {
+        if (f.path.endsWith('.sql')) migrations.write(f.readAsStringSync());
+      }
+    }
+    final sql = migrations.toString();
+
+    final missing = <String>[
+      for (final t in tables)
+        if (!RegExp(
+                'ALTER\\s+TABLE\\s+(public\\.)?$t\\s+REPLICA\\s+IDENTITY\\s+FULL',
+                caseSensitive: false)
+            .hasMatch(sql))
+          t,
+    ]..sort();
+
+    expect(
+      missing,
+      isEmpty,
+      reason: 'Hard-delete table(s) with no `REPLICA IDENTITY FULL` migration — '
+          'their realtime DELETEs are dropped by RLS and never propagate live '
+          '(see migrations 0064 / 0090):\n  ${missing.join('\n  ')}\n\nAdd '
+          '`ALTER TABLE public.<table> REPLICA IDENTITY FULL;` in a new '
+          'migration and deploy it.',
+    );
+  });
+}
+
+/// The quoted entries of the `_hardDeleteReconcileTables` set literal in
+/// `supabase_sync_service.dart`.
+Set<String> _hardDeleteTables() {
+  final src =
+      File('lib/core/services/supabase_sync_service.dart').readAsStringSync();
+  final start = src.indexOf('_hardDeleteReconcileTables = {');
+  if (start < 0) return const {};
+  final end = src.indexOf('}', start);
+  if (end < 0) return const {};
+  final block = src.substring(start, end);
+  return RegExp(r"'([^']+)'")
+      .allMatches(block)
+      .map((m) => m.group(1)!)
+      .toSet();
+}

--- a/test/sync/sync_dao_enqueue_guard_test.dart
+++ b/test/sync/sync_dao_enqueue_guard_test.dart
@@ -1,0 +1,105 @@
+import 'package:drift/drift.dart' show Value;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reebaplus_pos/core/database/app_database.dart';
+import 'package:reebaplus_pos/core/database/uuid_v7.dart';
+
+import '../helpers/dispatch_test_utils.dart';
+
+/// Sync safeguard — Layer A (CLAUDE.md §5). `enqueueUpsert` / `enqueueDelete`
+/// must reject an unknown or typo'd table name at the local write boundary.
+/// The pusher dispatches `<table>:upsert` to `_supabase.from(table)` with no
+/// whitelist, so a bad name would otherwise stick forever as a failed queue
+/// row instead of surfacing the bug where it was made. Mirrors the
+/// `_ledgerTables` guard locked in by sync_dao_ledger_guard_test.dart.
+void main() {
+  group('SyncDao.enqueueUpsert table-name guard', () {
+    test('rejects an unregistered table name', () async {
+      final boot = await bootstrapTestDb();
+      try {
+        expect(
+          () => boot.db.syncDao.enqueueUpsert(
+            'not_a_table',
+            ProductsCompanion(
+              id: Value(UuidV7.generate()),
+              businessId: Value(boot.businessId),
+            ),
+          ),
+          throwsA(isA<StateError>()),
+        );
+      } finally {
+        await boot.db.close();
+      }
+    });
+
+    test('allows a synced table (products)', () async {
+      final boot = await bootstrapTestDb();
+      try {
+        // Should not throw — products is in _syncedTenantTables.
+        await boot.db.syncDao.enqueueUpsert(
+          'products',
+          ProductsCompanion(
+            id: Value(UuidV7.generate()),
+            businessId: Value(boot.businessId),
+          ),
+        );
+      } finally {
+        await boot.db.close();
+      }
+    });
+
+    test('allows a cache table (inventory)', () async {
+      final boot = await bootstrapTestDb();
+      try {
+        // Caches are enqueued + pushed but absent from _syncedTenantTables;
+        // they live in kSyncCacheTables, so the guard must allow them.
+        await boot.db.syncDao.enqueueUpsert(
+          'inventory',
+          InventoryCompanion(
+            id: Value(UuidV7.generate()),
+            businessId: Value(boot.businessId),
+          ),
+        );
+      } finally {
+        await boot.db.close();
+      }
+    });
+  });
+
+  group('SyncDao.enqueueDelete table-name guard', () {
+    test('rejects an unregistered table name', () async {
+      final boot = await bootstrapTestDb();
+      try {
+        expect(
+          () => boot.db.syncDao.enqueueDelete('not_a_table', UuidV7.generate()),
+          throwsA(isA<StateError>()),
+        );
+      } finally {
+        await boot.db.close();
+      }
+    });
+
+    test('rejects a cache table (not a delete target)', () async {
+      final boot = await bootstrapTestDb();
+      try {
+        // Caches are rebuilt from domain responses, never hard-deleted by a
+        // client. enqueueDelete only accepts _syncedTenantTables members.
+        expect(
+          () => boot.db.syncDao.enqueueDelete('inventory', UuidV7.generate()),
+          throwsA(isA<StateError>()),
+        );
+      } finally {
+        await boot.db.close();
+      }
+    });
+
+    test('allows a synced, non-ledger table (saved_carts)', () async {
+      final boot = await bootstrapTestDb();
+      try {
+        // Should not throw — saved_carts is soft-deletable.
+        await boot.db.syncDao.enqueueDelete('saved_carts', UuidV7.generate());
+      } finally {
+        await boot.db.close();
+      }
+    });
+  });
+}

--- a/test/sync/sync_raw_write_leak_test.dart
+++ b/test/sync/sync_raw_write_leak_test.dart
@@ -1,0 +1,137 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reebaplus_pos/core/database/app_database.dart';
+
+/// Sync safeguard — Layer C (CLAUDE.md §5). Catches the genuinely *silent*
+/// failure: a local write to a synced table that never enqueues, so the row
+/// lives on-device and the cloud never sees it (no queue row, nothing in the
+/// Sync Issues screen). Models the source-scan style of
+/// tool/lint_tenant_queries.dart, but method-scoped.
+///
+/// Rule: for every raw Drift write to a synced table — `into(<t>)`,
+/// `update(<t>)`, `delete(<t>)`, or a `customStatement/customUpdate/
+/// customInsert` whose SQL writes a synced table — the *enclosing method* must
+/// contain enqueue evidence (any `enqueue…(` / `…Enqueue…(` call, which covers
+/// `enqueueUpsert`, `enqueueDelete`, the `enqueue('domain:…')` envelope, and
+/// helper calls like `_enqueueFullProduct(`) OR a `// sync-exempt: <reason>`
+/// marker. Method-scoping (not statement adjacency) is required: enqueues live
+/// in other branches, later in transactions, or in helper methods.
+///
+/// Scope: the DAO file + lib/shared + lib/features + lib/core/services. The
+/// sync engine carries a `// sync-exempt-file:` marker (it restores
+/// cloud-authoritative state — §5 #1/#2). Generated `*.g.dart` is skipped.
+///
+/// Known limitation (acceptable): a leaky method that *also* contains an
+/// unrelated `enqueue…(` call would pass. Layer A still guards mis-targeted
+/// enqueues, and Layer B guards unregistered tables.
+void main() {
+  test('no raw write to a synced table escapes the enqueue path', () {
+    final syncedGetters = kSyncedTenantTables.map(_snakeToCamel).toSet();
+    final syncedSqlNames = kSyncedTenantTables.toSet();
+
+    final files = <File>[
+      File('lib/core/database/daos.dart'),
+      ..._dartFilesUnder('lib/shared'),
+      ..._dartFilesUnder('lib/features'),
+      ..._dartFilesUnder('lib/core/services'),
+    ];
+
+    final leaks = <String>[];
+    for (final file in files) {
+      if (!file.existsSync()) continue;
+      final src = file.readAsStringSync();
+      if (src.contains('// sync-exempt-file:')) continue;
+      _scan(file.path, src, syncedGetters, syncedSqlNames, leaks);
+    }
+
+    expect(
+      leaks,
+      isEmpty,
+      reason: 'Raw write(s) to a synced table with no enqueue in the enclosing '
+          'method — the row would never reach the cloud (CLAUDE.md §5):\n  '
+          '${leaks.join('\n  ')}\n\nRoute the write through a DAO that calls '
+          'enqueueUpsert / enqueueDelete / enqueue, or — if it is a legitimate '
+          '§5 exception — add a `// sync-exempt: <reason>` comment inside the '
+          'method (or `// sync-exempt-file: <reason>` for a whole sync-engine '
+          'file).',
+    );
+  });
+}
+
+/// `order_items` -> `orderItems` (snake SQL name -> Drift table getter).
+String _snakeToCamel(String snake) {
+  final parts = snake.split('_');
+  return parts.first +
+      parts.skip(1).map((p) {
+        if (p.isEmpty) return p;
+        return p[0].toUpperCase() + p.substring(1);
+      }).join();
+}
+
+List<File> _dartFilesUnder(String dir) {
+  final d = Directory(dir);
+  if (!d.existsSync()) return const [];
+  return d
+      .listSync(recursive: true)
+      .whereType<File>()
+      .where((f) => f.path.endsWith('.dart') && !f.path.endsWith('.g.dart'))
+      .toList();
+}
+
+/// Top-level member boundary: a newline + exactly two spaces + non-space.
+/// Same heuristic as tool/lint_tenant_queries.dart — bounds a class method.
+final _memberBoundary = RegExp(r'\n  [^\s]');
+
+/// Any enqueue-shaped call: enqueueUpsert(, enqueueDelete(, enqueue(,
+/// _enqueueFullProduct( … . A bare comment ("we don't enqueue it") has no `(`
+/// and so does not satisfy it.
+final _enqueueEvidence = RegExp(r'[Ee]nqueue\w*\(');
+
+/// `into(t)`, `update(t)`, `delete(t)` — optionally `into(db.t)` / `into(_db.t)`.
+/// Only matches when the sole argument is a single (optionally dotted)
+/// identifier, which is exactly the Drift table-write form.
+final _builderWrite = RegExp(r'\b(?:into|update|delete)\(\s*(?:\w+\.)?(\w+)\s*\)');
+
+/// Raw-SQL writes inside custom* calls: `INSERT INTO t` / `UPDATE t` /
+/// `DELETE FROM t`.
+final _sqlWrite =
+    RegExp(r'(?:INSERT\s+INTO|UPDATE|DELETE\s+FROM)\s+(\w+)', caseSensitive: true);
+
+void _scan(
+  String path,
+  String src,
+  Set<String> syncedGetters,
+  Set<String> syncedSqlNames,
+  List<String> leaks,
+) {
+  void consider(int matchStart, String table, String kind) {
+    final before = src.substring(0, matchStart);
+    final starts = _memberBoundary.allMatches(before);
+    final methodStart = starts.isEmpty ? 0 : starts.last.start;
+    final afterMatch = _memberBoundary.firstMatch(src.substring(matchStart));
+    final methodEnd =
+        afterMatch == null ? src.length : matchStart + afterMatch.start;
+    final body = src.substring(methodStart, methodEnd);
+
+    if (_enqueueEvidence.hasMatch(body)) return;
+    if (body.contains('// sync-exempt:')) return;
+
+    final line = '\n'.allMatches(before).length + 1;
+    leaks.add('$path:$line  $kind write to "$table" with no enqueue');
+  }
+
+  for (final m in _builderWrite.allMatches(src)) {
+    final getter = m.group(1)!;
+    if (syncedGetters.contains(getter)) {
+      consider(m.start, getter, 'drift');
+    }
+  }
+
+  for (final m in _sqlWrite.allMatches(src)) {
+    final table = m.group(1)!;
+    if (syncedSqlNames.contains(table)) {
+      consider(m.start, table, 'sql');
+    }
+  }
+}

--- a/test/sync/sync_table_registration_test.dart
+++ b/test/sync/sync_table_registration_test.dart
@@ -1,0 +1,52 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reebaplus_pos/core/database/app_database.dart';
+
+import '../helpers/dispatch_test_utils.dart';
+
+/// Sync safeguard — Layer B (CLAUDE.md §5). The keystone future-proofing.
+///
+/// Reflects over the live Drift schema and asserts that every table carrying
+/// the "sync fingerprint" — BOTH a `business_id` and a `last_updated_at`
+/// column — is registered for sync (in `_syncedTenantTables`) or is an
+/// explicitly-exempt Phase D cache (`kSyncCacheTables`).
+///
+/// This makes the most common silent-sync failure impossible to merge: adding
+/// a new tenant table and forgetting to register it. A new fingerprinted table
+/// turns this test red until the author makes a deliberate choice — register
+/// it, or declare it an intentional cache.
+///
+/// One-directional on purpose: fingerprint ⇒ registered. We do NOT assert the
+/// reverse (every synced table is fingerprinted) — `businesses` syncs via its
+/// own realtime channel and has no `business_id`, and a future synced table
+/// could legitimately omit a column.
+void main() {
+  test('every sync-fingerprinted table is registered for sync', () async {
+    final boot = await bootstrapTestDb();
+    try {
+      final unregistered = <String>[];
+      for (final table in boot.db.allTables) {
+        final cols = table.$columns.map((c) => c.name).toSet();
+        final fingerprinted =
+            cols.contains('business_id') && cols.contains('last_updated_at');
+        if (!fingerprinted) continue;
+
+        final name = table.actualTableName;
+        if (kSyncedTenantTables.contains(name)) continue;
+        if (kSyncCacheTables.contains(name)) continue;
+        unregistered.add(name);
+      }
+
+      expect(
+        unregistered,
+        isEmpty,
+        reason: 'These tables carry the sync fingerprint (business_id + '
+            'last_updated_at) but are not registered for sync: $unregistered.\n'
+            'Add each to `_syncedTenantTables` in app_database.dart (and route '
+            'its writes through a DAO that enqueues — CLAUDE.md §5), or to '
+            '`kSyncCacheTables` if it is an intentional Phase D cache.',
+      );
+    } finally {
+      await boot.db.close();
+    }
+  });
+}

--- a/test/utils/date_period_test.dart
+++ b/test/utils/date_period_test.dart
@@ -2,17 +2,20 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:reebaplus_pos/core/utils/date_period.dart';
 
 void main() {
-  // Fixed reference instant so the rolling windows are deterministic.
-  final now = DateTime.utc(2026, 6, 1, 12, 0, 0);
+  // Fixed reference instant so the calendar boundaries are deterministic.
+  // 2026-06-03 is a Wednesday; its Sunday-start week begins 2026-05-31.
+  // Built as a LOCAL DateTime so it matches how `startFrom` constructs
+  // boundaries (local date parts), independent of the runner's timezone.
+  final now = DateTime(2026, 6, 3, 12, 0, 0);
 
   group('canonical labels', () {
     test('kDatePeriodLabels is the agreed set, in order', () {
       expect(kDatePeriodLabels, [
-        'Last 24 hours',
-        'Last 7 days',
-        'Last 30 days',
-        'Last year',
-        'To date',
+        'Today',
+        'This Week',
+        'This Month',
+        'This Year',
+        'To Date',
       ]);
     });
 
@@ -23,25 +26,30 @@ void main() {
     });
   });
 
-  group('datePeriodFromLabel tolerates legacy labels', () {
-    test('Day / Today -> last24Hours', () {
-      expect(datePeriodFromLabel('Day'), DatePeriod.last24Hours);
-      expect(datePeriodFromLabel('Today'), DatePeriod.last24Hours);
+  group('datePeriodFromLabel tolerates legacy / rolling labels', () {
+    test('Today / Day / Last 24 hours -> today', () {
+      expect(datePeriodFromLabel('Today'), DatePeriod.today);
+      expect(datePeriodFromLabel('Day'), DatePeriod.today);
+      expect(datePeriodFromLabel('Last 24 hours'), DatePeriod.today);
     });
-    test('Week / This Week / 7 Days -> last7Days', () {
-      expect(datePeriodFromLabel('Week'), DatePeriod.last7Days);
-      expect(datePeriodFromLabel('This Week'), DatePeriod.last7Days);
-      expect(datePeriodFromLabel('7 Days'), DatePeriod.last7Days);
+    test('This Week / Week / 7 Days / Last 7 days -> thisWeek', () {
+      expect(datePeriodFromLabel('This Week'), DatePeriod.thisWeek);
+      expect(datePeriodFromLabel('Week'), DatePeriod.thisWeek);
+      expect(datePeriodFromLabel('7 Days'), DatePeriod.thisWeek);
+      expect(datePeriodFromLabel('Last 7 days'), DatePeriod.thisWeek);
     });
-    test('Month / This Month / 30 Days / This Quarter -> last30Days', () {
-      expect(datePeriodFromLabel('Month'), DatePeriod.last30Days);
-      expect(datePeriodFromLabel('This Month'), DatePeriod.last30Days);
-      expect(datePeriodFromLabel('30 Days'), DatePeriod.last30Days);
-      expect(datePeriodFromLabel('This Quarter'), DatePeriod.last30Days);
+    test('This Month / Month / 30 Days / This Quarter / Last 30 days -> thisMonth',
+        () {
+      expect(datePeriodFromLabel('This Month'), DatePeriod.thisMonth);
+      expect(datePeriodFromLabel('Month'), DatePeriod.thisMonth);
+      expect(datePeriodFromLabel('30 Days'), DatePeriod.thisMonth);
+      expect(datePeriodFromLabel('This Quarter'), DatePeriod.thisMonth);
+      expect(datePeriodFromLabel('Last 30 days'), DatePeriod.thisMonth);
     });
-    test('Year / This Year -> lastYear', () {
-      expect(datePeriodFromLabel('Year'), DatePeriod.lastYear);
-      expect(datePeriodFromLabel('This Year'), DatePeriod.lastYear);
+    test('This Year / Year / Last year -> thisYear', () {
+      expect(datePeriodFromLabel('This Year'), DatePeriod.thisYear);
+      expect(datePeriodFromLabel('Year'), DatePeriod.thisYear);
+      expect(datePeriodFromLabel('Last year'), DatePeriod.thisYear);
     });
     test('To Date / All / All Time / unknown -> toDate', () {
       expect(datePeriodFromLabel('To Date'), DatePeriod.toDate);
@@ -50,79 +58,77 @@ void main() {
       expect(datePeriodFromLabel('something weird'), DatePeriod.toDate);
     });
     test('is case- and whitespace-insensitive', () {
-      expect(datePeriodFromLabel('  last 7 DAYS '), DatePeriod.last7Days);
+      expect(datePeriodFromLabel('  THIS week '), DatePeriod.thisWeek);
     });
   });
 
-  group('startFrom', () {
+  group('startFrom — calendar boundaries (anchored to now)', () {
     test('toDate is unbounded (null)', () {
       expect(DatePeriod.toDate.startFrom(now), isNull);
     });
-    test('windows subtract the right span', () {
-      expect(DatePeriod.last24Hours.startFrom(now),
-          now.subtract(const Duration(hours: 24)));
-      expect(DatePeriod.last7Days.startFrom(now),
-          now.subtract(const Duration(days: 7)));
-      expect(DatePeriod.last30Days.startFrom(now),
-          now.subtract(const Duration(days: 30)));
-      expect(DatePeriod.lastYear.startFrom(now),
-          now.subtract(const Duration(days: 365)));
+    test('today starts at local midnight today', () {
+      expect(DatePeriod.today.startFrom(now), DateTime(2026, 6, 3));
+    });
+    test('thisWeek starts at the most recent Sunday (Sunday-start week)', () {
+      // Wednesday 2026-06-03 -> Sunday 2026-05-31.
+      expect(DatePeriod.thisWeek.startFrom(now), DateTime(2026, 5, 31));
+      expect(DatePeriod.thisWeek.startFrom(now)!.weekday, DateTime.sunday);
+    });
+    test('thisWeek on a Sunday starts that same Sunday', () {
+      final sunday = DateTime(2026, 5, 31, 9, 0); // a Sunday
+      expect(DatePeriod.thisWeek.startFrom(sunday), DateTime(2026, 5, 31));
+    });
+    test('thisWeek on a Saturday starts the previous Sunday', () {
+      final saturday = DateTime(2026, 6, 6, 9, 0); // a Saturday
+      expect(DatePeriod.thisWeek.startFrom(saturday), DateTime(2026, 5, 31));
+    });
+    test('thisMonth starts at the first of the month', () {
+      expect(DatePeriod.thisMonth.startFrom(now), DateTime(2026, 6, 1));
+    });
+    test('thisYear starts at Jan 1', () {
+      expect(DatePeriod.thisYear.startFrom(now), DateTime(2026, 1, 1));
     });
   });
 
-  group('includes — boundaries (the bug we are fixing)', () {
-    test('last 24 hours: 23h ago in, 25h ago out', () {
+  group('includes — calendar boundaries', () {
+    test('today: midnight today in, one second before out, later today in', () {
+      expect(DatePeriod.today.includes(DateTime(2026, 6, 3), now: now), isTrue);
       expect(
-          DatePeriod.last24Hours
-              .includes(now.subtract(const Duration(hours: 23)), now: now),
-          isTrue);
-      expect(
-          DatePeriod.last24Hours
-              .includes(now.subtract(const Duration(hours: 25)), now: now),
-          isFalse);
-    });
-
-    test('last 7 days: 6d ago in, exactly 7d in, 7d+1s out', () {
-      expect(
-          DatePeriod.last7Days
-              .includes(now.subtract(const Duration(days: 6)), now: now),
-          isTrue);
-      // boundary is inclusive at exactly the start
-      expect(
-          DatePeriod.last7Days
-              .includes(now.subtract(const Duration(days: 7)), now: now),
-          isTrue);
-      expect(
-          DatePeriod.last7Days.includes(
-              now.subtract(const Duration(days: 7, seconds: 1)),
+          DatePeriod.today.includes(
+              DateTime(2026, 6, 2, 23, 59, 59),
               now: now),
           isFalse);
+      expect(DatePeriod.today.includes(DateTime(2026, 6, 3, 11), now: now),
+          isTrue);
     });
 
-    test('last 30 days: 29d in, 31d out', () {
-      expect(
-          DatePeriod.last30Days
-              .includes(now.subtract(const Duration(days: 29)), now: now),
+    test('thisWeek: Sunday start in, the moment before out', () {
+      expect(DatePeriod.thisWeek.includes(DateTime(2026, 5, 31), now: now),
           isTrue);
       expect(
-          DatePeriod.last30Days
-              .includes(now.subtract(const Duration(days: 31)), now: now),
+          DatePeriod.thisWeek
+              .includes(DateTime(2026, 5, 30, 23, 59, 59), now: now),
           isFalse);
     });
 
-    test('last year: 364d in, 366d out', () {
-      expect(
-          DatePeriod.lastYear
-              .includes(now.subtract(const Duration(days: 364)), now: now),
+    test('thisMonth: 1st in, last day of prior month out', () {
+      expect(DatePeriod.thisMonth.includes(DateTime(2026, 6, 1), now: now),
           isTrue);
       expect(
-          DatePeriod.lastYear
-              .includes(now.subtract(const Duration(days: 366)), now: now),
+          DatePeriod.thisMonth.includes(DateTime(2026, 5, 31, 23), now: now),
           isFalse);
     });
 
-    test('to date includes everything, however old, and the future', () {
-      expect(DatePeriod.toDate.includes(DateTime.utc(1990), now: now), isTrue);
+    test('thisYear: Jan 1 in, Dec 31 of prior year out', () {
+      expect(DatePeriod.thisYear.includes(DateTime(2026, 1, 1), now: now),
+          isTrue);
+      expect(
+          DatePeriod.thisYear.includes(DateTime(2025, 12, 31, 23), now: now),
+          isFalse);
+    });
+
+    test('toDate includes everything, however old, and the future', () {
+      expect(DatePeriod.toDate.includes(DateTime(1990), now: now), isTrue);
       expect(
           DatePeriod.toDate
               .includes(now.add(const Duration(days: 10)), now: now),
@@ -131,24 +137,32 @@ void main() {
   });
 
   group('includes — zone handling', () {
-    test('a local-zoned timestamp compares as the same instant as UTC now', () {
-      // 1 hour ago expressed in local time must be "in" the 24h window even
-      // though `now` is UTC — the helper normalises both to UTC.
-      final localOneHourAgo =
-          now.toLocal().subtract(const Duration(hours: 1));
-      expect(DatePeriod.last24Hours.includes(localOneHourAgo, now: now),
-          isTrue);
+    test('a UTC-zoned timestamp compares as the same instant', () {
+      // 11:00 today expressed in UTC is still "in" today's window when `now`
+      // is 12:00 — the helper normalises both to UTC before comparing.
+      final utcEarlierToday = DateTime(2026, 6, 3, 11).toUtc();
+      expect(DatePeriod.today.includes(utcEarlierToday, now: now), isTrue);
+    });
+  });
+
+  group('datePeriodLabelsForRole', () {
+    test('Manager-or-above gets the full five', () {
+      expect(datePeriodLabelsForRole(managerUp: true), kDatePeriodLabels);
+    });
+    test('below Manager is capped to Today / This Week / This Month', () {
+      expect(datePeriodLabelsForRole(managerUp: false),
+          ['Today', 'This Week', 'This Month']);
     });
   });
 
   group('dateRangeForLabel', () {
-    test('returns (start, null) for a bounded window', () {
-      final (start, end) = dateRangeForLabel('Last 7 days', now: now);
-      expect(start, now.subtract(const Duration(days: 7)));
+    test('returns (start, null) for a bounded period', () {
+      final (start, end) = dateRangeForLabel('This Month', now: now);
+      expect(start, DateTime(2026, 6, 1));
       expect(end, isNull);
     });
     test('returns (null, null) for to date', () {
-      final (start, end) = dateRangeForLabel('To date', now: now);
+      final (start, end) = dateRangeForLabel('To Date', now: now);
       expect(start, isNull);
       expect(end, isNull);
     });

--- a/tools/git-hooks/README.md
+++ b/tools/git-hooks/README.md
@@ -1,0 +1,51 @@
+# Git hooks — secret / sensitive-file guard
+
+These hooks stop secrets and sensitive files from being committed or pushed to the
+(private) repo. They are plain POSIX shell — **nothing to install**.
+
+## One-time activation (per clone)
+
+Git does not auto-enable hooks on clone, so run this once after cloning on any
+machine:
+
+```sh
+git config core.hooksPath tools/git-hooks
+chmod +x tools/git-hooks/pre-commit tools/git-hooks/pre-push
+```
+
+Verify with: `git config core.hooksPath` → should print `tools/git-hooks`.
+
+## What gets blocked
+
+**Sensitive filenames** (even with `git add -f`): `.env*`, `.envrc`, `*.jks`,
+`*.keystore`, `key.properties`, `*.pem`, `*.p12`, `*.p8`, `*.pfx`,
+`google-services.json`, `GoogleService-Info.plist`, `service-account*.json`, `id_rsa*`.
+
+**Secret content pasted into any tracked file** (scanned in the staged diff):
+- private-key blocks (`-----BEGIN ... PRIVATE KEY-----`)
+- AWS access key ids (`AKIA…`)
+- Supabase **service-role** keys (JWT whose decoded payload says `service_role`)
+
+It intentionally does **not** flag the Supabase **anon** key in `lib/main.dart`:
+anon keys are client-public by design (they ship in every APK and are gated by
+row-level security), so blocking them would be a permanent false positive.
+
+- `pre-commit` runs on `git commit` and scans the staged changes.
+- `pre-push` runs on `git push` and re-scans the commits being pushed (backstop for
+  anything committed with `--no-verify`).
+
+## Escape hatch
+
+If you are certain a flagged item is safe:
+
+```sh
+git commit --no-verify     # skip pre-commit
+git push   --no-verify     # skip pre-push
+```
+
+## Note
+
+This is a local guard. It is not enforced on GitHub's servers (server-side push
+protection requires GitHub's paid Secret Protection add-on, which isn't available
+on personal private repos). Keep `core.hooksPath` set on every machine you commit
+from.

--- a/tools/git-hooks/_scan.sh
+++ b/tools/git-hooks/_scan.sh
@@ -1,0 +1,77 @@
+#!/bin/sh
+# Shared secret-scanning logic for the pre-commit and pre-push hooks.
+# Sourced by both hooks. POSIX sh; only needs git, grep, tr, cut, base64.
+#
+# It deliberately flags ONLY high-signal secrets so it never false-positives on
+# the Supabase *anon* key that legitimately ships in lib/main.dart (anon keys are
+# client-public by design). It targets: sensitive filenames, private-key blocks,
+# AWS access keys, and Supabase *service-role* keys (the dangerous ones).
+
+# Filenames that must never be committed (extended-regex, matched on the path).
+SECRET_FILENAME_RE='(^|/)\.env(\.[^/]+)?$|(^|/)\.envrc$|\.jks$|\.keystore$|(^|/)key\.properties$|\.pem$|\.p12$|\.p8$|\.pfx$|(^|/)google-services\.json$|GoogleService-Info\.plist$|service-account[^/]*\.json$|(^|/)id_rsa'
+
+# Best-effort base64url decode (JWT payload segment). Prints decoded bytes or
+# nothing. Tries GNU (-d) then BSD/macOS (-D).
+_b64url_decode() {
+  s=$(printf '%s' "$1" | tr '_-' '/+')
+  case $(( ${#s} % 4 )) in
+    2) s="${s}==" ;;
+    3) s="${s}=" ;;
+  esac
+  printf '%s' "$s" | base64 -d 2>/dev/null || printf '%s' "$s" | base64 -D 2>/dev/null || true
+}
+
+# secret_scan <newline-separated-file-list> <unified-diff-text>
+# Prints any violations to stdout. Returns 0 when clean, 1 when something is found.
+secret_scan() {
+  _files=$1
+  _diff=$2
+  _bad=0
+
+  # --- 1. Filename blocklist (also catches `git add -f`) ------------------
+  if [ -n "$_files" ]; then
+    _hits=$(printf '%s\n' "$_files" | grep -E "$SECRET_FILENAME_RE" || true)
+    if [ -n "$_hits" ]; then
+      printf '%s\n' "$_hits" | while IFS= read -r f; do
+        [ -n "$f" ] && printf '  x sensitive filename: %s\n' "$f"
+      done
+      _bad=1
+    fi
+  fi
+
+  # --- 2. Content scan of ADDED lines only -------------------------------
+  _added=$(printf '%s\n' "$_diff" | grep -E '^\+' | grep -Ev '^\+\+\+' || true)
+  if [ -n "$_added" ]; then
+    # 2a. Private key blocks
+    if printf '%s\n' "$_added" | grep -Eq -- '-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----'; then
+      printf '  x private key block (-----BEGIN ... PRIVATE KEY-----)\n'
+      _bad=1
+    fi
+    # 2b. AWS access key id
+    if printf '%s\n' "$_added" | grep -Eq 'AKIA[0-9A-Z]{16}'; then
+      printf '  x AWS access key id (AKIA...)\n'
+      _bad=1
+    fi
+    # 2c. Supabase service-role JWT: decode payload, look for service_role
+    _jwts=$(printf '%s\n' "$_added" | grep -oE 'eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}' || true)
+    if [ -n "$_jwts" ]; then
+      _sr=$(printf '%s\n' "$_jwts" | while IFS= read -r jwt; do
+        [ -n "$jwt" ] || continue
+        if _b64url_decode "$(printf '%s' "$jwt" | cut -d. -f2)" | grep -q 'service_role'; then
+          echo HIT
+        fi
+      done)
+      if [ -n "$_sr" ]; then
+        printf '  x Supabase SERVICE-ROLE key (decoded JWT role=service_role)\n'
+        _bad=1
+      fi
+    fi
+    # 2d. Cheap fallback: a line naming service_role alongside a JWT
+    if printf '%s\n' "$_added" | grep -Eiq 'service_role.*eyJ[A-Za-z0-9_-]{10,}\.'; then
+      printf '  x service-role key (service_role label + JWT)\n'
+      _bad=1
+    fi
+  fi
+
+  return $_bad
+}

--- a/tools/git-hooks/pre-commit
+++ b/tools/git-hooks/pre-commit
@@ -1,0 +1,20 @@
+#!/bin/sh
+# Block secrets / sensitive files from being committed.
+# Active via:  git config core.hooksPath tools/git-hooks   (see README.md)
+# Override (only when you are SURE it's a false positive):  git commit --no-verify
+
+set -u
+DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+. "$DIR/_scan.sh"
+
+files=$(git diff --cached --name-only --diff-filter=ACM)
+diff=$(git diff --cached --diff-filter=ACM)
+
+if secret_scan "$files" "$diff"; then
+  exit 0
+fi
+
+printf '\n[BLOCKED] commit stopped: possible secret / sensitive file (see above).\n'
+printf '  - Remove it from the staging area, e.g.  git restore --staged <file>\n'
+printf '  - If it is genuinely safe, override with:  git commit --no-verify\n\n'
+exit 1

--- a/tools/git-hooks/pre-push
+++ b/tools/git-hooks/pre-push
@@ -1,0 +1,40 @@
+#!/bin/sh
+# Backstop: re-scan the commits about to be pushed, in case a secret slipped in
+# via `git commit --no-verify` or before the hook existed.
+# Override (NOT recommended):  git push --no-verify
+
+set -u
+DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+. "$DIR/_scan.sh"
+
+bad=0
+
+# git feeds one line per ref on stdin: <local_ref> <local_sha> <remote_ref> <remote_sha>
+while read -r local_ref local_sha remote_ref remote_sha; do
+  # branch deletion (local sha all zeros) -> nothing to scan
+  if printf '%s' "$local_sha" | grep -Eq '^0+$'; then
+    continue
+  fi
+  if printf '%s' "$remote_sha" | grep -Eq '^0+$'; then
+    # new branch on the remote: scan commits not already on any remote
+    commits=$(git rev-list "$local_sha" --not --remotes)
+  else
+    commits=$(git rev-list "$remote_sha".."$local_sha")
+  fi
+  for c in $commits; do
+    files=$(git show --name-only --diff-filter=ACM --format= "$c")
+    cdiff=$(git show --diff-filter=ACM --format= "$c")
+    if ! secret_scan "$files" "$cdiff"; then
+      printf '   ^ in commit %s\n' "$(git show -s --format='%h %s' "$c")"
+      bad=1
+    fi
+  done
+done
+
+if [ "$bad" -ne 0 ]; then
+  printf '\n[BLOCKED] push stopped: possible secret in the commits above.\n'
+  printf '  - Remove the secret and rewrite history (e.g. git rebase / amend), then re-push.\n'
+  printf '  - To override (NOT recommended):  git push --no-verify\n\n'
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## What this delivers (our work)

Makes per-staff permission overrides actually take effect, fixes a cross-device sync bug, and adds a Restore-defaults action.

### 1. Enforcement — overrides now take effect everywhere
The per-user override system saved fine, but toggling a permission off often changed nothing because the feature gated on the **role slug** / the wrong key / nothing / the **raw role grants** instead of the **effective** permission. Audited all 29 toggle keys (auditors + adversarial verifiers); 22 were already correct, 9 were real leaks — all fixed to use `hasPermission` / `currentUserPermissionsProvider`:
`reports.see_profit`, `customers.add`, `customers.wallet.totals.view`, `customers.wallet.update`, `suppliers.manage`, `staff.invite`, `reports.see_cost_prices`. Two toggles whose features aren't built (`customers.update`, `shipments.manage`) are **hidden** from both editors.
Guardrail: `test/permissions/permission_enforcement_test.dart` fails if any non-hidden catalogue key has no enforcement reference.

### 2. Live-revert fix — migration 0090
Turning an override **off** for a stock keeper *deletes* the row (hard delete). Realtime authorizes a DELETE against the row's `business_id`-scoped RLS using only the `REPLICA IDENTITY` columns; `user_permission_overrides` (added in 0088, after 0064) was still PK-only, so `business_id` was absent and Realtime **dropped the DELETE** — ON propagated, OFF didn't. `0090` sets `REPLICA IDENTITY FULL` (the 4th hard-delete table, missed by 0064). **Already deployed via `supabase db push`.** Guardrail: `test/sync/replica_identity_full_test.dart` covers every hard-delete table.

### 3. Restore defaults button
Bottom of the per-staff permission screen. Clears all of a staff member's overrides (→ role defaults) via `clearAllForUser` (hard-delete + enqueue, so it propagates live). **Confirmation dialog** so a stray tap can't wipe overrides; disabled when there are none; hidden for the CEO. Documented in master plan §10.2.1; covered by `test/permissions/user_permission_overrides_dao_test.dart`.

## ⚠️ Scope note for reviewers
This branch is a **snapshot of the whole working tree**, so it also bundles unrelated in-progress work that was already uncommitted: a permission-label rename in `app_database.dart`, `date_period` changes, the sync-write-guardrail tests + `tools/git-hooks`, `stock_approvals_screen.dart`, and migrations 0088/0089. The label-rename has **6 pre-existing failing tests** in `test/settings/role_permissions_detail_test.dart` (old labels + a hard-coded switch count) — owned by that work, not this change. Please review/split before merging to main if you want those separated.

## Test plan
- `flutter analyze` clean on all touched files.
- `flutter test test/permissions test/sync test/staff test/customers test/inventory` → pass.
- On-device: as CEO, revoke `reports.see_profit` from a Manager / `customers.add` from a Cashier → switch to that staff (shared-PIN) → gated UI disappears. Toggle a stock keeper override ON then OFF → reverts live (0090). Tap **Restore defaults** → confirm → all overrides clear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stock adjustment approval workflow: stock keepers now submit requests for inventory changes that require manager/CEO approval.
  * Added per-user permission customization allowing staff members to override their role-based permissions.
  * Added Stock Approvals report card for managing pending requests.
  * Switched date filters from rolling windows to calendar-anchored periods (Today, This Week, This Month, This Year, To Date).

* **Bug Fixes**
  * Improved floating action button positioning above system navigation bars.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->