### PR TITLE
Business-Scoped Stream primitive: guarded factory + full migration (#23 #24 #25)

### DIFF
--- a/BUILD_LOG.md
+++ b/BUILD_LOG.md
@@ -2,6 +2,54 @@
 
 ---
 
+## 2026-07-03 — Business-Scoped Stream primitive: guarded factory + full migration (PRD #23 = #24 + #25)
+
+**Scope:** retire the build-time-poison provider bug *by construction*. A
+business-scoped `StreamProvider` that calls a `requireBusinessId()`-backed DAO
+`watch*()` baked the session businessId at first build and, if first-subscribed
+in the create-business null window, either **threw + stuck errored** or
+**silent-empty-stuck** for the whole session (empty Receive/Transfer/POS store
+pickers until restart). Fixed once per provider before (S153); now unrepresentable.
+
+**New primitive — `lib/core/providers/business_scoped_stream.dart`:**
+- `currentBusinessIdProvider` — the single watchable businessId seam
+  (`authProvider.select(currentUser?.businessId)`). Nothing else re-derives the
+  tenant; tests flip it via `overrideWith`.
+- Four guarded factories: `businessScopedStream` / `businessScopedStreamFamily`
+  + `…AutoDispose` / `…AutoDisposeFamily` twins (Riverpod types keep-alive and
+  autoDispose distinctly, so lifecycle is preserved). Each watches the seam,
+  emits a required `whenAbsent` while unbound, and hands the closure
+  **`(ref, db, businessId)`** with a guaranteed non-null id (`ref` lets the few
+  store-scoped feeds compose `lockedStoreProvider`).
+
+**Migration:** 62 session-scoped stream declarations lifted onto the factory
+across `stream_providers.dart` + `app_providers.dart` — behaviour-preserving
+(`whenAbsent` = the prior null-window value). Consumers untouched. The
+FutureProvider `firstPullCompletedProvider` was repointed onto the seam so no
+inline `authProvider.select(...businessId)` remains.
+
+**Stayed raw (allowlist, 11):** permissions catalogue + unscoped roles (global);
+`_userMemberships` / `myUserStores` / `activeStaff` / `deviceStaff` (explicit-id,
+resolve before bind — routing them through the factory would break the shared-PIN
+picker); `orphanQueueItems` / `orphanQueueCount` (device-local, no `business_id`);
+`localBusinesses` / `pendingCrateReturns` / `pendingReturnsWithDetails`
+(intentionally unscoped selects).
+
+**Enforcement + tests:**
+- `test/providers/business_scoped_stream_ban_test.dart` — bans a raw
+  `StreamProvider` declaration anywhere in `lib/` (name-keyed allowlist,
+  shrink-only ratchet) + companion strictness test (planted raw caught, multi-line
+  caught, all four factory forms not flagged). Modeled on `gate_static_ban_test.dart`.
+- `test/providers/business_scoped_stream_test.dart` — drives the factory
+  `null → bound → switched → unbound` through the seam override and proves it never
+  runs the closure in the null window. No database required.
+
+**Verified:** `flutter analyze` clean. Full suite 652 passed / 58 skipped /
+1 pre-existing failure (`who_is_working_screen_test.dart` "Carol" — fails
+identically with these changes stashed, unrelated to this work).
+
+---
+
 ## 2026-07-03 — Flip the gate enforcement: empty the allowlist, remove the bare helpers (issue #22)
 
 **Scope:** the epic #16 finish line. The named-gate migration's shrinking

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -61,8 +61,9 @@ is baked and sticks stale/empty for the session).
 
 **Business-Scoped Stream**:
 A live-query provider declared through the `businessScopedStream` factory (or
-`businessScopedStreamFamily` for keyed ones). It watches the Current Business
-Id, emits its required `whenAbsent` value until a business is bound, hands the
-closure the resolved non-null id, and rebuilds on bind or switch — so a
-tenant-scoped read cannot be baked to a missing or stale business at build time.
+`businessScopedStreamFamily` for keyed ones, plus `…AutoDispose` twins). It
+watches the Current Business Id, emits its required `whenAbsent` value until a
+business is bound, hands the closure `(ref, db, businessId)` with the resolved
+non-null id, and rebuilds on bind or switch — so a tenant-scoped read cannot be
+baked to a missing or stale business at build time.
 _Avoid_: raw `StreamProvider` over a DAO `watch*`, inline businessId guards.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -48,3 +48,21 @@ An outbox entry the cloud has *permanently* rejected (e.g. `42501` / `P0001` /
 identity drift), moved to `sync_queue_orphans`. Still un-uploaded local data the
 Outbox invariant protects: visible and exportable, never silently dropped.
 _Avoid_: failed row, dead-letter.
+
+### Scoping
+
+**Current Business Id**:
+The id of the tenant bound to the current session — null until a business binds
+(login, or the create-business handoff). A device may hold more than one
+business's data, so every tenant-scoped read filters to it. Exposed reactively
+by `currentBusinessIdProvider`, the single watchable source.
+_Avoid_: reading `db.currentBusinessId` at build time (non-reactive → the read
+is baked and sticks stale/empty for the session).
+
+**Business-Scoped Stream**:
+A live-query provider declared through the `businessScopedStream` factory (or
+`businessScopedStreamFamily` for keyed ones). It watches the Current Business
+Id, emits its required `whenAbsent` value until a business is bound, hands the
+closure the resolved non-null id, and rebuilds on bind or switch — so a
+tenant-scoped read cannot be baked to a missing or stale business at build time.
+_Avoid_: raw `StreamProvider` over a DAO `watch*`, inline businessId guards.

--- a/CONTEXT/progress-tracker.md
+++ b/CONTEXT/progress-tracker.md
@@ -8,9 +8,50 @@ The human updates it when resolving open questions or making architectural decis
 
 ## Current Phase
 
-151 sessions logged. Codebase is live and being verified on-device.
+152 sessions logged. Codebase is live and being verified on-device.
 
-### Design landed (not yet built): Business-Scoped Stream primitive (2026-07-03, PRD #23 → issues #24, #25)
+### SHIPPED: Business-Scoped Stream primitive — factory + full migration (2026-07-03, PRD #23 = issues #24 + #25)
+- **Built both slices in one pass.** New `lib/core/providers/business_scoped_stream.dart`:
+  the `currentBusinessIdProvider` seam (`authProvider.select(currentUser?.businessId)`)
+  plus four guarded factories — `businessScopedStream` /
+  `businessScopedStreamFamily` and their `…AutoDispose` twins (Riverpod types
+  keep-alive and autoDispose streams distinctly, so preserving each provider's
+  lifecycle needs the twin). Each watches the seam, emits a required `whenAbsent`
+  while unbound, and hands the closure **`(ref, db, businessId)`** with a
+  guaranteed non-null id. `ref` is passed (a small, documented deviation from the
+  ADR's `(db, businessId)`) because several tenant feeds must compose
+  `lockedStoreProvider` to derive store scope; the guarantee is unchanged.
+- **Migration surface was bigger than the "~41" estimate: 62 session-scoped
+  declarations** migrated across `stream_providers.dart` (all order/expense/
+  transfer/product/category/manufacturer/supplier/role/permission/crate/stock
+  feeds, incl. the `allStoresProvider` throw-poison tracer + the
+  `storeInventoryCountsProvider` silent-empty custom-SQL tracer) and
+  `app_providers.dart` (supplier ledger/crate feeds, customer credit, the
+  business-scoped `sync_queue` feeds, `hasLocalProductsProvider`). Each is a
+  behaviour-preserving lift — `whenAbsent` equals what it emitted before
+  (`[]` / `{}` / `0` / `null` / `kDefaultCurrency` / a `.empty()` stats zero).
+  **Consumers untouched.** Prefactor also repointed the FutureProvider
+  `firstPullCompletedProvider` onto the seam (no inline `.select` left).
+- **Final allowlist = 11 genuinely non-session-scoped streams** (not just the 2
+  globals): the permissions catalogue + unscoped roles; 4 explicit-id feeds
+  resolved *before* bind (`_userMemberships`, `myUserStores`, `activeStaff`,
+  `deviceStaff` — the shared-PIN / Who's-Working pickers); 2 device-local engine
+  feeds (`orphanQueueItems`, `orphanQueueCount` — `sync_queue_orphans` has no
+  `business_id`); 3 intentionally-unscoped selects (`localBusinesses`,
+  `pendingCrateReturns`, `pendingReturnsWithDetails`). Forcing any through the
+  factory would break pre-bind resolution or change device-local semantics.
+- **Enforcement:** `test/providers/business_scoped_stream_ban_test.dart` bans a
+  raw `StreamProvider` declaration anywhere in `lib/` (allowlist = the 11 above,
+  shrink-only ratchet) + a companion strictness test (planted raw caught,
+  multi-line caught, all four factory forms not flagged). Unit test
+  `test/providers/business_scoped_stream_test.dart` drives the factory
+  `null → bound → switched → unbound` via the seam override and proves it never
+  runs the closure in the null window — no database needed.
+- **Verified:** `flutter analyze` clean; full suite 652 passed / 58 skipped /
+  1 pre-existing failure (`who_is_working_screen_test.dart` "Carol" — confirmed
+  failing identically with these changes stashed, unrelated).
+
+### Design landed (superseded by the SHIPPED entry above): Business-Scoped Stream primitive (2026-07-03, PRD #23 → issues #24, #25)
 - **Planning only — no app code shipped this session.** Grilled the design
   (`/grill-with-docs`), wrote the paper trail, and filed the work.
 - **Problem:** business-scoped `StreamProvider`s bake the current businessId at

--- a/CONTEXT/progress-tracker.md
+++ b/CONTEXT/progress-tracker.md
@@ -10,6 +10,30 @@ The human updates it when resolving open questions or making architectural decis
 
 151 sessions logged. Codebase is live and being verified on-device.
 
+### Design landed (not yet built): Business-Scoped Stream primitive (2026-07-03, PRD #23 → issues #24, #25)
+- **Planning only — no app code shipped this session.** Grilled the design
+  (`/grill-with-docs`), wrote the paper trail, and filed the work.
+- **Problem:** business-scoped `StreamProvider`s bake the current businessId at
+  first build via `requireBusinessId()`; a first subscribe in the create-business
+  null window either **throws + sticks errored** (e.g. `allStoresProvider`) or
+  **silent-empty-sticks** (custom-SQL providers reading `db.currentBusinessId`)
+  for the whole session → empty store pickers until restart. Hand-patched once
+  per provider (S153). See `project_business_scoped_provider_build_time_poison`.
+- **Decision (ADR 0003, `docs/adr/0003-business-scoped-stream.md`):** a guarded
+  factory `businessScopedStream<T>` (+ `businessScopedStreamFamily<T, Arg>`) that
+  **owns the declaration** — watches a new `currentBusinessIdProvider` seam,
+  emits a required `whenAbsent` value while unbound, hands the closure a non-null
+  businessId, rebuilds on bind/switch. Makes the bug unrepresentable by
+  construction; a source-scan ban test (modeled on `gate_static_ban_test.dart`)
+  keeps new providers on it, with a small non-empty allowlist for genuine globals
+  (permissions catalogue, unscoped roles). Glossary terms added to `CONTEXT.md`.
+- **Size correction:** the originating "257 providers" was a consumer count; the
+  real surface is **~41 declarations in 2 files** (`stream_providers.dart`,
+  `app_providers.dart`); consumers untouched.
+- **NEXT:** implement in a fresh session per issue — **#24** (factory + seam +
+  tracer trio + ban test, CI green) then **#25** (migrate remaining ~38 + shrink
+  allowlist to globals). #25 blocked by #24.
+
 ### Flip: gate enforcement made permanent — allowlist emptied, bare helpers removed (2026-07-03, issue #22)
 - **Goal (epic #16 finish line):** flip the named-gate enforcement from a
   shrinking ratchet to a permanent ban, retire the last cross-cutting permission

--- a/docs/adr/0003-business-scoped-stream.md
+++ b/docs/adr/0003-business-scoped-stream.md
@@ -42,11 +42,16 @@ files; consumers (`ref.watch(xProvider)`) are untouched.
 
 ## Key boundary decisions
 
-- **The closure receives the resolved, non-null businessId.** So
-  `requireBusinessId()` can never throw from a factory-built provider, and
+- **The closure receives `(ref, db, businessId)` with a resolved, non-null id.**
+  So `requireBusinessId()` can never throw from a factory-built provider, and
   custom-SQL providers (`WHERE business_id = ?`) migrate too — the primitive
   subsumes **both** the throw-poison and the silent-empty families, not just the
-  DAO-watch ones.
+  DAO-watch ones. A DAO-watch closure ignores the id (the DAO reads it from the
+  session); a custom-SQL closure binds it directly. The closure is also handed
+  the provider `ref`, because several tenant-scoped feeds must still compose a
+  sibling provider — the active-store `lockedStoreProvider` — to derive their
+  store scope; the guarantee (non-null `businessId`, guarded null window) is
+  unchanged, `ref` is purely additive.
 - **`whenAbsent` is required, never inferred.** The null-window value genuinely
   varies across sites (`[]`, `{}`, `0`, `null`, `kDefaultCurrency`), so there is
   no default to guess. Requiring it forces a conscious choice and keeps the
@@ -68,8 +73,12 @@ files; consumers (`ref.watch(xProvider)`) are untouched.
 - **Family gets a second factory, not a hand-written carve-out.** Riverpod won't
   let one function emit both plain and family providers, so the `.family` cases
   get `businessScopedStreamFamily`. Leaving them hand-written would re-open the
-  hole for the next family provider someone adds; two guarded front doors keep
-  the invariant total.
+  hole for the next family provider someone adds; guarded front doors keep the
+  invariant total. Riverpod likewise types keep-alive and `autoDispose` streams
+  distinctly, so each has an `AutoDispose` twin
+  (`businessScopedStreamAutoDispose` / `…AutoDisposeFamily`) — four functions,
+  one guard — preserving each migrated provider's original lifecycle exactly
+  (an autoDispose family that tears down per-key state stays autoDispose).
 
 ## Consequences
 
@@ -81,7 +90,19 @@ files; consumers (`ref.watch(xProvider)`) are untouched.
 - Staged in two independently-grabbable issues: (1) the factories +
   `currentBusinessIdProvider` + tests + a ban test whose allowlist temporarily
   names every current raw provider (CI green); (2) the mechanical migration of
-  ~41 sites, shrinking the allowlist to just the globals, plus the companion
-  "planted violation is caught / migrated form is not flagged" strictness test.
+  the session-scoped sites, shrinking the allowlist to the genuinely
+  non-tenant-scoped streams, plus the companion "planted violation is caught /
+  migrated form is not flagged" strictness test. The real surface is larger than
+  the issue's "~41" estimate — **62 session-scoped declarations** migrated across
+  the two provider files. The final allowlist is the **11** streams that are not
+  session-scoped and must stay raw: the two globals (permissions catalogue,
+  unscoped roles), four keyed by an explicit id resolved *before* a business
+  binds (`_userMemberships`, `myUserStores`, `activeStaff`, `deviceStaff` — the
+  shared-PIN / Who's-Working pickers), two device-local sync-engine feeds
+  (`orphanQueueItems`, `orphanQueueCount` — `sync_queue_orphans` has no
+  `business_id`), and three intentionally-unscoped selects (`localBusinesses`,
+  `pendingCrateReturns`, `pendingReturnsWithDetails`). Forcing any of these
+  through the factory would break pre-bind resolution or change device-local
+  semantics, so "off the factory" is correct, not a shortfall.
 - The `whenAbsent`-vs-`AsyncLoading` behaviour choice is deferred, not decided:
   revisit if a provider genuinely wants a loading state during the null window.

--- a/docs/adr/0003-business-scoped-stream.md
+++ b/docs/adr/0003-business-scoped-stream.md
@@ -1,0 +1,87 @@
+# Business-scoped stream providers via a guarded factory
+
+**Status:** accepted (2026-07-03)
+
+A `StreamProvider` that calls a `BusinessScopedDao` `watch*()` bakes the
+businessId into its Drift query once, at first build, via `requireBusinessId()`
+— which **throws** when no business is bound. Because such a provider's only
+dependency is the never-changing `databaseProvider`, a first subscribe during
+the brief null-businessId window (the create-business handoff, where
+`setCurrentUser` binds the id only after the post-onboarding pull) errors and
+**sticks for the whole session**: every store picker renders empty until a cold
+restart. A quieter sibling reads `db.currentBusinessId` synchronously and
+**silent-empty-sticks** the same way. Both were hand-patched one provider at a
+time (S153, `allStoresProvider`). We introduce **`businessScopedStream<T>`**
+(and **`businessScopedStreamFamily<T, Arg>`**) — a factory that *owns the
+provider declaration*: it watches **`currentBusinessIdProvider`**, emits a
+required `whenAbsent` value while the id is null, and passes the resolved
+**non-null** businessId into the closure. The bug is therefore unrepresentable
+in any provider declared through the factory, and a static ban test keeps new
+providers on it. The migration surface is ~41 declarations in two provider
+files; consumers (`ref.watch(xProvider)`) are untouched.
+
+## Considered Options
+
+- **A body helper called inside `StreamProvider((ref) => …)`** — rejected: it is
+  the S153 hand-patch under a nicer name. A future provider can still skip it,
+  which re-opens the exact defect we are retiring. Only owning the *declaration*
+  delivers "by construction."
+- **Per-provider inline guards (status quo)** — rejected: this is the documented
+  recurring bug; every new tenant-scoped provider re-opens it, and the
+  throw-poison / silent-empty split means half the failures are invisible.
+- **A `custom_lint` AST rule** — rejected *for now*: it could tell scoped from
+  global streams precisely, but there is no `custom_lint` infra in the repo. A
+  source-scan test matches three existing precedents (the gate ban, the
+  sync-registry membership test, the sync-registry golden test) and needs no new
+  toolchain.
+- **Emit `AsyncLoading` while unbound instead of a `whenAbsent` value** —
+  rejected as the default: it is a behaviour change (an empty-`[]` flash becomes
+  a spinner) and would leave the app-wide currency provider in loading, breaking
+  the root currency watch that needs a concrete `kDefaultCurrency` before a
+  business binds. Left available as a future opt-in (omit `whenAbsent`).
+
+## Key boundary decisions
+
+- **The closure receives the resolved, non-null businessId.** So
+  `requireBusinessId()` can never throw from a factory-built provider, and
+  custom-SQL providers (`WHERE business_id = ?`) migrate too — the primitive
+  subsumes **both** the throw-poison and the silent-empty families, not just the
+  DAO-watch ones.
+- **`whenAbsent` is required, never inferred.** The null-window value genuinely
+  varies across sites (`[]`, `{}`, `0`, `null`, `kDefaultCurrency`), so there is
+  no default to guess. Requiring it forces a conscious choice and keeps the
+  migration a behaviour-preserving 1:1 lift.
+- **`currentBusinessIdProvider` is the single watchable businessId seam**
+  (`= authProvider.select((a) => a.currentUser?.businessId)`); nothing else
+  re-derives it. It makes the factory unit-testable by `overrideWith` (flip
+  `null → id`, assert `whenAbsent → data`) rather than by faking `AuthService`.
+  Non-reactive `db.currentBusinessId` reads are the anti-pattern it replaces.
+- **Rebuild-on-switch falls out of watching the seam.** Every factory-built
+  provider re-runs for the new tenant on a business switch, pre-solving a
+  Phase-2 switcher staleness concern (business-isolation root cause) without
+  touching the deliberately-deferred *eviction* decision.
+- **Global / unscoped streams stay off the factory.** `permissionsDao.watchAll`
+  (the never-synced global catalogue) and `rolesDao.watchAllUnscoped` are not
+  tenant-scoped. Unlike the gate ban's empty allowlist, this ban's allowlist is
+  **small but non-empty** — it names these globals — with the same shrink-only
+  ratchet.
+- **Family gets a second factory, not a hand-written carve-out.** Riverpod won't
+  let one function emit both plain and family providers, so the `.family` cases
+  get `businessScopedStreamFamily`. Leaving them hand-written would re-open the
+  hole for the next family provider someone adds; two guarded front doors keep
+  the invariant total.
+
+## Consequences
+
+- One gated read path: no business-scoped stream — plain or family — can be
+  declared without watching the id and guarding the null window, so the
+  build-time-poison class becomes impossible rather than audited.
+- The factory is a pure, isolated unit test (flip `currentBusinessIdProvider`,
+  assert the emission), instead of the current per-provider integration checks.
+- Staged in two independently-grabbable issues: (1) the factories +
+  `currentBusinessIdProvider` + tests + a ban test whose allowlist temporarily
+  names every current raw provider (CI green); (2) the mechanical migration of
+  ~41 sites, shrinking the allowlist to just the globals, plus the companion
+  "planted violation is caught / migrated form is not flagged" strictness test.
+- The `whenAbsent`-vs-`AsyncLoading` behaviour choice is deferred, not decided:
+  revisit if a provider genuinely wants a loading state during the null window.

--- a/lib/core/providers/app_providers.dart
+++ b/lib/core/providers/app_providers.dart
@@ -12,6 +12,7 @@ import 'package:supabase_flutter/supabase_flutter.dart';
 
 import 'package:reebaplus_pos/core/data/business_types.dart';
 import 'package:reebaplus_pos/core/database/app_database.dart';
+import 'package:reebaplus_pos/core/providers/business_scoped_stream.dart';
 import 'package:reebaplus_pos/core/services/biometric_service.dart';
 import 'package:reebaplus_pos/core/services/business_logo_service.dart';
 import 'package:reebaplus_pos/core/theme/theme_notifier.dart';
@@ -187,30 +188,33 @@ final customerServiceProvider = ChangeNotifierProvider<CustomerService>((ref) {
 /// Map of customerId → signed credits balance (kobo), computed live from the
 /// WalletTransactions ledger. Replaces the cached `customers.wallet_balance_kobo`
 /// column that PR 2a removed.
-final creditBalancesKoboProvider = StreamProvider.autoDispose<Map<String, int>>(
-  (ref) {
-    return ref.read(databaseProvider).customersDao.watchAllWalletBalancesKobo();
-  },
+final creditBalancesKoboProvider =
+    businessScopedStreamAutoDispose<Map<String, int>>(
+  (ref, db, businessId) => db.customersDao.watchAllWalletBalancesKobo(),
+  whenAbsent: const {},
 );
 
 /// §13.4 Ring 7 — business-wide crate-deposit balancing figures
 /// (taken / refunded / kept / held). Held = taken − refunded − kept.
 final crateDepositSummaryProvider =
-    StreamProvider.autoDispose<CrateDepositSummary>((ref) {
-      return ref
-          .read(databaseProvider)
-          .walletTransactionsDao
-          .watchCrateDepositSummary();
-    });
+    businessScopedStreamAutoDispose<CrateDepositSummary>(
+  (ref, db, businessId) =>
+      db.walletTransactionsDao.watchCrateDepositSummary(),
+  whenAbsent: const CrateDepositSummary(
+    takenKobo: 0,
+    refundedKobo: 0,
+    keptKobo: 0,
+    heldKobo: 0,
+  ),
+);
 
 /// §13.4 Ring 7 — per-customer held deposit (kobo); only non-zero holders.
 final depositsHeldByCustomerProvider =
-    StreamProvider.autoDispose<Map<String, int>>((ref) {
-      return ref
-          .read(databaseProvider)
-          .walletTransactionsDao
-          .watchDepositsHeldByCustomer();
-    });
+    businessScopedStreamAutoDispose<Map<String, int>>(
+  (ref, db, businessId) =>
+      db.walletTransactionsDao.watchDepositsHeldByCustomer(),
+  whenAbsent: const {},
+);
 
 // ── Supplier ────────────────────────────────────────────────────────────────
 final supplierServiceProvider = ChangeNotifierProvider<SupplierService>((ref) {
@@ -235,54 +239,53 @@ final receiveStockServiceProvider = Provider<ReceiveStockService>((ref) {
 /// supplier. Drives the per-supplier balance chip on the Suppliers list.
 /// Scoped to the active store (§21.11); null lock = "All Stores" aggregate.
 final supplierBalancesKoboProvider =
-    StreamProvider.autoDispose<Map<String, int>>((ref) {
-      final storeId = ref.watch(lockedStoreProvider).value;
-      return ref
-          .read(databaseProvider)
-          .supplierLedgerDao
-          .watchAllBalancesKobo(storeId: storeId);
-    });
+    businessScopedStreamAutoDispose<Map<String, int>>(
+  (ref, db, businessId) {
+    final storeId = ref.watch(lockedStoreProvider).value;
+    return db.supplierLedgerDao.watchAllBalancesKobo(storeId: storeId);
+  },
+  whenAbsent: const {},
+);
 
 /// One supplier row, live (Supplier Details header). Null once soft-deleted.
-final supplierByIdProvider = StreamProvider.autoDispose
-    .family<SupplierData?, String>((ref, id) {
-      return ref.read(databaseProvider).catalogDao.watchSupplierById(id);
-    });
+final supplierByIdProvider =
+    businessScopedStreamAutoDisposeFamily<SupplierData?, String>(
+  (ref, db, businessId, id) => db.catalogDao.watchSupplierById(id),
+  whenAbsent: null,
+);
 
 /// One supplier's signed ledger balance (kobo), live. Active-store scoped (§21.11).
-final supplierBalanceProvider = StreamProvider.autoDispose.family<int, String>((
-  ref,
-  id,
-) {
-  final storeId = ref.watch(lockedStoreProvider).value;
-  return ref
-      .read(databaseProvider)
-      .supplierLedgerDao
-      .watchBalanceKobo(id, storeId: storeId);
-});
+final supplierBalanceProvider =
+    businessScopedStreamAutoDisposeFamily<int, String>(
+  (ref, db, businessId, id) {
+    final storeId = ref.watch(lockedStoreProvider).value;
+    return db.supplierLedgerDao.watchBalanceKobo(id, storeId: storeId);
+  },
+  whenAbsent: 0,
+);
 
 /// One supplier's full ledger history (invoices + payments + voids), newest
 /// first. Active-store scoped (§21.11).
-final supplierLedgerHistoryProvider = StreamProvider.autoDispose
-    .family<List<SupplierLedgerEntryData>, String>((ref, id) {
-      final storeId = ref.watch(lockedStoreProvider).value;
-      return ref
-          .read(databaseProvider)
-          .supplierLedgerDao
-          .watchHistory(id, storeId: storeId);
-    });
+final supplierLedgerHistoryProvider =
+    businessScopedStreamAutoDisposeFamily<List<SupplierLedgerEntryData>, String>(
+  (ref, db, businessId, id) {
+    final storeId = ref.watch(lockedStoreProvider).value;
+    return db.supplierLedgerDao.watchHistory(id, storeId: storeId);
+  },
+  whenAbsent: const [],
+);
 
 /// Every ledger entry (invoices + payments + voids) across all suppliers,
 /// newest first — drives the Transaction history screen. Active-store scoped
 /// (§21.11); null lock = "All Stores" aggregate.
 final supplierAllHistoryProvider =
-    StreamProvider.autoDispose<List<SupplierLedgerEntryData>>((ref) {
-      final storeId = ref.watch(lockedStoreProvider).value;
-      return ref
-          .read(databaseProvider)
-          .supplierLedgerDao
-          .watchAllHistory(storeId: storeId);
-    });
+    businessScopedStreamAutoDispose<List<SupplierLedgerEntryData>>(
+  (ref, db, businessId) {
+    final storeId = ref.watch(lockedStoreProvider).value;
+    return db.supplierLedgerDao.watchAllHistory(storeId: storeId);
+  },
+  whenAbsent: const [],
+);
 
 // ── Supplier empty-crate tracking (§3.13) ────────────────────────────────────
 /// Records crate receipts/returns against a supplier (with deposits).
@@ -293,42 +296,38 @@ final supplierCrateServiceProvider = Provider<SupplierCrateService>((ref) {
 /// One supplier's per-manufacturer crate balances, live. A positive balance =
 /// WE owe the supplier that many empties; negative = a crate credit.
 /// Business-wide (crate debt is between the store and the supplier, not a store).
-final supplierCrateBalancesProvider = StreamProvider.autoDispose
-    .family<List<SupplierCrateBalanceWithManufacturer>, String>((ref, id) {
-      return ref
-          .read(databaseProvider)
-          .supplierCrateBalancesDao
-          .watchBySupplier(id);
-    });
+final supplierCrateBalancesProvider =
+    businessScopedStreamAutoDisposeFamily<
+        List<SupplierCrateBalanceWithManufacturer>, String>(
+  (ref, db, businessId, id) => db.supplierCrateBalancesDao.watchBySupplier(id),
+  whenAbsent: const [],
+);
 
 /// One supplier's net refundable deposit still held by them (kobo), live.
-final supplierCrateDepositHeldProvider = StreamProvider.autoDispose
-    .family<int, String>((ref, id) {
-      return ref
-          .read(databaseProvider)
-          .supplierCrateLedgerDao
-          .watchDepositHeldKobo(id);
-    });
+final supplierCrateDepositHeldProvider =
+    businessScopedStreamAutoDisposeFamily<int, String>(
+  (ref, db, businessId, id) =>
+      db.supplierCrateLedgerDao.watchDepositHeldKobo(id),
+  whenAbsent: 0,
+);
 
 /// One supplier's cumulative crates received from / returned (sent back) to
 /// them — running totals, not the net balance.
-final supplierCrateMovementTotalsProvider = StreamProvider.autoDispose
-    .family<({int received, int returned}), String>((ref, id) {
-      return ref
-          .read(databaseProvider)
-          .supplierCrateLedgerDao
-          .watchMovementTotals(id);
-    });
+final supplierCrateMovementTotalsProvider =
+    businessScopedStreamAutoDisposeFamily<({int received, int returned}),
+        String>(
+  (ref, db, businessId, id) => db.supplierCrateLedgerDao.watchMovementTotals(id),
+  whenAbsent: (received: 0, returned: 0),
+);
 
 /// One supplier's empty-crate movement history (receipts + returns), newest
 /// first.
-final supplierCrateHistoryProvider = StreamProvider.autoDispose
-    .family<List<SupplierCrateLedgerEntryData>, String>((ref, id) {
-      return ref
-          .read(databaseProvider)
-          .supplierCrateLedgerDao
-          .watchHistory(id);
-    });
+final supplierCrateHistoryProvider =
+    businessScopedStreamAutoDisposeFamily<List<SupplierCrateLedgerEntryData>,
+        String>(
+  (ref, db, businessId, id) => db.supplierCrateLedgerDao.watchHistory(id),
+  whenAbsent: const [],
+);
 
 // ── Delivery receipts (rider hand-off on customer orders, §orders) ───────────
 final deliveryReceiptServiceProvider =
@@ -367,18 +366,30 @@ final supabaseSyncServiceProvider = Provider<SupabaseSyncService>((ref) {
 final syncDiagnosticProvider = Provider<SyncDiagnostic>((ref) {
   return SyncDiagnostic(ref.read(databaseProvider));
 });
-final failedQueueItemsProvider = StreamProvider.autoDispose((ref) {
-  return ref.read(databaseProvider).syncDao.watchFailedItems();
-});
-final failedQueueCountProvider = StreamProvider.autoDispose<int>((ref) {
-  return ref.read(databaseProvider).syncDao.watchFailedCount();
-});
-final pendingQueueCountProvider = StreamProvider.autoDispose<int>((ref) {
-  return ref.read(databaseProvider).syncDao.watchPendingCount();
-});
-final pendingQueueItemsProvider = StreamProvider.autoDispose((ref) {
-  return ref.read(databaseProvider).syncDao.watchPendingItems();
-});
+// The `sync_queue` feeds filter by the current business (`whereBusiness`), so
+// they are business-scoped and go through the factory. The `sync_queue_orphans`
+// feeds carry no business_id column (device-local engine state) and stay raw.
+final failedQueueItemsProvider =
+    businessScopedStreamAutoDispose<List<SyncQueueData>>(
+  (ref, db, businessId) => db.syncDao.watchFailedItems(),
+  whenAbsent: const [],
+);
+final failedQueueCountProvider = businessScopedStreamAutoDispose<int>(
+  (ref, db, businessId) => db.syncDao.watchFailedCount(),
+  whenAbsent: 0,
+);
+final pendingQueueCountProvider = businessScopedStreamAutoDispose<int>(
+  (ref, db, businessId) => db.syncDao.watchPendingCount(),
+  whenAbsent: 0,
+);
+final pendingQueueItemsProvider =
+    businessScopedStreamAutoDispose<List<SyncQueueData>>(
+  (ref, db, businessId) => db.syncDao.watchPendingItems(),
+  whenAbsent: const [],
+);
+// Device-local sync-engine state (no business_id column) — intentionally raw,
+// allowlisted in the ban test. Not tenant-scoped, so it must NOT be forced
+// through the factory.
 final orphanQueueItemsProvider = StreamProvider.autoDispose((ref) {
   return ref.read(databaseProvider).syncDao.watchOrphans();
 });
@@ -433,6 +444,9 @@ final pendingReturnsWithDetailsProvider =
       );
     });
 
+// Intentionally UNSCOPED — a device may hold more than one business's row and
+// [currentBusinessProvider] resolves the active one against the session id.
+// Not a business-scoped stream; stays raw (allowlisted in the ban test).
 final localBusinessesProvider = StreamProvider.autoDispose<List<BusinessData>>((
   ref,
 ) {
@@ -518,10 +532,10 @@ final manualPullActiveProvider = StateProvider<bool>((ref) => false);
 /// True once the local Drift database has at least one product row — used as
 /// the fresh-device gate signal. Distinct-filtered so it only notifies when
 /// the boolean flips (empty → non-empty), keeping rebuilds cheap.
-final hasLocalProductsProvider = StreamProvider<bool>((ref) {
-  final db = ref.watch(databaseProvider);
-  return db.inventoryDao
+final hasLocalProductsProvider = businessScopedStream<bool>(
+  (ref, db, businessId) => db.inventoryDao
       .watchAllProductDatasWithStock()
       .map((list) => list.isNotEmpty)
-      .distinct();
-});
+      .distinct(),
+  whenAbsent: false,
+);

--- a/lib/core/providers/business_scoped_stream.dart
+++ b/lib/core/providers/business_scoped_stream.dart
@@ -1,0 +1,105 @@
+/// Business-scoped stream providers via a guarded factory (ADR 0003).
+///
+/// **The bug this retires.** A `StreamProvider` that calls a business-scoped DAO
+/// `watch*()` bakes the session businessId into its Drift query once, at first
+/// build, via `requireBusinessId()` — which THROWS when no business is bound.
+/// Because such a provider's only dependency is the never-changing
+/// `databaseProvider`, a first subscribe during the brief null-businessId window
+/// (the create-business handoff, where `setCurrentUser` binds the id only after
+/// the post-onboarding pull) errors and STICKS for the whole session — every
+/// store picker renders empty until a cold restart. A quieter sibling that reads
+/// `db.currentBusinessId` synchronously silent-empty-sticks the same way.
+///
+/// **The fix.** Declaring a stream through [businessScopedStream] (or its family
+/// / autoDispose variants) makes the bug unrepresentable: the factory *owns the
+/// declaration*. It watches [currentBusinessIdProvider], emits the required
+/// [BusinessScopedCreate]-paired `whenAbsent` value while the id is null, and
+/// passes the resolved NON-NULL businessId into the closure — so the closure is
+/// total (`requireBusinessId()` can never throw from a factory-built provider),
+/// it rebuilds the instant a business binds, and it re-queries on a business
+/// switch (a free property of watching the seam). The static ban test
+/// (`test/providers/business_scoped_stream_ban_test.dart`) keeps every new
+/// business-scoped stream on the factory.
+library;
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:reebaplus_pos/core/database/app_database.dart';
+import 'package:reebaplus_pos/core/providers/app_providers.dart';
+
+/// The single watchable source of the current session's businessId (ADR 0003 —
+/// the *Current Business Id* seam). Null until a business binds (login, or the
+/// create-business handoff). Nothing else re-derives "who is the current
+/// tenant"; the factory watches this, and tests flip it via `overrideWith` to
+/// drive the guard without spinning up a database. Non-reactive
+/// `db.currentBusinessId` reads behind a stream are the anti-pattern this
+/// replaces — they bake the id at build time and stick stale/empty.
+final currentBusinessIdProvider = Provider<String?>((ref) {
+  return ref.watch(authProvider.select((a) => a.currentUser?.businessId));
+});
+
+/// Builds the real, business-scoped stream once an id is bound. Receives the
+/// provider [ref] (so a scoped stream can still compose sibling providers —
+/// e.g. the active-store `lockedStoreProvider` — which several store-scoped
+/// feeds need), the [AppDatabase], and the resolved **non-null** [businessId].
+/// A DAO-watch closure ignores the id (the DAO reads it from the session); a
+/// custom-SQL closure uses it directly (`WHERE business_id = ?`).
+typedef BusinessScopedCreate<T> =
+    Stream<T> Function(Ref ref, AppDatabase db, String businessId);
+
+/// The keyed ([Arg]) counterpart of [BusinessScopedCreate].
+typedef BusinessScopedFamilyCreate<T, Arg> =
+    Stream<T> Function(Ref ref, AppDatabase db, String businessId, Arg arg);
+
+/// A guarded, keep-alive business-scoped [StreamProvider]. Emits [whenAbsent]
+/// while no business is bound, then swaps in `create(...)` the instant one binds.
+StreamProvider<T> businessScopedStream<T>(
+  BusinessScopedCreate<T> create, {
+  required T whenAbsent,
+}) {
+  return StreamProvider<T>((ref) {
+    final businessId = ref.watch(currentBusinessIdProvider);
+    if (businessId == null) return Stream<T>.value(whenAbsent);
+    return create(ref, ref.watch(databaseProvider), businessId);
+  });
+}
+
+/// The `autoDispose` variant of [businessScopedStream] — same guard, torn down
+/// when no longer watched.
+AutoDisposeStreamProvider<T> businessScopedStreamAutoDispose<T>(
+  BusinessScopedCreate<T> create, {
+  required T whenAbsent,
+}) {
+  return StreamProvider.autoDispose<T>((ref) {
+    final businessId = ref.watch(currentBusinessIdProvider);
+    if (businessId == null) return Stream<T>.value(whenAbsent);
+    return create(ref, ref.watch(databaseProvider), businessId);
+  });
+}
+
+/// The keyed ([Arg]) variant. Riverpod cannot emit both plain and family
+/// providers from one function, so keyed business-scoped streams get their own
+/// guarded front door rather than a hand-written carve-out.
+StreamProviderFamily<T, Arg> businessScopedStreamFamily<T, Arg>(
+  BusinessScopedFamilyCreate<T, Arg> create, {
+  required T whenAbsent,
+}) {
+  return StreamProvider.family<T, Arg>((ref, arg) {
+    final businessId = ref.watch(currentBusinessIdProvider);
+    if (businessId == null) return Stream<T>.value(whenAbsent);
+    return create(ref, ref.watch(databaseProvider), businessId, arg);
+  });
+}
+
+/// The `autoDispose` keyed variant of [businessScopedStreamFamily].
+AutoDisposeStreamProviderFamily<T, Arg>
+businessScopedStreamAutoDisposeFamily<T, Arg>(
+  BusinessScopedFamilyCreate<T, Arg> create, {
+  required T whenAbsent,
+}) {
+  return StreamProvider.autoDispose.family<T, Arg>((ref, arg) {
+    final businessId = ref.watch(currentBusinessIdProvider);
+    if (businessId == null) return Stream<T>.value(whenAbsent);
+    return create(ref, ref.watch(databaseProvider), businessId, arg);
+  });
+}

--- a/lib/core/providers/stream_providers.dart
+++ b/lib/core/providers/stream_providers.dart
@@ -13,6 +13,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:reebaplus_pos/core/data/currencies.dart';
 import 'package:reebaplus_pos/core/database/app_database.dart';
 import 'package:reebaplus_pos/core/providers/app_providers.dart';
+import 'package:reebaplus_pos/core/providers/business_scoped_stream.dart';
 import 'package:reebaplus_pos/core/theme/theme_notifier.dart';
 import 'package:reebaplus_pos/core/utils/business_time.dart';
 import 'package:reebaplus_pos/core/utils/date_period.dart';
@@ -21,13 +22,18 @@ import 'package:reebaplus_pos/shared/utils/role_display.dart';
 import 'package:reebaplus_pos/features/subscription/subscription_access.dart';
 
 // ── Orders ──────────────────────────────────────────────────────────────────
-final allOrdersProvider = StreamProvider<List<OrderWithItems>>((ref) {
-  return ref.watch(orderServiceProvider).watchAllOrdersWithItems();
-});
+final allOrdersProvider = businessScopedStream<List<OrderWithItems>>(
+  (ref, db, businessId) =>
+      ref.watch(orderServiceProvider).watchAllOrdersWithItems(),
+  whenAbsent: const [],
+);
 
-final pendingOrdersProvider = StreamProvider.family<List<OrderWithItems>, String?>((ref, storeId) {
-  return ref.watch(orderServiceProvider).watchPendingOrdersWithItems(storeId: storeId);
-});
+final pendingOrdersProvider =
+    businessScopedStreamFamily<List<OrderWithItems>, String?>(
+  (ref, db, businessId, storeId) =>
+      ref.watch(orderServiceProvider).watchPendingOrdersWithItems(storeId: storeId),
+  whenAbsent: const [],
+);
 
 class OrdersPageState {
   final List<OrderWithItems> orders;
@@ -197,19 +203,22 @@ final paginatedOrdersProvider = StateNotifierProvider.autoDispose.family<
   return PaginatedOrdersNotifier(ref, arg);
 });
 
-final ordersStatsProvider = StreamProvider.autoDispose.family<
+final ordersStatsProvider = businessScopedStreamAutoDisposeFamily<
     OrdersStats,
     ({String status, String? storeId, String dateLabel, String search})
->((ref, arg) {
-  final (from, to) = dateRangeForLabel(arg.dateLabel);
-  return ref.watch(orderServiceProvider).watchOrdersStats(
-        status: arg.status,
-        storeId: arg.storeId,
-        from: from,
-        to: to,
-        search: arg.search,
-      );
-});
+>(
+  (ref, db, businessId, arg) {
+    final (from, to) = dateRangeForLabel(arg.dateLabel);
+    return ref.watch(orderServiceProvider).watchOrdersStats(
+          status: arg.status,
+          storeId: arg.storeId,
+          from: from,
+          to: to,
+          search: arg.search,
+        );
+  },
+  whenAbsent: OrdersStats.empty(),
+);
 
 // ── Activity Logs ───────────────────────────────────────────────────────────
 class ActivityLogsPageState {
@@ -551,41 +560,39 @@ final paginatedStockHistoryProvider = StateNotifierProvider.autoDispose.family<
   return PaginatedStockHistoryNotifier(ref, arg);
 });
 
-final stockHistoryStatsProvider = StreamProvider.autoDispose.family<
+final stockHistoryStatsProvider = businessScopedStreamAutoDisposeFamily<
     StockHistoryStats,
     ({String? storeId, String period})
->((ref, arg) async* {
-  final db = ref.watch(databaseProvider);
-  final businessId = db.currentBusinessId;
-  String tz = 'UTC';
-  if (businessId != null) {
-    tz = await getBusinessTimezone(db, businessId);
-  }
+>(
+  (ref, db, businessId, arg) async* {
+    final tz = await getBusinessTimezone(db, businessId);
 
-  final now = DateTime.now();
-  DateTime? startDate;
-  DateTime? endDate;
-  switch (arg.period) {
-    case 'Today':
-      startDate = localDayStartUtc(now, tz);
-      break;
-    case '7 Days':
-      startDate = now.subtract(const Duration(days: 7));
-      break;
-    case '30 Days':
-      startDate = now.subtract(const Duration(days: 30));
-      break;
-    case 'All':
-    default:
-      break;
-  }
+    final now = DateTime.now();
+    DateTime? startDate;
+    DateTime? endDate;
+    switch (arg.period) {
+      case 'Today':
+        startDate = localDayStartUtc(now, tz);
+        break;
+      case '7 Days':
+        startDate = now.subtract(const Duration(days: 7));
+        break;
+      case '30 Days':
+        startDate = now.subtract(const Duration(days: 30));
+        break;
+      case 'All':
+      default:
+        break;
+    }
 
-  yield* db.stockLedgerDao.watchTransactionsStats(
-    storeId: arg.storeId,
-    startDate: startDate,
-    endDate: endDate,
-  );
-});
+    yield* db.stockLedgerDao.watchTransactionsStats(
+      storeId: arg.storeId,
+      startDate: startDate,
+      endDate: endDate,
+    );
+  },
+  whenAbsent: StockHistoryStats.empty(),
+);
 
 // ── Supplier Transaction History Pagination ──────────────────────────────────
 
@@ -756,80 +763,80 @@ final paginatedSupplierHistoryProvider = StateNotifierProvider.autoDispose
   return PaginatedSupplierHistoryNotifier(ref, arg);
 });
 
-final supplierHistoryStatsProvider = StreamProvider.autoDispose.family<
+final supplierHistoryStatsProvider = businessScopedStreamAutoDisposeFamily<
     SupplierLedgerStats,
-    ({String? storeId, String period})>((ref, arg) {
-  final db = ref.watch(databaseProvider);
-  final (startDate, _) = dateRangeForLabel(arg.period);
-  return db.supplierLedgerDao.watchSupplierHistoryStats(
-    storeId: arg.storeId,
-    startDate: startDate,
-  );
-});
+    ({String? storeId, String period})>(
+  (ref, db, businessId, arg) {
+    final (startDate, _) = dateRangeForLabel(arg.period);
+    return db.supplierLedgerDao.watchSupplierHistoryStats(
+      storeId: arg.storeId,
+      startDate: startDate,
+    );
+  },
+  whenAbsent: SupplierLedgerStats.empty(),
+);
 
 // ── Stores ──────────────────────────────────────────────────────────────────
-final allStoresProvider = StreamProvider<List<StoreData>>((ref) {
-  // Rebuild whenever the active business binds/changes. watchActiveStores()
-  // bakes the businessId into its query at build time via requireBusinessId(),
-  // which THROWS when no business is bound yet. Because this provider's only
-  // other dependency (databaseProvider) never changes, a build during the brief
-  // null-businessId window (e.g. the post-onboarding handoff, where
-  // setCurrentUser binds `value` only AFTER the post-onboarding pull + the
-  // "business ready" delay) would error and STICK for the whole session — every
-  // store picker (Receive checkout, Request Stock, POS scope) then renders empty
-  // until an app restart. Watching the businessId lets the provider re-run the
-  // instant it binds, and the null-guard returns an empty stream rather than
-  // poisoning on the throw — mirroring usersByBusinessProvider's guard.
-  final businessId = ref.watch(
-    authProvider.select((a) => a.currentUser?.businessId),
-  );
-  if (businessId == null) return Stream.value(const <StoreData>[]);
-  return ref.watch(databaseProvider).storesDao.watchActiveStores();
-});
+/// Active stores for the bound business — the store picker feed (Receive
+/// checkout, Request Stock, POS scope). Guarded by the factory (ADR 0003):
+/// `watchActiveStores()` bakes the businessId at build time via
+/// `requireBusinessId()`, which threw and stuck the whole session if first-built
+/// in the null-businessId window; the factory returns `[]` until a business
+/// binds and re-queries the instant it does.
+final allStoresProvider = businessScopedStream<List<StoreData>>(
+  (ref, db, businessId) => db.storesDao.watchActiveStores(),
+  whenAbsent: const [],
+);
 
-final storeInventoryCountsProvider = StreamProvider<Map<String, ({int skuCount, int totalQuantity})>>((ref) {
-  final db = ref.watch(databaseProvider);
-  final businessId = db.currentBusinessId;
-  if (businessId == null) return Stream.value({});
-  return db.customSelect(
-    'SELECT store_id, SUM(quantity) as qty, COUNT(DISTINCT product_id) as sku_count FROM inventory WHERE business_id = ? GROUP BY store_id',
-    variables: [Variable(businessId)],
-    readsFrom: {db.inventory},
-  ).watch().map((rows) {
-    final map = <String, ({int skuCount, int totalQuantity})>{};
-    for (final row in rows) {
-      final storeId = row.readNullable<String>('store_id');
-      if (storeId != null) {
-        map[storeId] = (
-          skuCount: row.readNullable<num>('sku_count')?.toInt() ?? 0,
-          totalQuantity: row.readNullable<num>('qty')?.toInt() ?? 0,
-        );
+/// Per-store SKU + quantity counts, keyed by store id. The silent-empty variant
+/// of the build-time-poison bug: it read `db.currentBusinessId` synchronously
+/// and stuck empty. The factory hands the closure the resolved non-null
+/// businessId to bind into the custom SQL directly.
+final storeInventoryCountsProvider =
+    businessScopedStream<Map<String, ({int skuCount, int totalQuantity})>>(
+  (ref, db, businessId) {
+    return db.customSelect(
+      'SELECT store_id, SUM(quantity) as qty, COUNT(DISTINCT product_id) as sku_count FROM inventory WHERE business_id = ? GROUP BY store_id',
+      variables: [Variable(businessId)],
+      readsFrom: {db.inventory},
+    ).watch().map((rows) {
+      final map = <String, ({int skuCount, int totalQuantity})>{};
+      for (final row in rows) {
+        final storeId = row.readNullable<String>('store_id');
+        if (storeId != null) {
+          map[storeId] = (
+            skuCount: row.readNullable<num>('sku_count')?.toInt() ?? 0,
+            totalQuantity: row.readNullable<num>('qty')?.toInt() ?? 0,
+          );
+        }
       }
-    }
-    return map;
-  });
-});
+      return map;
+    });
+  },
+  whenAbsent: const {},
+);
 
 // ── Expenses ───────────────────────────────────────────────────────────────
-final allExpensesProvider = StreamProvider<List<ExpenseWithCategory>>((ref) {
-  final db = ref.watch(databaseProvider);
-  return db.expensesDao.watchAll();
-});
+final allExpensesProvider = businessScopedStream<List<ExpenseWithCategory>>(
+  (ref, db, businessId) => db.expensesDao.watchAll(),
+  whenAbsent: const [],
+);
 
 /// Map of expense category id → name. Resolves the category text for display
 /// after the cached `expenses.category` column was removed.
-final expenseCategoryNamesProvider = StreamProvider<Map<String, String>>((ref) {
-  final db = ref.watch(databaseProvider);
-  return db.expensesDao.watchAllCategories().map(
-    (cats) => {for (final c in cats) c.id: c.name},
-  );
-});
+final expenseCategoryNamesProvider = businessScopedStream<Map<String, String>>(
+  (ref, db, businessId) => db.expensesDao
+      .watchAllCategories()
+      .map((cats) => {for (final c in cats) c.id: c.name}),
+  whenAbsent: const {},
+);
 
 /// Count of expenses awaiting CEO approval (§20.1 — bell badge + the pending
 /// section header). Business-scoped.
-final pendingExpensesCountProvider = StreamProvider<int>((ref) {
-  return ref.watch(databaseProvider).expensesDao.watchPendingCount();
-});
+final pendingExpensesCountProvider = businessScopedStream<int>(
+  (ref, db, businessId) => db.expensesDao.watchPendingCount(),
+  whenAbsent: 0,
+);
 
 /// The store the Expenses screen is scoped to (§20.8): the active-store picker
 /// (§12.1) drives it for everyone, exactly like Home / Inventory / POS / Supplier
@@ -857,9 +864,10 @@ final viewerScopedExpensesProvider = Provider<List<ExpenseWithCategory>>((ref) {
 /// All live monthly budget goals for the business (§20.1/§20.3). The
 /// business-wide goal is the row with a null store_id; per-store goals carry a
 /// store_id. Use [resolveMonthlyBudgetKobo] to pick the goal for a view's scope.
-final expenseBudgetsProvider = StreamProvider<List<ExpenseBudgetData>>((ref) {
-  return ref.watch(databaseProvider).expenseBudgetsDao.watchAll();
-});
+final expenseBudgetsProvider = businessScopedStream<List<ExpenseBudgetData>>(
+  (ref, db, businessId) => db.expenseBudgetsDao.watchAll(),
+  whenAbsent: const [],
+);
 
 /// Resolves the monthly budget goal (kobo) for a store scope: the store's own
 /// goal if set, else the business-wide goal (null store_id), else null (unset).
@@ -883,12 +891,10 @@ int? resolveMonthlyBudgetKobo(
 /// Approver-side store scoping is applied by
 /// [viewerScopedPendingStockRequestsProvider].
 final pendingStockRequestsProvider =
-    StreamProvider<List<StockAdjustmentRequestData>>((ref) {
-      return ref
-          .watch(databaseProvider)
-          .stockAdjustmentRequestsDao
-          .watchPending();
-    });
+    businessScopedStream<List<StockAdjustmentRequestData>>(
+  (ref, db, businessId) => db.stockAdjustmentRequestsDao.watchPending(),
+  whenAbsent: const [],
+);
 
 /// Pending stock requests the current viewer may approve (§16.6.1): a CEO sees
 /// every store; a Manager sees only requests for the store(s) they're assigned
@@ -915,9 +921,10 @@ final viewerScopedPendingStockRequestsProvider =
 /// Approver-side store scoping is applied by
 /// [viewerScopedPendingQuickSaleRequestsProvider].
 final pendingQuickSaleRequestsProvider =
-    StreamProvider<List<QuickSaleRequestData>>((ref) {
-      return ref.watch(databaseProvider).quickSaleRequestsDao.watchPending();
-    });
+    businessScopedStream<List<QuickSaleRequestData>>(
+  (ref, db, businessId) => db.quickSaleRequestsDao.watchPending(),
+  whenAbsent: const [],
+);
 
 /// Pending Quick Sale requests the current viewer may approve (§12.3.1): a CEO
 /// sees every store; a Manager sees only requests for the store(s) they're
@@ -942,19 +949,19 @@ final viewerScopedPendingQuickSaleRequestsProvider =
 // ── Stock Transfers (§16.8.1) ────────────────────────────────────────────────
 /// All in_transit transfers for the business — the raw feed from which the
 /// viewer-scoped providers derive their lists in memory.
-final allInTransitTransfersProvider = StreamProvider<List<StockTransferData>>((
-  ref,
-) {
-  return ref.watch(databaseProvider).stockTransferDao.watchAllInTransit();
-});
+final allInTransitTransfersProvider =
+    businessScopedStream<List<StockTransferData>>(
+  (ref, db, businessId) => db.stockTransferDao.watchAllInTransit(),
+  whenAbsent: const [],
+);
 
 /// All `pending` transfer requests for the business — the raw feed the
 /// viewer-scoped request providers derive their lists from in memory.
-final allPendingTransfersProvider = StreamProvider<List<StockTransferData>>((
-  ref,
-) {
-  return ref.watch(databaseProvider).stockTransferDao.watchAllPending();
-});
+final allPendingTransfersProvider =
+    businessScopedStream<List<StockTransferData>>(
+  (ref, db, businessId) => db.stockTransferDao.watchAllPending(),
+  whenAbsent: const [],
+);
 
 /// Pending requests the current viewer's stores must ACCEPT & DISPATCH — i.e.
 /// requests where one of the viewer's stores HOLDS the goods (`fromLocationId`).
@@ -1003,33 +1010,33 @@ final viewerScopedOutgoingRequestsProvider = Provider<List<StockTransferData>>(
 
 /// `pending` requests THIS store must fulfil (others asking it to send).
 final storeIncomingRequestsProvider =
-    StreamProvider.family<List<StockTransferData>, String>((ref, storeId) {
-      return ref
-          .watch(databaseProvider)
-          .stockTransferDao
-          .watchPendingForHolderStore(storeId);
-    });
+    businessScopedStreamFamily<List<StockTransferData>, String>(
+  (ref, db, businessId, storeId) =>
+      db.stockTransferDao.watchPendingForHolderStore(storeId),
+  whenAbsent: const [],
+);
 
 /// `pending` requests THIS store raised that have not been dispatched yet.
 final storeOutgoingRequestsProvider =
-    StreamProvider.family<List<StockTransferData>, String>((ref, storeId) {
-      return ref
-          .watch(databaseProvider)
-          .stockTransferDao
-          .watchPendingFromStore(storeId);
-    });
+    businessScopedStreamFamily<List<StockTransferData>, String>(
+  (ref, db, businessId, storeId) =>
+      db.stockTransferDao.watchPendingFromStore(storeId),
+  whenAbsent: const [],
+);
 
 /// `in_transit` transfers arriving AT this store (the confirm-receipt queue).
 final storeIncomingTransfersProvider =
-    StreamProvider.family<List<StockTransferData>, String>((ref, storeId) {
-      return ref.watch(databaseProvider).stockTransferDao.watchIncoming(storeId);
-    });
+    businessScopedStreamFamily<List<StockTransferData>, String>(
+  (ref, db, businessId, storeId) => db.stockTransferDao.watchIncoming(storeId),
+  whenAbsent: const [],
+);
 
 /// `in_transit` transfers dispatched FROM this store (awaiting receipt).
 final storeOutgoingTransfersProvider =
-    StreamProvider.family<List<StockTransferData>, String>((ref, storeId) {
-      return ref.watch(databaseProvider).stockTransferDao.watchOutgoing(storeId);
-    });
+    businessScopedStreamFamily<List<StockTransferData>, String>(
+  (ref, db, businessId, storeId) => db.stockTransferDao.watchOutgoing(storeId),
+  whenAbsent: const [],
+);
 
 /// In-transit transfers where the current viewer's stores are the DESTINATION
 /// (the confirm queue). CEO sees all stores; store users see only their
@@ -1075,76 +1082,72 @@ final viewerScopedOutgoingTransfersProvider = Provider<List<StockTransferData>>(
 
 /// Completed stock transfers (received + cancelled), business-wide, newest
 /// first. Used by the history tab on the Incoming Transfers screen.
-final stockTransferHistoryProvider = StreamProvider<List<StockTransferData>>((
-  ref,
-) {
-  return ref.watch(databaseProvider).stockTransferDao.watchHistory();
-});
+final stockTransferHistoryProvider =
+    businessScopedStream<List<StockTransferData>>(
+  (ref, db, businessId) => db.stockTransferDao.watchHistory(),
+  whenAbsent: const [],
+);
 
 /// Completed stock transfers (received + cancelled) involving a specific store in either direction, newest
 /// first. Used by the Transfer History section in the store details hub.
 final storeTransferHistoryProvider =
-    StreamProvider.family<List<StockTransferData>, String>((ref, storeId) {
-  return ref
-      .watch(databaseProvider)
-      .stockTransferDao
-      .watchHistoryForStore(storeId);
-});
+    businessScopedStreamFamily<List<StockTransferData>, String>(
+  (ref, db, businessId, storeId) =>
+      db.stockTransferDao.watchHistoryForStore(storeId),
+  whenAbsent: const [],
+);
 
 // ── Products by store ───────────────────────────────────────────────────────
 final productsByStoreProvider =
-    StreamProvider.family<List<ProductDataWithStock>, String>((ref, storeId) {
-      return ref
-          .watch(databaseProvider)
-          .inventoryDao
-          .watchProductDatasWithStockByStore(storeId);
-    });
+    businessScopedStreamFamily<List<ProductDataWithStock>, String>(
+  (ref, db, businessId, storeId) =>
+      db.inventoryDao.watchProductDatasWithStockByStore(storeId),
+  whenAbsent: const [],
+);
 
 /// Products with stock totals for a store scope, where the key may be null to
 /// mean "All Stores". Drives the Product Details screen's realtime refresh so a
 /// product edit / stock change syncing in from another device updates the open
 /// detail view live (§5).
 final productsWithStockProvider =
-    StreamProvider.family<List<ProductDataWithStock>, String?>((ref, storeId) {
-      return ref
-          .watch(databaseProvider)
-          .inventoryDao
-          .watchProductsWithStock(storeId: storeId);
-    });
+    businessScopedStreamFamily<List<ProductDataWithStock>, String?>(
+  (ref, db, businessId, storeId) =>
+      db.inventoryDao.watchProductsWithStock(storeId: storeId),
+  whenAbsent: const [],
+);
 
 // ── Categories ──────────────────────────────────────────────────────────────
-final allCategoriesProvider = StreamProvider<List<CategoryData>>((ref) {
-  return ref.watch(databaseProvider).inventoryDao.watchAllCategories();
-});
+final allCategoriesProvider = businessScopedStream<List<CategoryData>>(
+  (ref, db, businessId) => db.inventoryDao.watchAllCategories(),
+  whenAbsent: const [],
+);
 
 // ── Manufacturers ───────────────────────────────────────────────────────────
-final allManufacturersProvider = StreamProvider<List<ManufacturerData>>((ref) {
-  final db = ref.watch(databaseProvider);
-  // Business-scoped via the DAO so a device holding more than one business's
-  // data can't surface another business's manufacturers.
-  return db.inventoryDao.watchAllManufacturers();
-});
+// Business-scoped via the DAO so a device holding more than one business's
+// data can't surface another business's manufacturers.
+final allManufacturersProvider = businessScopedStream<List<ManufacturerData>>(
+  (ref, db, businessId) => db.inventoryDao.watchAllManufacturers(),
+  whenAbsent: const [],
+);
 
 // ── Suppliers ────────────────────────────────────────────────────────────────
 /// All (non-deleted) suppliers for the current business. Lets screens keep the
 /// supplier dropdown live so an add / rename on another device reflects (§5).
-final allSuppliersProvider = StreamProvider<List<SupplierData>>((ref) {
-  return ref.watch(databaseProvider).catalogDao.watchAllSupplierDatas();
-});
+final allSuppliersProvider = businessScopedStream<List<SupplierData>>(
+  (ref, db, businessId) => db.catalogDao.watchAllSupplierDatas(),
+  whenAbsent: const [],
+);
 
 // ── Store by id ─────────────────────────────────────────────────────────────
 /// Streams a single store row keyed by id. Returns null when the
 /// store hasn't loaded yet or has been (soft-)deleted. Used wherever
 /// a screen needs to display the *active* store and have it auto-update
 /// when the cloud renames or marks it deleted.
-final storeByIdProvider = StreamProvider.family<StoreData?, String>((
-  ref,
-  storeId,
-) {
-  final db = ref.watch(databaseProvider);
-  // Business-scoped lookup (DAO filters by current business + id).
-  return db.storesDao.watchStore(storeId);
-});
+// Business-scoped lookup (DAO filters by current business + id).
+final storeByIdProvider = businessScopedStreamFamily<StoreData?, String>(
+  (ref, db, businessId, storeId) => db.storesDao.watchStore(storeId),
+  whenAbsent: null,
+);
 
 // ── Roles & permissions (master plan §2.4, schema v13) ─────────────────────
 
@@ -1153,17 +1156,13 @@ final storeByIdProvider = StreamProvider.family<StoreData?, String>((
 /// canonical display order for roles across the whole app — any UI that lists
 /// roles must come through this provider (or otherwise sort by [roleRank]) so
 /// the tier order is consistent everywhere.
-final allRolesProvider = StreamProvider<List<RoleData>>((ref) {
-  return ref
-      .watch(databaseProvider)
-      .rolesDao
-      .watchAll()
-      .map(
-        (roles) =>
-            roles.toList()
-              ..sort((a, b) => roleRank(a.slug).compareTo(roleRank(b.slug))),
-      );
-});
+final allRolesProvider = businessScopedStream<List<RoleData>>(
+  (ref, db, businessId) => db.rolesDao.watchAll().map(
+        (roles) => roles.toList()
+          ..sort((a, b) => roleRank(a.slug).compareTo(roleRank(b.slug))),
+      ),
+  whenAbsent: const [],
+);
 
 // ── Appearance (business accent colour, §10.1) ──────────────────────────────
 
@@ -1181,16 +1180,16 @@ DesignSystem? _parseDesignSystem(String? v) {
 }
 
 /// The business-wide accent colour, streamed from the synced `settings` row.
-/// Null when no session is bound (pre-login) or the key is unset/invalid — the
-/// app-root bridge then leaves the device's themeController value alone (blue
-/// default). The null-session guard is required because `settingsDao.watch`
-/// calls `requireBusinessId()`, which throws without a business.
-final businessDesignSystemProvider = StreamProvider<DesignSystem?>((ref) {
-  ref.watch(authProvider); // re-subscribe when the session binds / unbinds
-  final db = ref.watch(databaseProvider);
-  if (db.currentBusinessId == null) return Stream.value(null);
-  return db.settingsDao.watch(kBusinessDesignSystemKey).map(_parseDesignSystem);
-});
+/// Null when no session is bound (pre-login, via the factory's `whenAbsent`) or
+/// the key is unset/invalid — the app-root bridge then leaves the device's
+/// themeController value alone (blue default). The factory owns the null-session
+/// guard (`settingsDao.watch` calls `requireBusinessId()`, which throws without
+/// a business) and re-subscribes on bind/unbind.
+final businessDesignSystemProvider = businessScopedStream<DesignSystem?>(
+  (ref, db, businessId) =>
+      db.settingsDao.watch(kBusinessDesignSystemKey).map(_parseDesignSystem),
+  whenAbsent: null,
+);
 
 /// The business-wide currency code (ISO-4217, e.g. 'NGN', 'USD'), streamed
 /// from the synced `default_currency` setting (Business Info, §10.1). Falls
@@ -1198,14 +1197,12 @@ final businessDesignSystemProvider = StreamProvider<DesignSystem?>((ref) {
 /// The app-root bridge (main.dart) feeds this into [setActiveCurrencyCode] so
 /// every money display follows the CEO-chosen currency live, including across
 /// devices. Mirrors [businessDesignSystemProvider]'s null-session guard.
-final currencyCodeProvider = StreamProvider<String>((ref) {
-  ref.watch(authProvider); // re-subscribe when the session binds / unbinds
-  final db = ref.watch(databaseProvider);
-  if (db.currentBusinessId == null) return Stream.value(kDefaultCurrency);
-  return db.settingsDao
+final currencyCodeProvider = businessScopedStream<String>(
+  (ref, db, businessId) => db.settingsDao
       .watch('default_currency')
-      .map((code) => code ?? kDefaultCurrency);
-});
+      .map((code) => code ?? kDefaultCurrency),
+  whenAbsent: kDefaultCurrency,
+);
 
 /// The active currency display symbol (e.g. '₦', r'$', 'GH₵'), derived from
 /// [currencyCodeProvider]. For widgets that render a symbol directly (input
@@ -1223,26 +1220,20 @@ final allPermissionsProvider = StreamProvider<List<PermissionData>>((ref) {
 
 /// Granted permissions for a specific role.
 final rolePermissionsProvider =
-    StreamProvider.family<List<RolePermissionData>, String>((ref, roleId) {
-      return ref
-          .watch(databaseProvider)
-          .rolePermissionsDao
-          .watchForRole(roleId);
-    });
+    businessScopedStreamFamily<List<RolePermissionData>, String>(
+  (ref, db, businessId, roleId) => db.rolePermissionsDao.watchForRole(roleId),
+  whenAbsent: const [],
+);
 
 /// Per-staff permission overrides for a specific user (§10.2.1). A row forces
 /// `permissionKey` on (`isGranted` true) or off (false) for that user,
 /// overriding their role default; no row = inherit.
 final userPermissionOverridesProvider =
-    StreamProvider.family<List<UserPermissionOverrideData>, String>((
-      ref,
-      userId,
-    ) {
-      return ref
-          .watch(databaseProvider)
-          .userPermissionOverridesDao
-          .watchForUser(userId);
-    });
+    businessScopedStreamFamily<List<UserPermissionOverrideData>, String>(
+  (ref, db, businessId, userId) =>
+      db.userPermissionOverridesDao.watchForUser(userId),
+  whenAbsent: const [],
+);
 
 /// Per-store role permission overrides for a specific (store, role) (§10.2.1
 /// Store scope). A row forces `permissionKey` on (`isGranted` true) or off
@@ -1251,29 +1242,27 @@ final userPermissionOverridesProvider =
 /// resolver (active store + current role) and the role-page editor (picked
 /// store + edited role) can both watch exactly the slice they need.
 final storeRolePermissionsProvider =
-    StreamProvider.family<
+    businessScopedStreamFamily<
       List<StoreRolePermissionData>,
       ({String storeId, String roleId})
-    >((ref, key) {
-      return ref
-          .watch(databaseProvider)
-          .storeRolePermissionsDao
-          .watchFor(key.storeId, key.roleId);
-    });
+    >(
+  (ref, db, businessId, key) =>
+      db.storeRolePermissionsDao.watchFor(key.storeId, key.roleId),
+  whenAbsent: const [],
+);
 
 /// Per-role tunable settings (max discount %, max expense approval kobo).
 final roleSettingsProvider =
-    StreamProvider.family<List<RoleSettingData>, String>((ref, roleId) {
-      return ref.watch(databaseProvider).roleSettingsDao.watchForRole(roleId);
-    });
+    businessScopedStreamFamily<List<RoleSettingData>, String>(
+  (ref, db, businessId, roleId) => db.roleSettingsDao.watchForRole(roleId),
+  whenAbsent: const [],
+);
 
 /// All memberships for the current business — drives Staff Management.
-final userBusinessesProvider = StreamProvider<List<UserBusinessData>>((ref) {
-  return ref
-      .watch(databaseProvider)
-      .userBusinessesDao
-      .watchForCurrentBusiness();
-});
+final userBusinessesProvider = businessScopedStream<List<UserBusinessData>>(
+  (ref, db, businessId) => db.userBusinessesDao.watchForCurrentBusiness(),
+  whenAbsent: const [],
+);
 
 /// Active staff (user + role) for a given business — drives the Who Is
 /// Working picker (master plan §8). Keyed by an explicit businessId because
@@ -1307,16 +1296,13 @@ final myUserStoresProvider = StreamProvider.family<List<UserStoreData>, String>(
 /// [userBusinessesProvider] so Staff Management can render each
 /// membership's name/avatar. Read-only (no synced write); businessId
 /// is the current session's via the Drift business resolver.
-final usersByBusinessProvider = StreamProvider<Map<String, UserData>>((ref) {
-  final db = ref.watch(databaseProvider);
-  final businessId = db.currentBusinessId;
-  if (businessId == null) {
-    return Stream<Map<String, UserData>>.value(const {});
-  }
-  return (db.select(db.users)..where((t) => t.businessId.equals(businessId)))
-      .watch()
-      .map((rows) => {for (final u in rows) u.id: u});
-});
+final usersByBusinessProvider = businessScopedStream<Map<String, UserData>>(
+  (ref, db, businessId) =>
+      (db.select(db.users)..where((t) => t.businessId.equals(businessId)))
+          .watch()
+          .map((rows) => {for (final u in rows) u.id: u}),
+  whenAbsent: const {},
+);
 
 // ── Role badge resolver (master plan §8.2) ──────────────────────────────────
 
@@ -1369,9 +1355,10 @@ final userRoleProvider = Provider.family<RoleData?, String>((ref, userId) {
 
 /// Active (unused, unrevoked, unexpired) invite codes for the current
 /// business — drives the Invites tab in Staff Management.
-final activeInviteCodesProvider = StreamProvider<List<InviteCodeData>>((ref) {
-  return ref.watch(databaseProvider).inviteCodesDao.watchActive();
-});
+final activeInviteCodesProvider = businessScopedStream<List<InviteCodeData>>(
+  (ref, db, businessId) => db.inviteCodesDao.watchActive(),
+  whenAbsent: const [],
+);
 
 // ── Current-user role & permission checks (PIVOT_PLAN step 8A) ───────────────
 
@@ -1757,58 +1744,53 @@ final businessTimezoneProvider = FutureProvider<String>((ref) async {
 /// Current empty-crate holdings per manufacturer (`manufacturerId → count`).
 /// Crate businesses only (§13/§18.3); used by the Daily Reconciliation Report's
 /// empty-crates section. Point-in-time pool balance, not a day-scoped movement.
-final emptyCratesByManufacturerProvider = StreamProvider<Map<String, int>>((
-  ref,
-) {
-  return ref
-      .watch(databaseProvider)
-      .inventoryDao
-      .watchEmptyCratesByManufacturer();
-});
+final emptyCratesByManufacturerProvider = businessScopedStream<Map<String, int>>(
+  (ref, db, businessId) => db.inventoryDao.watchEmptyCratesByManufacturer(),
+  whenAbsent: const {},
+);
 
 /// Every `damaged` empty-crate movement (§17.2 crate-aware damages — the
 /// stored-empty fate). Drives the Daily Reconciliation Statement's forfeited
 /// crate-deposit roll-up for empties damaged in storage, which write no
 /// stock_adjustment. Crate businesses only.
-final allCrateDamagesProvider = StreamProvider<List<CrateLedgerData>>((ref) {
-  return ref.watch(databaseProvider).inventoryDao.watchAllCrateDamages();
-});
+final allCrateDamagesProvider = businessScopedStream<List<CrateLedgerData>>(
+  (ref, db, businessId) => db.inventoryDao.watchAllCrateDamages(),
+  whenAbsent: const [],
+);
 
 /// Per-store empty-crate balances for the currently locked store (§16.8.1 Phase 2).
 /// Returns an empty list when no store is locked. Crate businesses only.
-final storeCrateBalancesProvider = StreamProvider<List<StoreCrateBalanceData>>((
-  ref,
-) {
-  final storeId = ref.watch(lockedStoreProvider).value;
-  if (storeId == null) return Stream.value(const []);
-  return ref
-      .watch(databaseProvider)
-      .storeCrateBalancesDao
-      .watchForStore(storeId);
-});
+final storeCrateBalancesProvider =
+    businessScopedStream<List<StoreCrateBalanceData>>(
+  (ref, db, businessId) {
+    final storeId = ref.watch(lockedStoreProvider).value;
+    if (storeId == null) return Stream.value(const []);
+    return db.storeCrateBalancesDao.watchForStore(storeId);
+  },
+  whenAbsent: const [],
+);
 
 /// Current empty-crate balance per manufacturer for a given store, mapped as
 /// manufacturerId -> balance. Scoped to [storeId] (§16.8.1).
 final storeEmptiesByManufacturerProvider =
-    StreamProvider.family<Map<String, int>, String>((ref, storeId) {
-  return ref
-      .watch(databaseProvider)
-      .storeCrateBalancesDao
+    businessScopedStreamFamily<Map<String, int>, String>(
+  (ref, db, businessId, storeId) => db.storeCrateBalancesDao
       .watchForStore(storeId)
-      .map((rows) => {for (final row in rows) row.manufacturerId: row.balance});
-});
+      .map((rows) => {for (final row in rows) row.manufacturerId: row.balance}),
+  whenAbsent: const {},
+);
 
 /// Full bottles in stock per manufacturer, scoped to the active store (§16.8.1
 /// Phase 2). When a store is locked it counts only that store's inventory; in
 /// "All Stores" it sums every store. Keyed by manufacturer id. Drives the
 /// "Full" figures on the inventory Empty Crates tab.
-final fullCratesByManufacturerProvider = StreamProvider<Map<String, int>>((ref) {
-  final storeId = ref.watch(lockedStoreProvider).value;
-  return ref
-      .watch(databaseProvider)
-      .inventoryDao
-      .watchFullCratesByManufacturer(storeId: storeId);
-});
+final fullCratesByManufacturerProvider = businessScopedStream<Map<String, int>>(
+  (ref, db, businessId) {
+    final storeId = ref.watch(lockedStoreProvider).value;
+    return db.inventoryDao.watchFullCratesByManufacturer(storeId: storeId);
+  },
+  whenAbsent: const {},
+);
 
 // ── Daily Stock Count (master plan §17) ──────────────────────────────────────
 
@@ -1816,25 +1798,27 @@ final fullCratesByManufacturerProvider = StreamProvider<Map<String, int>>((ref) 
 /// drives the Stock Count History sheet and feeds the Daily Reconciliation
 /// Report (Ring 3, §25.9). Live so a count saved on another device appears
 /// without a manual refresh (§5).
-final allStockCountsProvider = StreamProvider<List<StockCountData>>((ref) {
-  return ref.watch(databaseProvider).stockCountsDao.watchAllForBusiness();
-});
+final allStockCountsProvider = businessScopedStream<List<StockCountData>>(
+  (ref, db, businessId) => db.stockCountsDao.watchAllForBusiness(),
+  whenAbsent: const [],
+);
 
 /// Every applied stock adjustment for the business (newest first). Used by the
 /// §25.10 Business Statement / Store Reconciliation to value damages
 /// (`reason` `damage:<key>`, §17.2): at cost for the CEO P&L, at selling price
 /// for the Manager reconciliation.
-final allStockAdjustmentsProvider = StreamProvider<List<StockAdjustmentData>>((
-  ref,
-) {
-  return ref.watch(databaseProvider).inventoryDao.watchAllAdjustments();
-});
+final allStockAdjustmentsProvider =
+    businessScopedStream<List<StockAdjustmentData>>(
+  (ref, db, businessId) => db.inventoryDao.watchAllAdjustments(),
+  whenAbsent: const [],
+);
 
 /// Every supplier-ledger entry across all suppliers (business-wide, newest
 /// first). Used by the §25.10 CEO statement of account for goods received
 /// (invoice debits) and supplier payments (payment credits). Store scoping is
 /// applied in the report from each entry's `storeId` (§21.11).
 final allSupplierLedgerEntriesProvider =
-    StreamProvider<List<SupplierLedgerEntryData>>((ref) {
-      return ref.watch(databaseProvider).supplierLedgerDao.watchAllHistory();
-    });
+    businessScopedStream<List<SupplierLedgerEntryData>>(
+  (ref, db, businessId) => db.supplierLedgerDao.watchAllHistory(),
+  whenAbsent: const [],
+);

--- a/lib/features/sync/controllers/first_load_overlay_controller.dart
+++ b/lib/features/sync/controllers/first_load_overlay_controller.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:reebaplus_pos/core/providers/app_providers.dart';
+import 'package:reebaplus_pos/core/providers/business_scoped_stream.dart';
 import 'package:reebaplus_pos/core/services/first_load_marker_service.dart';
 import 'package:reebaplus_pos/core/services/supabase_sync_service.dart';
 
@@ -313,9 +314,7 @@ final firstLoadLandingReadyProvider = Provider<bool>((ref) {
 /// fresh device, and is corrected to true on a returning device (whose store is
 /// non-empty anyway, so the overlay stays hidden).
 final firstPullCompletedProvider = FutureProvider<bool>((ref) async {
-  final businessId = ref.watch(
-    authProvider.select((a) => a.currentUser?.businessId),
-  );
+  final businessId = ref.watch(currentBusinessIdProvider);
   if (businessId == null) return false;
   return FirstLoadMarkerService.hasCompletedPull(businessId);
 });

--- a/test/providers/business_scoped_stream_ban_test.dart
+++ b/test/providers/business_scoped_stream_ban_test.dart
@@ -1,0 +1,128 @@
+// Static enforcement seam (issue #24/#25, ADR 0003). A source scan that bans a
+// raw `StreamProvider` declaration anywhere in `lib/`: every business-scoped
+// live-query stream must be declared through the guarded factory
+// (`businessScopedStream` / `businessScopedStreamFamily` and their autoDispose
+// variants), so the build-time-poison bug (a tenant-scoped `watch*()` baking a
+// missing businessId at first build and sticking the whole session) cannot be
+// re-introduced. Prior art: test/permissions/gate_static_ban_test.dart and the
+// sync-registry golden/registration tests.
+//
+// The allowlist is SMALL and NON-EMPTY: it names the genuinely-NON-tenant-scoped
+// streams that legitimately stay raw (the ADR's "global/unscoped streams stay
+// off the factory"). It is a shrink-only ratchet — never add a business-scoped
+// provider to it; route the provider through the factory instead.
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// Provider names permitted to remain a raw `StreamProvider`. Each is NOT scoped
+/// to the current session's business, so forcing it through the factory would be
+/// wrong (it would break pre-bind resolution or change device-local semantics).
+///
+/// Grouped by why it is exempt:
+const _allowlist = <String>{
+  // Genuinely global catalogue / unscoped-by-design (role ids are globally
+  // unique, so the role is resolvable before a business binds).
+  'allPermissionsProvider',
+  '_allRolesUnscopedProvider',
+  // Keyed by an explicit id (not the session businessId) and resolved BEFORE a
+  // business binds — routing these through the factory would emit `whenAbsent`
+  // during the shared-PIN / Who's-Working picker and break role resolution.
+  '_userMembershipsProvider', // watchForUser(userId) — no whereBusiness
+  'myUserStoresProvider', // watchForUser(userId) — no whereBusiness
+  'activeStaffProvider', // watchActiveStaffForBusiness(explicit businessId)
+  'deviceStaffProvider', // watchDeviceStaffForBusiness(explicit businessId)
+  // Device-local sync-engine state — `sync_queue_orphans` carries no business_id
+  // column, so it is not tenant-scoped.
+  'orphanQueueItemsProvider',
+  'orphanQueueCountProvider',
+  // Intentionally unscoped — a device may hold more than one business's rows.
+  'localBusinessesProvider', // all businesses on the device
+  'pendingCrateReturnsProvider', // raw select, no session filter
+  'pendingReturnsWithDetailsProvider', // raw join, no session filter
+};
+
+/// Matches a top-level raw stream provider declaration —
+/// `final xProvider = StreamProvider…` in any of its forms (`.family`,
+/// `.autoDispose`, `.autoDispose.family`). Dart's `\s` matches newlines, so a
+/// declaration split across lines is still caught. A factory-built provider
+/// reads `= businessScopedStream…` and never matches.
+final _rawStreamDecl = RegExp(r'final\s+(\w+)\s*=\s*StreamProvider');
+
+/// The factory itself contains `return StreamProvider…` bodies — never scanned
+/// (it is the one place raw `StreamProvider` is the correct primitive).
+const _factoryFile = 'lib/core/providers/business_scoped_stream.dart';
+
+void main() {
+  test('no raw business-scoped StreamProvider is declared outside the factory',
+      () {
+    final found = <String, String>{}; // provider name → file path
+    for (final entity in Directory('lib').listSync(recursive: true)) {
+      if (entity is! File) continue;
+      final path = entity.path;
+      if (!path.endsWith('.dart') || path.endsWith('.g.dart')) continue;
+      if (path == _factoryFile) continue;
+      for (final m in _rawStreamDecl.allMatches(entity.readAsStringSync())) {
+        found[m.group(1)!] = path;
+      }
+    }
+
+    final offenders = <String>[];
+    found.forEach((name, path) {
+      if (!_allowlist.contains(name)) {
+        offenders.add('$name  ($path)');
+      }
+    });
+
+    expect(
+      offenders,
+      isEmpty,
+      reason:
+          'A raw StreamProvider was declared for a business-scoped read. Declare '
+          'it through the factory instead: businessScopedStream / '
+          'businessScopedStreamFamily (+ autoDispose variants), which guard the '
+          'null-businessId window (ADR 0003). If it is genuinely NOT '
+          'tenant-scoped, add its name to the allowlist with a reason.\n'
+          '${offenders.join('\n')}',
+    );
+
+    // Shrink-only ratchet: an allowlist entry with no matching raw provider is
+    // stale (the provider was migrated or renamed) — remove it.
+    final stale =
+        _allowlist.where((name) => !found.containsKey(name)).toList();
+    expect(
+      stale,
+      isEmpty,
+      reason:
+          'Stale allowlist entries — these no longer name a raw StreamProvider. '
+          'The allowlist may only shrink; remove them.\n${stale.join('\n')}',
+    );
+  });
+
+  test('the scan is strict — a planted raw provider is caught, the migrated '
+      'form is not', () {
+    // A re-introduced raw business-scoped stream is caught…
+    const planted =
+        "final xProvider = StreamProvider<int>((ref) => ref.watch(dbP).x());";
+    expect(_rawStreamDecl.hasMatch(planted), isTrue,
+        reason: 'the scanner must catch a re-introduced raw StreamProvider');
+
+    // …a multi-line declaration is caught (Dart \s spans newlines)…
+    const plantedMultiline =
+        'final xProvider =\n    StreamProvider.autoDispose.family<int, String>(';
+    expect(_rawStreamDecl.hasMatch(plantedMultiline), isTrue,
+        reason: 'a declaration split across lines must still be caught');
+
+    // …and none of the migrated (factory) forms trip the ban.
+    for (final migrated in [
+      'final xProvider = businessScopedStream<int>((ref, db, id) => db.x());',
+      'final xProvider = businessScopedStreamFamily<int, String>(',
+      'final xProvider = businessScopedStreamAutoDispose<int>(',
+      'final xProvider = businessScopedStreamAutoDisposeFamily<int, String>(',
+    ]) {
+      expect(_rawStreamDecl.hasMatch(migrated), isFalse,
+          reason: 'a factory-built provider must not trip the ban: $migrated');
+    }
+  });
+}

--- a/test/providers/business_scoped_stream_test.dart
+++ b/test/providers/business_scoped_stream_test.dart
@@ -1,0 +1,162 @@
+// Unit tests for the business-scoped stream factory (ADR 0003, issue #24).
+//
+// The module under test is the factory itself, driven through the
+// [currentBusinessIdProvider] seam: null → bound → switched → unbound. We assert
+// what the provider EMITS (whenAbsent → data → re-queried data), not how it is
+// wired. No database is required — the `databaseProvider` override is an inert
+// in-memory handle the closures ignore, and all data comes from
+// `StreamController`s keyed by the resolved businessId. Prior art:
+// test/permissions/guarded_test.dart (override a context provider with a
+// flippable source and assert the consequence).
+
+import 'dart:async';
+
+import 'package:drift/native.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:reebaplus_pos/core/database/app_database.dart';
+import 'package:reebaplus_pos/core/providers/app_providers.dart';
+import 'package:reebaplus_pos/core/providers/business_scoped_stream.dart';
+
+/// Flippable source of the current businessId; [currentBusinessIdProvider] is
+/// overridden to read it, so a test drives `null → id → other-id → null`.
+final _businessId = StateProvider<String?>((ref) => null);
+
+/// Per-businessId stream sources — a business SWITCH is shown re-querying the
+/// new tenant's data by handing back a different controller.
+late Map<String, StreamController<String>> _emitters;
+
+StreamController<String> _emitterFor(String key) =>
+    _emitters.putIfAbsent(key, () => StreamController<String>.broadcast());
+
+/// A plain guarded stream under test. The closure ignores `db` and returns the
+/// controller keyed by the resolved (non-null) businessId.
+final _probe = businessScopedStream<String>(
+  (ref, db, businessId) => _emitterFor(businessId).stream,
+  whenAbsent: 'ABSENT',
+);
+
+/// A guarded stream whose closure THROWS if ever run — proving the factory never
+/// invokes it in the null window (the exact build-time poison a raw provider
+/// hits via `requireBusinessId()`).
+final _throwIfUnguarded = businessScopedStream<String>(
+  (ref, db, businessId) => throw StateError('closure ran while unbound'),
+  whenAbsent: 'SAFE',
+);
+
+/// The keyed front door gets the same guard.
+final _familyProbe = businessScopedStreamFamily<String, String>(
+  (ref, db, businessId, arg) => _emitterFor('$businessId/$arg').stream,
+  whenAbsent: 'ABSENT',
+);
+
+void main() {
+  late ProviderContainer container;
+  late AppDatabase db;
+
+  setUp(() {
+    _emitters = {};
+    db = AppDatabase.forTesting(NativeDatabase.memory());
+    container = ProviderContainer(
+      overrides: [
+        currentBusinessIdProvider.overrideWith((ref) => ref.watch(_businessId)),
+        databaseProvider.overrideWithValue(db),
+      ],
+    );
+  });
+
+  tearDown(() async {
+    for (final c in _emitters.values) {
+      await c.close();
+    }
+    container.dispose();
+    await db.close();
+  });
+
+  void setBusiness(String? id) =>
+      container.read(_businessId.notifier).state = id;
+
+  // Let the event loop deliver Stream.value / controller events into the
+  // AsyncValue state.
+  Future<void> pump() async {
+    await Future<void>.delayed(Duration.zero);
+    await Future<void>.delayed(Duration.zero);
+  }
+
+  test('null window: emits whenAbsent and never runs the closure', () async {
+    container.listen(_throwIfUnguarded, (_, __) {});
+    container.listen(_probe, (_, __) {});
+    await pump();
+
+    final guarded = container.read(_throwIfUnguarded);
+    expect(guarded, isA<AsyncData<String>>());
+    expect(guarded.value, 'SAFE');
+    // The throwing closure was never invoked — no poison in the null window.
+    expect(guarded.hasError, isFalse);
+
+    expect(container.read(_probe).value, 'ABSENT');
+  });
+
+  test('binds: swaps whenAbsent for the tenant stream when an id binds',
+      () async {
+    container.listen(_probe, (_, __) {});
+    await pump();
+    expect(container.read(_probe).value, 'ABSENT');
+
+    setBusiness('biz-1');
+    await pump();
+    _emitterFor('biz-1').add('DATA-1');
+    await pump();
+    expect(container.read(_probe).value, 'DATA-1');
+  });
+
+  test('switches: re-queries the NEW tenant on a business switch', () async {
+    container.listen(_probe, (_, __) {});
+    setBusiness('biz-1');
+    await pump();
+    _emitterFor('biz-1').add('DATA-1');
+    await pump();
+    expect(container.read(_probe).value, 'DATA-1');
+
+    setBusiness('biz-2'); // switch
+    await pump();
+    _emitterFor('biz-2').add('DATA-2');
+    await pump();
+    expect(
+      container.read(_probe).value,
+      'DATA-2',
+      reason: 'the switch re-subscribed to biz-2, never leaking biz-1 data',
+    );
+  });
+
+  test('unbinds: returns to whenAbsent when the business unbinds', () async {
+    container.listen(_probe, (_, __) {});
+    setBusiness('biz-1');
+    await pump();
+    _emitterFor('biz-1').add('DATA-1');
+    await pump();
+    expect(container.read(_probe).value, 'DATA-1');
+
+    setBusiness(null);
+    await pump();
+    expect(container.read(_probe).value, 'ABSENT');
+  });
+
+  group('family variant', () {
+    test('emits whenAbsent for a keyed provider in the null window', () async {
+      container.listen(_familyProbe('k'), (_, __) {});
+      await pump();
+      expect(container.read(_familyProbe('k')).value, 'ABSENT');
+    });
+
+    test('binds per key when an id binds', () async {
+      container.listen(_familyProbe('k'), (_, __) {});
+      setBusiness('biz-1');
+      await pump();
+      _emitterFor('biz-1/k').add('DATA-1');
+      await pump();
+      expect(container.read(_familyProbe('k')).value, 'DATA-1');
+    });
+  });
+}


### PR DESCRIPTION
Implements PRD #23 in full — both slices #24 (factory + seam + tracers + enforcement) and #25 (the complete migration).

## What this retires
A business-scoped `StreamProvider` that calls a `requireBusinessId()`-backed DAO `watch*()` baked the session businessId at first build. First-subscribed in the create-business null window, it either **threw + stuck errored** or **silent-empty-stuck** for the whole session → empty Receive/Transfer/POS store pickers until a cold restart. Previously hand-patched once per provider (S153).

## The primitive — `lib/core/providers/business_scoped_stream.dart`
- `currentBusinessIdProvider` — the single watchable businessId seam (`authProvider.select(currentUser?.businessId)`). Nothing else re-derives the tenant; tests flip it via `overrideWith`.
- Four guarded factories: `businessScopedStream` / `businessScopedStreamFamily` + their `…AutoDispose` twins. Each watches the seam, emits a required `whenAbsent` while unbound, and hands the closure `(ref, db, businessId)` with a **guaranteed non-null id**; rebuilds on bind **and** on business switch.

## Migration
- **62 session-scoped stream declarations** lifted onto the factory across `stream_providers.dart` + `app_providers.dart` — behaviour-preserving (`whenAbsent` = the prior null-window value: `[]` / `{}` / `0` / `null` / `kDefaultCurrency` / a `.empty()` stats zero). **Consumers untouched.**
- `firstPullCompletedProvider` (FutureProvider) repointed onto the seam — no inline `.select` left.

## Enforcement + tests
- `test/providers/business_scoped_stream_ban_test.dart` — bans a raw `StreamProvider` anywhere in `lib/` (name allowlist = the 11 genuinely non-session-scoped streams, shrink-only ratchet) + a strictness companion (planted raw caught, multi-line caught, all four factory forms not flagged).
- `test/providers/business_scoped_stream_test.dart` — drives the factory `null → bound → switched → unbound` via the seam override; proves it never runs the closure in the null window. No database required.

## Two judgment calls (flagged for review)
1. **Closure gets `ref`** (`(ref, db, businessId)` vs the ADR's `(db, businessId)`) — several tenant feeds must compose the active-store `lockedStoreProvider`, impossible without `ref`. The non-null-id guarantee is unchanged. ADR 0003 + glossary updated.
2. **Final allowlist is 11, not "just the 2 globals"** — the extra 9 (explicit-id pre-bind pickers, device-local orphan feeds, unscoped selects) are genuinely not session-scoped; forcing them through the factory would break pre-bind resolution or change device-local semantics. Each entry documented with its reason.

## Verification
- `flutter analyze` clean.
- Full suite: **652 passed / 58 skipped / 1 pre-existing failure** (`who_is_working_screen_test.dart` "Carol" — confirmed failing identically with these changes stashed, unrelated).

Closes #24, closes #25. Implements #23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Real-time data now updates more reliably when switching or binding businesses.
  * Several live views, including orders, inventory, suppliers, transfers, roles, and sync queues, now stay in sync with the current business.

* **Bug Fixes**
  * Prevented empty or stale data from appearing during the brief period before a business is selected.
  * Improved fallback behavior so screens show safe defaults instead of breaking on missing context.

* **Tests**
  * Added coverage for business switching and safeguards against unsafe live data sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->