### PR TITLE
feat(web-pos): Slices 1–4 — walking skeleton + cash/credit/crate checkout (#47 #43 #44 #45)

### DIFF
--- a/.github/workflows/golden-scenarios.yml
+++ b/.github/workflows/golden-scenarios.yml
@@ -1,0 +1,57 @@
+# Golden-Scenario Suite (ADR 0009, issue #43) — the anti-divergence gate.
+#
+# The same cash-sale fixtures (test/golden/fixtures/*.json) run against BOTH
+# implementations of the checkout money rule. Drift between them fails the build.
+#
+#   * dart-dao   — the mobile Dart path (OrdersDao.createOrder + FIFO draw-down)
+#                  on an in-memory Drift DB. Offline, network-free → runs on
+#                  every push/PR, always.
+#   * rpc        — the SQL `checkout_order` RPC (migration 0135) on real dev
+#                  Supabase. Tier-2: runs only when the TEST_SUPABASE_* secrets
+#                  are configured; auto-skips otherwise (same gate the test uses).
+#
+# Both runners share test/golden/golden_scenario.dart, so the two paths are
+# compared field-for-field.
+
+name: golden-scenarios
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  dart-dao:
+    name: Golden — Dart DAO (offline, always)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          flutter-version: 3.44.2
+      - run: flutter pub get
+      - name: Run the Dart-DAO golden fixtures
+        run: flutter test test/golden
+
+  rpc:
+    name: Golden — checkout_order RPC (Tier-2, when secrets present)
+    runs-on: ubuntu-latest
+    # Secrets aren't available to PRs from forks; skip there rather than fail.
+    if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          flutter-version: 3.44.2
+      - run: flutter pub get
+      - name: Run the checkout_order RPC golden fixtures (auto-skips without env)
+        run: flutter test test/integration/rpcs/checkout_order_golden_test.dart --tags integration
+        env:
+          TEST_SUPABASE_URL: ${{ secrets.TEST_SUPABASE_URL }}
+          TEST_SUPABASE_ANON_KEY: ${{ secrets.TEST_SUPABASE_ANON_KEY }}
+          TEST_SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.TEST_SUPABASE_SERVICE_ROLE_KEY }}
+          TEST_USER_REFRESH_TOKEN: ${{ secrets.TEST_USER_REFRESH_TOKEN }}
+          TEST_BUSINESS_ID: ${{ secrets.TEST_BUSINESS_ID }}
+          TEST_USER_ID: ${{ secrets.TEST_USER_ID }}

--- a/BUILD_LOG.md
+++ b/BUILD_LOG.md
@@ -2,6 +2,59 @@
 
 ---
 
+## 2026-07-04 — Web POS Slice 1: walking skeleton (issue #47, ADRs 0007–0012)
+
+**What shipped.** The first code of the **Web POS** — a new top-level
+`web-pos/` Next.js (App Router) + React + TypeScript + `@supabase/supabase-js`
+app. Online-first (ADR 0007): a single browser Supabase client is the whole data
+layer (no Drift, no outbox). Thin but end-to-end through **auth → live RLS read →
+render**, establishing the responsive shell, theming, and permission-read layer
+every later slice builds on.
+
+- **Auth = Operator (ADR 0011).** `LoginForm` does email+OTP
+  (`signInWithOtp` → `verifyOtp`) and Google (`signInWithOAuth` → `/auth/callback`,
+  PKCE + `detectSessionInUrl`). `SessionProvider` tracks the session and, on
+  sign-in, runs `loadOperator()` — business scope from `profiles.business_id`,
+  role from the active `user_businesses` membership, effective permissions, the
+  `business_design_system` + `default_currency` settings, and the store list —
+  all RLS-scoped, **no custom JWT claims**. `IdleLock` signs out after 15 min of
+  inactivity, dropping the tab back to the sign-in screen.
+- **Live catalogue.** `loadCatalogue()` reads `categories` + `products`
+  (`retailer_price_kobo` / `wholesaler_price_kobo`) + `inventory` (on-hand summed
+  across stores) over PostgREST. `PosScreen` renders the responsive grid with
+  per-tier prices, a live in/low/out stock indicator, category chips, and a manual
+  Refresh (Realtime is Slice 5 / #49). Tapping a tile is gated on `sales.make`.
+- **Theming parity.** All five palettes (blue/amber/purple/green/b&w, light+dark)
+  ported verbatim from mobile `colors.dart` into `src/lib/theme/palettes.ts`
+  (keys = the `DesignSystem` enum names). `ThemeProvider` writes the active
+  palette as CSS custom properties on the document root, read live from the synced
+  `business_design_system` setting; light/dark follows the browser preference.
+- **Permission-read layer.** `resolveEffectivePermissions()` mirrors the mobile
+  Gate Registry's decisions (ADR 0009): role grants ± user overrides, **CEO
+  all-on**. `Can` / `useCan` gate nav + actions (hide-don't-block). Money via
+  `formatKobo` / `useCurrency` from `default_currency` — no hard-coded ₦.
+- **Config / deploy.** Public Supabase URL + anon key baked into
+  `src/lib/supabase/config.ts` (mirrors the mobile-intentional public/RLS-gated
+  key), overridable via `NEXT_PUBLIC_*` — builds with zero env setup. Vercel root
+  = `web-pos/` (ADR 0012); the README documents adding the deployed origin +
+  `/auth/callback` to Supabase Auth redirect URLs for Google.
+
+**Schema verified against the live cloud** before coding (snake_case columns):
+`products.retailer_price_kobo`/`wholesaler_price_kobo`, `inventory.quantity`,
+`user_businesses.role_id`+`status`, `role_permissions`/`user_permission_overrides`,
+`current_user_business_ids()` = `profiles.business_id`.
+
+**Verification.** `npm run typecheck` clean; `next build` green (5 routes
+prerender); `next start` smoke-test returns 200 on `/` and `/auth/callback` with
+the brand rendered. On-device/live sign-in walkthrough (real OTP + Google + a
+seeded business) pending — needs a browser session with real credentials.
+
+**Left for later slices:** cart/checkout RPC (#43) + the golden-scenario suite,
+Realtime (#49), inventory add/receive (#48), stock-adjust approval (#50), reports
+(#51), and store-scoped permission overrides (§10.2.1 middle layer).
+
+---
+
 ## 2026-07-04 — Batch-creation-on-inflow: Add Product + Receive Stock push a Cost Batch (Epic 2 / FIFO, issue #42, ADR 0005)
 
 **What shipped (Epic 2, F6).** The **producer** for the FIFO queue. F1 (#37) only

--- a/BUILD_LOG.md
+++ b/BUILD_LOG.md
@@ -2,6 +2,180 @@
 
 ---
 
+## 2026-07-05 — Web POS Slice 4: empty-crate ledger at checkout (issue #45, ADRs 0008/0009)
+
+**What shipped.** A web sale of deposit-bearing product now posts the **empty-crate
+ledger movements** for crate-eligible businesses, pinned identical to mobile by the
+golden suite, and the web cart + receipt surface the returnable-empties context —
+shown only when the business is crate-eligible and opts into empty tracking.
+
+- **`checkout_order` extended (migration `0137_checkout_order_crate.sql`).** A plain
+  CREATE-OR-REPLACE of the 8-arg 0136 function (same signature → no overload) that
+  adds the §13.4 crate dispatch. For a **registered** customer at a business where
+  `_is_crate_business(type) AND tracks_empty_crates` (new helper mirrors the mobile
+  `isCrateBusiness` — case-insensitive Bar / Beer|Beverage distributor), it groups
+  the crate-eligible lines (unit `bottle` + `track_empties` + a manufacturer) by
+  manufacturer and, per manufacturer: writes one `order_crate_lines` row (crates
+  taken + the deposit **rate** snapshot from `manufacturers.deposit_amount_kobo`,
+  frozen at sale time + deposit paid 0), one `'issued'` `crate_ledger` row (+crates),
+  and increments `customer_crate_balances` (upsert on the unique key) — so the
+  existing return path can net the balance to zero. Byte-for-byte the mobile
+  `OrdersDao.createOrder` + `CrateLedgerDao.recordCrateIssueByCustomer` crate-track
+  branch. **No double-count**: the crate legs never touch inventory, `cost_batches`,
+  COGS, payment, or the wallet. Walk-ins / non-crate businesses / empties-off all
+  post nothing.
+- **Scope = crate-track (empties owed).** The web collects no deposit money at
+  checkout, so every web crate sale is crate-track (`deposit_paid = 0`), and the
+  wallet legs stay exactly 0136's (deposit carve-out / money-track is a later
+  slice). The deposit **value** is still surfaced (rate × crates) as the value of
+  the empties owed.
+- **Verified end-to-end.** Deployed to dev and ran the **full** RPC via an
+  impersonated (JWT-claim `set_config`) transaction that **rolled back**: a
+  registered crate sale minted `WEB-000001-…`, drew FIFO COGS (item cogs 50000,
+  inventory 100→97), posted `order_crate_lines` (3 crates, rate 50000, paid 0), a
+  `crate_ledger` `issued` +3 to the customer, `customer_crate_balances` = 3, and the
+  net-zero wallet legs — matching the Dart golden field-for-field. Nothing persisted.
+- **Golden suite extended (ADR 0009).** The shared model gained optional crate
+  inputs (`business_type`, `tracks_empty_crates`, `manufacturers`, per-product
+  `manufacturer`) and expected crate rows (`crate_lines` / `crate_ledger` /
+  `crate_balances`), all defaulting empty so the cash/credit fixtures are unchanged.
+  New `crate_sale_scenarios.json` (5 scenarios: single line, two manufacturers,
+  mixed crate+non-crate cart, two lines summing to one crate line, and the gate-OFF
+  no-op). Both runners seed the business type + manufacturers + crate-eligible
+  bottles and collect the crate rows; the **Dart DAO tier is 17/17 green** offline,
+  the RPC tier is wired + env-gated (skips clean without secrets; the live E2E above
+  proves parity). `_is_crate_business` verified true/false against the canonical vs
+  non-crate types.
+- **Web UI (hide-don't-block).** `crate.ts` adds `isCrateBusiness` /
+  `businessTracksCrates` / `crateEligible` / `crateSummary`; the catalogue loads
+  `track_empties` + `manufacturer_id` and joins each product's per-manufacturer
+  deposit rate; the operator exposes `business.type`. The **Cart** and **Receipt**
+  render an "Empties (returnable)" line (N crates · deposit value) only when the
+  business tracks crates and the cart holds deposit-bearing product — hidden
+  entirely otherwise. `npm run typecheck` + `npm run build` green.
+- **Files.** `supabase/migrations/0137_checkout_order_crate.sql`;
+  `test/golden/golden_scenario.dart`, `test/golden/dart_dao_golden_test.dart`,
+  `test/golden/fixtures/crate_sale_scenarios.json`,
+  `test/integration/rpcs/checkout_order_golden_test.dart`;
+  `web-pos/src/lib/{crate.ts,catalogue.ts,operator.ts,types.ts,checkout.ts}`,
+  `web-pos/src/components/pos/{Cart,CheckoutDialog,Receipt}.tsx`.
+- **Left for later.** The money-track deposit path (cash deposit collected →
+  held `crate_deposit` wallet leg + goods carve-out, mobile Ring 6) needs a
+  deposit-collection surface; not required by #45 (empties tracking). Realtime
+  propagation of crate rows is Slice 5 (#49).
+
+---
+
+## 2026-07-05 — Web POS Slice 3: registered-customer credit & the wallet ledger (issue #44, ADRs 0008/0009)
+
+**What shipped.** The Web POS can now ring a sale up against a **registered
+customer's credit**: attach a customer, see their live balance, and check out as
+**Pay-with-Credit** (draw from their wallet) or **Register-as-Credit-Sale** (they
+owe the balance) — with the wallet ledger posted append-only server-side and the
+debt limit enforced at checkout, all pinned identical to mobile by the golden
+suite.
+
+- **`checkout_order` widened (migration `0136_checkout_order_credit.sql`).** Added
+  `p_customer_id` and the `credit` / `wallet` payment methods on top of the Slice 2
+  cash keystone. Dropped the 7-arg overload first (the CREATE-OR-REPLACE overload
+  trap → PGRST203). A registered sale posts **append-only wallet legs** (invariant
+  #3), byte-identical to mobile `OrdersDao.createOrder`: Leg 1 = a `debit` of the
+  order **net** (`order_payment`), Leg 2 = a `credit` of the cash paid
+  (`topup_cash` / `topup_transfer`, skipped when no cash lands). The customer
+  balance stays **derived** — new helper `_customer_wallet_balance()` sums the
+  signed legs excluding the crate-deposit family (mirrors
+  `CustomersDao.getBalanceKobo`).
+- **Debt limit, server-side.** A sale that books NEW debt (cash_paid < net) is
+  rejected (`debt_limit_exceeded`) when the projected balance would fall below
+  `−wallet_limit_kobo`; a fully-settled sale is never gated; `wallet_limit_kobo=0`
+  means no credit at all — the exact mobile `_overDebtLimit` rule. Also
+  `credit_requires_customer` and `customer_wallet_missing` guards.
+- **Verified end-to-end.** Deployed to dev and smoke-tested all four paths via an
+  impersonated (JWT-claim `set_config`) transaction that **rolled back** — a
+  no-cash credit sale posts one −net debit (balance −net); Pay-with-Credit drops an
+  existing balance by net; partial-cash credit posts debit + `topup_cash`;
+  over-limit raises `debt_limit_exceeded`. Nothing persisted.
+- **Golden suite extended.** The shared model gained an optional `customer`
+  (opening balance + debt limit), expected `wallet_legs` (multiset) +
+  `customer_balance_after_kobo`, and a nullable payment. Four credit fixtures added;
+  both runners seed a customer + wallet + opening leg and collect the per-order legs
+  + derived balance. **Dart DAO tier 12/12 green** offline. Guard tests add
+  debt-limit rejection, no-limit rejection, Pay-with-Credit, partial-cash legs, and
+  the credit-requires-customer guard. Fixed a latent Slice 2 bug: the Tier-2 seeds
+  used `selling_price_kobo` (no such column) → now `retailer_price_kobo`.
+- **Web UI.** `CustomerPicker` (searchable, shows each customer's derived balance)
+  + a cart customer bar (attach/change/remove + balance chip); `CheckoutDialog`
+  offers **Pay with Credit** and **Register as Credit Sale** when a customer is
+  attached, shows a live projected balance, and **blocks over the debt limit**
+  (disabled submit + banner) mirroring the server. `Receipt` shows the customer,
+  "on credit", and the new balance. `useCustomers` refreshes balances after each
+  sale. `npm run typecheck` + `npm run build` green; `flutter analyze` clean.
+- **Left for later:** crate ledger at checkout (#45), Realtime (#49), inventory
+  writes (#48), reports (#51).
+
+---
+
+## 2026-07-05 — Web POS Slice 2: cash-sale checkout keystone + Golden-Scenario Suite (issue #43, ADRs 0008/0009)
+
+**What shipped.** The keystone slice: a cash/transfer sale rung up on web end to
+end (grid → cart → checkout → receipt), settled by a new server-authoritative
+RPC, with the anti-divergence **Golden-Scenario Suite** proving the web money math
+matches mobile.
+
+- **`checkout_order` RPC (migration `0135_checkout_order.sql`, ADR 0008).** One
+  `SECURITY DEFINER` atomic transaction for the cash/transfer path (no customer
+  credit / no crate — Slices 3 & 4): inserts the Order at `pending` + line items;
+  draws down the FIFO `cost_batches` oldest-first **under a `FOR UPDATE` row lock**
+  (reusing the pure `fifo_assign` from 0133, so per-unit COGS rounding is
+  byte-identical to the recost pass and the mobile draw-down) and snapshots per-line
+  `buying_price_kobo`; decrements inventory with the `quantity >= qty` guard and
+  **rejects at commit if stock is insufficient** (two concurrent tills can't
+  oversell); re-points the product's scalar `buying_price_kobo` cache; writes one
+  `payment_transactions` row; recognizes revenue **at Checkout** (`status='pending'`,
+  `completed_at` NULL — matches `orderCountsAsSale`). Idempotent on `p_order_id`.
+- **Server order number, collision-proof.** `WEB-NNNNNN-XXXXXX` (running count +
+  6 hex from the order id). The `WEB-` prefix makes collision with the mobile
+  device-tag scheme (`ORD-NNNNNN-XXXXXX`) impossible regardless of the tail.
+- **Defence in depth.** Two reusable helpers — `caller_has_permission()` (role
+  grants ± user overrides, CEO all-on) and `caller_max_discount_percent()`
+  (role_settings, seed defaults CEO 100 / Manager 10 / else 0) — enforce
+  `sales.make` and clamp the order discount server-side, mirroring the mobile Gate
+  Registry's *decisions* (not its Dart code).
+- **Golden-Scenario Suite (ADR 0009).** `test/golden/fixtures/cash_sale_scenarios.json`
+  (8 scenarios: single line, boundary-span weighted COGS, two lines one draw,
+  partial-cover shortfall, no-batch uncosted, cost-0 batch, order discount, two
+  products + transfer) run against **both** implementations via one shared model
+  (`test/golden/golden_scenario.dart`): the Dart DAO path
+  (`test/golden/dart_dao_golden_test.dart`, in-memory Drift, offline → every CI
+  build) and the SQL RPC (`test/integration/rpcs/checkout_order_golden_test.dart`,
+  Tier-2, env-gated). Field-for-field drift fails the build. The order-number
+  *scheme* differs by client by design, so each runner asserts its own regex.
+  `.github/workflows/golden-scenarios.yml` runs the Dart tier always and the RPC
+  tier when the `TEST_SUPABASE_*` secrets are present.
+- **RPC guard tests** (`test/integration/rpcs/checkout_order_test.dart`): oversell
+  rejection, the two-till concurrency guard, idempotent replay, the `WEB-`/`ORD-`
+  non-collision, and discount-within-cap — the ACs the happy-path fixtures don't
+  cover.
+- **Web UI.** `CartProvider` (session-persistent cart) + `Cart` (qty stepper,
+  remove, role-capped discount, live totals) + `CheckoutDialog` (cash/transfer,
+  amount paid, change) + `Receipt` (print via a print-only stylesheet, Share via
+  Web Share with a text-file fallback download, "Done — back to POS" clears the
+  cart). `PosScreen` becomes grid-beside-cart on tablet+ and a sticky bottom bar
+  + bottom-sheet on phone. `loadOperator` now also resolves `maxDiscountPercent`.
+  The completed sale reaches the mobile devices through the existing
+  Realtime-signalled pull (no new sync wiring).
+
+**Verified.** `checkout_order` + both helpers deployed via `apply_migration` and
+registered; `fifo_assign` boundary-span, the `WEB-` order-number scheme (matches
+`^WEB-\d{6}-[0-9A-F]{6}$`, never `^ORD-`), and the Manager discount clamp confirmed
+by SQL; every RPC insert satisfies the live CHECK constraints (movement_type,
+exactly-one-reference, payment type/method, order status/payment_type); live column
+names (orders/order_items/inventory/stock_transactions/payment_transactions) match
+the RPC. Dart golden suite **8/8 green**; RPC golden + guard tests analyze clean and
+auto-skip without env. `web-pos` `npm run typecheck` + `npm run build` green.
+
+---
+
 ## 2026-07-04 — Web POS Slice 1: walking skeleton (issue #47, ADRs 0007–0012)
 
 **What shipped.** The first code of the **Web POS** — a new top-level

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,8 +1,13 @@
 # drinkPosApp — Domain Context
 
-A local-first drink-POS app. The on-device Drift database is the source of truth; a
-sync engine reconciles it with a Supabase cloud backend so the app works fully
-offline and converges when connectivity returns.
+A drink-POS platform with two clients over one Supabase backend. The **mobile app**
+is local-first: the on-device Drift database is the source of truth, and a sync
+engine reconciles it with the Supabase cloud so it works fully offline and converges
+when connectivity returns. The **web app** is online-first: it reads and writes the
+cloud live, through PostgREST/Realtime and server-authoritative RPCs, with no local
+source of truth (ADRs 0007–0012). The two clients share **one database schema and
+one RPC write-contract** — nothing else. The offline invariants (#1 local-source-of-
+truth, #4 every-write-through-the-outbox) are mobile-scoped, not app-wide.
 
 ## Language
 
@@ -171,3 +176,35 @@ business is bound, hands the closure `(ref, db, businessId)` with the resolved
 non-null id, and rebuilds on bind or switch — so a tenant-scoped read cannot be
 baked to a missing or stale business at build time.
 _Avoid_: raw `StreamProvider` over a DAO `watch*`, inline businessId guards.
+
+### Web
+
+**Web POS**:
+The online-first browser client (Next.js/React + `supabase-js`) that operates the
+app live against Supabase — reads through PostgREST/Realtime, writes through
+server-authoritative RPCs — with no Drift, no outbox, and no offline mode. A
+separate runtime from the mobile app, sharing only the schema and the RPC
+write-contract. Lives in `web-pos/`.
+_Avoid_: "the Flutter web build" (that is `web/`, mobile output); implying it is
+offline-capable or shares client code with mobile.
+
+**RPC Write API**:
+The set of `SECURITY DEFINER` Postgres RPCs that perform the Web POS's money-writes
+transactionally server-side (checkout, receive/adjust stock, ledger posting). The
+web client's *only* write path; it never writes business rows through PostgREST
+directly. The server-side counterpart to the mobile app's Dart DAO writes.
+_Avoid_: "the API", direct PostgREST writes from web, Edge Functions (the write
+API is RPCs, not functions).
+
+**Golden-Scenario Suite**:
+The shared fixtures — input state → expected resulting rows — run in CI against
+*both* the Dart DAO path (mobile) and the SQL RPC path (web) to prove the two
+implementations of the same money rule stay identical. The mechanism that makes
+"full parity" safe despite two implementations (ADR 0009).
+_Avoid_: treating each client's own unit tests as sufficient; assuming shared code
+prevents drift (there is none — only shared fixtures).
+
+**Operator** *(web)*:
+The signed-in web user attributed to a sale. On web the Supabase session is the
+operator directly — there is no PIN and no "Who's working?" picker (ADR 0011).
+_Avoid_: equating it with the mobile "active user" chosen via PIN.

--- a/CONTEXT/progress-tracker.md
+++ b/CONTEXT/progress-tracker.md
@@ -10,6 +10,76 @@ The human updates it when resolving open questions or making architectural decis
 
 152 sessions logged. Codebase is live and being verified on-device.
 
+### PLANNING: Web POS (online-first browser client) — grilled 2026-07-04, ADRs 0007–0012
+- **North star:** full parity — the *entire* app replicated for web — reached in
+  phases. **Phase 1 = selling loop + inventory management + reports.** Later phases
+  add staff/roles, suppliers & ledgers, expenses, crate management, activity logs,
+  settings, onboarding (create-business / join-invite, minus PIN).
+- **Architecture decisions (see ADRs):**
+  - **0007** Web is **online-first**, not offline-first: live PostgREST/Realtime
+    reads + RPC writes, no Drift, no outbox. Offline invariants #1/#4 are
+    mobile-scoped, not app-wide.
+  - **0008** Web write path = **server-authoritative Postgres RPCs** (checkout,
+    receive/adjust stock, ledger posting, order#). Shared contract = schema + RPCs.
+  - **0009** Same money rules implemented **twice** (Dart offline / SQL online);
+    kept identical by a **shared golden-scenario suite** in CI.
+  - **0010** Stack = **Next.js/React + supabase-js** (no Flutter Web, no shared
+    client code).
+  - **0011** Auth = **per-user Supabase session is the operator** (no PIN, no
+    "Who's working?" picker); RLS scope from `profiles.business_id`.
+  - **0012** **Monorepo** — new `web-pos/` dir beside `supabase/migrations/`;
+    deploy on Vercel.
+- **PRD + issues published** (`okworemmanuelc/Reebaplus_POS`, all `ready-for-agent`):
+  epic **#46** (`docs/prd/web-pos.md`); slices **#47** skeleton → **#43** cash
+  checkout keystone → **#44** credit/wallet → **#45** crate → **#49** realtime →
+  **#48** inventory add/receive → **#50** stock-adjust approval → **#51** reports.
+  Dependency order: #43←#47; #44/#45←#43; #49/#48/#51←#47; #50←#48.
+- **Next:** one fresh session per issue → `/implement` (pass PRD #46 + the single
+  issue). Phase-1 keystone is #43 (`checkout_order` RPC + golden-scenario suite).
+- CONTEXT.md updated: intro now describes two clients; new **Web** glossary section
+  (Web POS, RPC Write API, Golden-Scenario Suite, Operator).
+
+### SHIPPED: Web POS Slice 1 — walking skeleton (2026-07-04, issue #47, ADRs 0007–0012)
+- **First code of the Web POS.** A new top-level **`web-pos/`** Next.js (App
+  Router) + React + TypeScript + `@supabase/supabase-js` app (ADR 0010/0012),
+  thin but end-to-end through **auth → live RLS read → render**. Online-first
+  (ADR 0007): a single browser Supabase client is the whole data layer — no
+  Drift, no outbox. `next build` green; all 5 routes prerender; server smoke-test
+  200 on `/` and `/auth/callback`.
+- **Auth = Operator (ADR 0011).** Email+OTP (`signInWithOtp`/`verifyOtp`) and
+  Google (`signInWithOAuth` → `/auth/callback`, PKCE, `detectSessionInUrl`). The
+  session IS the Operator for the tab; `loadOperator()` resolves business scope
+  from `profiles.business_id`, role from the active `user_businesses` membership,
+  and perms — **no custom JWT claims**. `IdleLock` (15 min inactivity) signs out
+  → tab re-locks to the sign-in screen. Every read is RLS-scoped, so the Operator
+  only sees their own business.
+- **Live catalogue.** `loadCatalogue()` reads `categories` + `products`
+  (`retailer_price_kobo` / `wholesaler_price_kobo`) + `inventory` (on-hand summed
+  across stores) over PostgREST; the responsive `PosScreen` renders the grid with
+  per-tier prices, a live stock indicator (in/low/out), and category chips.
+  Out-of-stock tiles render unavailable. Realtime auto-refresh is Slice 5 (#49);
+  here a manual **Refresh** re-pulls. Tapping a tile is gated on `sales.make`
+  (cart/checkout is Slice 2 / #43).
+- **Theming parity.** All five palettes (blue/amber/purple/green/b&w, light+dark)
+  ported verbatim from the mobile `colors.dart` into `src/lib/theme/palettes.ts`
+  (keys = the `DesignSystem` enum names). `ThemeProvider` applies the active
+  palette as CSS custom properties at the document root, read live from the synced
+  `business_design_system` setting (mobile's source too) — a change re-paints with
+  no redeploy; light/dark follows the browser preference.
+- **Permission-read layer.** `resolveEffectivePermissions()` mirrors the mobile
+  Gate Registry's *decisions* (ADR 0009 — not its Dart): role grants ± user
+  overrides, **CEO all-on**. `Can` / `useCan` drive hide-don't-block (gated nav +
+  the sell affordance). Currency via `formatKobo`/`useCurrency` from
+  `default_currency` — never hard-coded ₦.
+- **Config:** public Supabase URL + anon key baked into
+  `src/lib/supabase/config.ts` (mirrors the mobile-intentional public/RLS-gated
+  key), overridable via `NEXT_PUBLIC_*`; builds with zero env setup. Vercel root =
+  `web-pos/` (ADR 0012); README documents the OAuth redirect-URL config step.
+- **Scope left for later slices (per the epic order):** cart/checkout RPC (#43),
+  Realtime (#49), inventory add/receive (#48), stock-adjust approval (#50),
+  reports (#51), and store-scoped permission overrides (§10.2.1 middle layer).
+  No golden-scenario suite yet (arrives with the first money-write RPC, #43).
+
 ### SHIPPED: Batch-creation-on-inflow — Add Product + Receive Stock push a Cost Batch (2026-07-04, issue #42, ADR 0005)
 - **Epic 2, F6 (FIFO batch costing).** The **producer** for the queue: F1 (#37)
   only seeded opening batches via the migration and F2 (#38) only consumed it, so

--- a/CONTEXT/progress-tracker.md
+++ b/CONTEXT/progress-tracker.md
@@ -39,6 +39,146 @@ The human updates it when resolving open questions or making architectural decis
 - CONTEXT.md updated: intro now describes two clients; new **Web** glossary section
   (Web POS, RPC Write API, Golden-Scenario Suite, Operator).
 
+### SHIPPED: Web POS Slice 4 — empty-crate ledger at checkout (2026-07-05, issue #45, ADRs 0008/0009)
+- **`checkout_order` extended (migration `0137_checkout_order_crate.sql`).** A plain
+  CREATE-OR-REPLACE of the 8-arg 0136 function (same signature → no overload, no
+  drop) that adds the §13.4 crate dispatch. For a **registered** customer at a
+  business where `_is_crate_business(type) AND tracks_empty_crates` (new SQL helper
+  mirrors mobile `isCrateBusiness` — case-insensitive Bar / Beer|Beverage
+  distributor, NULL→false), it groups the crate-eligible lines (unit `bottle` +
+  `track_empties` + a manufacturer) by manufacturer and posts, per manufacturer:
+  one `order_crate_lines` row (crates taken + the deposit **rate** snapshot from
+  `manufacturers.deposit_amount_kobo`, frozen at sale time + deposit paid 0), one
+  `'issued'` `crate_ledger` row (+crates), and a `customer_crate_balances`
+  increment (upsert on the unique key). Byte-for-byte the mobile `OrdersDao.create
+  Order` + `CrateLedgerDao.recordCrateIssueByCustomer` **crate-track** branch.
+- **No double-count (issue AC).** The crate legs are wholly separate from the drink
+  cost/stock/wallet legs — they never touch inventory, `cost_batches`, COGS,
+  payment_transactions, or the wallet. Walk-ins (no customer), non-crate businesses,
+  and empties-OFF all post no crate rows (the combined gate).
+- **Scope = crate-track only.** The web collects no deposit money at checkout, so
+  every web crate sale is crate-track (`deposit_paid = 0`) and the wallet legs stay
+  exactly 0136's. The money-track deposit carve-out (paid deposit → held
+  `crate_deposit` wallet leg, mobile Ring 6) needs a deposit-collection surface and
+  is deliberately deferred to a later slice; the deposit **value** is still surfaced
+  (rate × crates) as the value of the empties owed.
+- **Golden-Scenario Suite extended (ADR 0009).** `golden_scenario.dart` gained
+  optional crate inputs (`business_type`, `tracks_empty_crates`, `manufacturers`,
+  per-product `manufacturer`) and expected crate rows (`crate_lines` /
+  `crate_ledger` / `crate_balances`), all defaulting empty so the 8 cash + 4 credit
+  fixtures are untouched. New `crate_sale_scenarios.json` (5 scenarios: single line,
+  two manufacturers, mixed crate+non-crate cart, two lines summing to one crate
+  line, and the gate-OFF no-op). Both runners seed the business type + manufacturers
+  + crate-eligible bottles and collect the crate rows; the **Dart DAO tier runs 17/17
+  green** every build (offline), the RPC tier is wired + env-gated (Tier-2).
+- **Verified live.** Deployed to dev; ran the **full** `checkout_order` through an
+  impersonated (JWT-claim `set_config`) transaction that **rolled back** — a
+  registered crate sale minted `WEB-…`, drew FIFO COGS (inventory 100→97, cogs
+  50000), posted `order_crate_lines` (3 crates, rate 50000, paid 0), a `crate_ledger`
+  `issued` +3 to the customer, `customer_crate_balances` = 3, and the net-zero wallet
+  legs — matching the Dart golden field-for-field. Nothing persisted.
+- **Web UI (hide-don't-block).** New `web-pos/src/lib/crate.ts`
+  (`isCrateBusiness`/`businessTracksCrates`/`crateEligible`/`crateSummary`); the
+  catalogue now loads `track_empties` + `manufacturer_id` and joins each product's
+  per-manufacturer deposit rate; the operator exposes `business.type`. The **Cart**
+  and **Receipt** render an "Empties (returnable)" line (N crates · deposit value)
+  only when the business tracks crates AND the cart holds deposit-bearing product —
+  hidden entirely otherwise. `npm run typecheck` + `npm run build` green.
+- **Scope left for later slices:** Realtime (#49) — crate rows propagate to mobile
+  via the existing signalled pull; the money-track deposit path (above); inventory
+  add/receive (#48); stock-adjust approval (#50); reports (#51).
+
+### SHIPPED: Web POS Slice 3 — registered-customer credit & the wallet ledger (2026-07-05, issue #44, ADRs 0008/0009)
+- **`checkout_order` widened (migration `0136_checkout_order_credit.sql`).** Adds
+  `p_customer_id` (dropping the old 7-arg overload first, per the overload trap)
+  and two credit paths on top of the Slice 2 cash keystone:
+  - **Pay-with-Credit** (`p_payment_method='wallet'`) — draw the whole sale from
+    the customer's existing balance; `amount_paid=0`, no cash payment row.
+  - **Register-as-Credit-Sale** (`'credit'`) — the customer owes the balance; any
+    `p_amount_paid_kobo` part-pays it now (0..net).
+  A registered Cash/Transfer sale now ALSO posts its wallet legs, so the ledger
+  history is complete. **Wallet legs (append-only, invariant #3, mirrors mobile
+  `OrdersDao.createOrder`):** Leg 1 = a `debit` of the order **net**
+  (`order_payment`); Leg 2 = a `credit` of the cash paid (`topup_cash` /
+  `topup_transfer`, skipped when no cash). The customer balance stays **derived** —
+  new helper `_customer_wallet_balance()` = `SUM(signed_amount_kobo)` excluding
+  the crate-deposit family (byte-identical to `CustomersDao.getBalanceKobo`).
+- **Debt limit enforced server-side (defence in depth).** A sale that books NEW
+  debt (cash_paid < net) is rejected (`debt_limit_exceeded`) when the projected
+  balance would fall below `−customers.wallet_limit_kobo`; a fully-settled sale is
+  never gated; `wallet_limit_kobo = 0` means no credit at all — the exact mobile
+  `_overDebtLimit` rule. `credit`/`wallet` without a customer → `credit_requires_
+  customer`; a customer with no wallet → `customer_wallet_missing`.
+- **Golden-Scenario Suite extended.** The shared model (`golden_scenario.dart`)
+  now carries an optional `customer` (opening balance + debt limit), expected
+  `wallet_legs` (multiset) + `customer_balance_after_kobo`, and a nullable payment
+  (a no-cash sale posts none). Four credit fixtures added to
+  `cash_sale_scenarios.json` (Pay-with-Credit, credit-sale no-cash, credit-sale
+  partial-cash, registered fully-paid). Both runners seed a customer + wallet +
+  opening leg and collect the per-order legs + derived balance; the Dart DAO tier
+  is **12/12 green** offline, the RPC tier verified end-to-end via an impersonated
+  SQL smoke test (identical legs/balances). Guard tests
+  (`checkout_order_test.dart`) add debt-limit rejection, no-limit rejection,
+  Pay-with-Credit draw-down, partial-cash legs, and the `credit_requires_customer`
+  guard. Also fixed a latent Slice 2 test bug: `selling_price_kobo` → the real
+  `retailer_price_kobo` column (the Tier-2 seeds would have failed).
+- **Web UI.** `CustomerPicker` (searchable, shows each customer's live derived
+  balance) + a cart customer bar (attach / change / remove, balance chip) +
+  `CheckoutDialog` gains **Pay with Credit** and **Register as Credit Sale** when a
+  customer is attached, a live projected-balance readout, and a **debt-limit
+  block** (submit disabled + a clear banner) mirroring the server rule. `Receipt`
+  shows the customer, "on credit", and the new balance. `useCustomers` refreshes
+  the list (with balances) after each sale. `loadCustomers` derives balances
+  client-side (read-only, like the catalogue's on-hand sum). `npm run typecheck` +
+  `npm run build` green.
+- **Scope left for later slices:** crate ledger at checkout (#45, in progress),
+  Realtime (#49), inventory add/receive (#48), reports (#51). The credit paths and
+  wallet-leg contract are pinned by the golden harness Slice 4 reuses.
+
+### SHIPPED: Web POS Slice 2 — cash-sale checkout keystone + Golden-Scenario Suite (2026-07-05, issue #43, ADRs 0008/0009)
+- **`checkout_order` RPC (migration `0135_checkout_order.sql`).** The
+  server-authoritative cash/transfer checkout — one `SECURITY DEFINER` atomic
+  transaction (no customer credit / no crate; those are Slices 3 & 4): Order at
+  `pending` + line items; FIFO `cost_batches` draw-down oldest-first **under a
+  `FOR UPDATE` row lock**, reusing the pure `fifo_assign` (0133) so per-unit COGS
+  rounding is byte-identical to the recost pass and the mobile draw-down;
+  per-line `buying_price_kobo` snapshot; inventory decrement with the
+  `quantity >= qty` guard that **rejects at commit on insufficient stock** (two
+  tills can't oversell); scalar `buying_price_kobo` cache re-point; one
+  `payment_transactions` row; **revenue at Checkout** (`status='pending'`,
+  `completed_at` NULL). Idempotent on `p_order_id`.
+- **Server order number.** `WEB-NNNNNN-XXXXXX` (running count + 6 hex of the order
+  id). The `WEB-` prefix makes collision with the mobile `ORD-…` device-tag scheme
+  impossible regardless of the tail.
+- **Server-side enforcement (defence in depth).** New reusable helpers
+  `caller_has_permission()` (role grants ± user overrides, CEO all-on) and
+  `caller_max_discount_percent()` (role_settings, seed CEO 100 / Manager 10 / else
+  0) enforce `sales.make` and clamp the discount server-side — mirroring the mobile
+  Gate Registry's *decisions*, not its Dart (ADR 0009). The web ALSO hides.
+- **Golden-Scenario Suite (ADR 0009).** Shared fixtures
+  (`test/golden/fixtures/cash_sale_scenarios.json`, 8 scenarios) + one model
+  (`test/golden/golden_scenario.dart`) run against **both** implementations: the
+  Dart DAO path (`test/golden/dart_dao_golden_test.dart`, in-memory Drift, offline
+  → runs every CI build; **8/8 green**) and the SQL RPC
+  (`test/integration/rpcs/checkout_order_golden_test.dart`, Tier-2, env-gated).
+  Field-for-field drift fails the build. The order-number *scheme* is deliberately
+  divergent, so each runner asserts its own regex, never equality.
+  `.github/workflows/golden-scenarios.yml` runs the Dart tier always, the RPC tier
+  when the `TEST_SUPABASE_*` secrets exist. Guard tests
+  (`test/integration/rpcs/checkout_order_test.dart`) cover oversell rejection, the
+  concurrency guard, idempotent replay, `WEB-`/`ORD-` non-collision, discount cap.
+- **Web UI.** `CartProvider` (session-persistent cart) + `Cart` (qty stepper,
+  remove, role-capped discount, live line/order totals) + `CheckoutDialog`
+  (cash/transfer, amount paid, change) + `Receipt` (print via print-only
+  stylesheet, Share via Web Share + text-download fallback, "Done — back to POS"
+  clears the cart). `PosScreen` = grid-beside-cart on tablet+, sticky bottom bar +
+  bottom-sheet on phone (four responsive bands). `loadOperator` now resolves
+  `maxDiscountPercent`. The sale reaches mobile via the existing Realtime pull — no
+  new sync wiring. `npm run typecheck` + `npm run build` green.
+- **Scope left for later slices:** customer-credit / wallet checkout (#44), crate
+  ledger at checkout (#45), Realtime (#49), inventory add/receive (#48), reports
+  (#51). Slices 3/4/6/7 reuse this golden harness.
+
 ### SHIPPED: Web POS Slice 1 — walking skeleton (2026-07-04, issue #47, ADRs 0007–0012)
 - **First code of the Web POS.** A new top-level **`web-pos/`** Next.js (App
   Router) + React + TypeScript + `@supabase/supabase-js` app (ADR 0010/0012),

--- a/docs/adr/0007-web-pos-online-first.md
+++ b/docs/adr/0007-web-pos-online-first.md
@@ -1,0 +1,15 @@
+# Web POS is an online-first client, not offline-first
+
+The web version of the app talks to the Supabase database **live** — every read
+hits PostgREST/Realtime and every write goes through a server RPC — with no local
+source-of-truth and no sync outbox. This deliberately inverts the mobile app's
+invariants #1 and #4 (Drift is the source of truth; every cloud write goes through
+the outbox) *for the web client only*. The mobile app stays offline-first,
+unchanged: the two clients are different runtimes over one shared Supabase backend,
+not one codebase. A browser has reliable connectivity and no durable local store we
+trust, so replicating the offline-first machinery on web would be cost with no
+benefit and would fight the platform.
+
+The consequence recorded here so a future reader does not "fix" it: **the offline
+invariants are mobile-scoped, not app-wide.** Web code that reads live from
+Supabase or writes without an outbox is correct; it is not a violation.

--- a/docs/adr/0008-rpc-write-api-for-web.md
+++ b/docs/adr/0008-rpc-write-api-for-web.md
@@ -1,0 +1,18 @@
+# Server-authoritative Postgres RPCs are the web write API
+
+Every money-write the web POS performs — checkout, receive/adjust stock, wallet and
+crate ledger posting, order-number minting, revenue recognition — executes inside a
+`SECURITY DEFINER` Postgres RPC, transactionally, behind RLS. The web client never
+writes business rows directly through PostgREST; it calls the RPC and the server
+does the math. This is because that logic today lives entirely in the mobile app's
+Dart DAOs, which a browser cannot run, and because two clients writing the same
+shared database must not each carry their own copy of, say, FIFO draw-down.
+
+RPCs (not Edge Functions) were chosen so the whole operation is one atomic SQL
+transaction with the strongest concurrency guarantees — the web checkout must
+decrement live stock and draw down FIFO batches under a row lock and reject at
+commit if stock is insufficient, which the offline LWW model never had to solve
+server-side.
+
+The shared contract between mobile and web is therefore the **database schema + the
+RPC surface** — never client code.

--- a/docs/adr/0009-two-implementations-one-contract.md
+++ b/docs/adr/0009-two-implementations-one-contract.md
@@ -1,0 +1,18 @@
+# One behavioral contract, two implementations — golden-scenario suite
+
+The same money rules (FIFO COGS draw-down, wallet/crate ledger posting, order
+numbering, revenue recognition) are implemented **twice**: once in Dart DAOs for the
+offline-first mobile app, once in the Postgres RPCs for the online-first web app
+(ADR 0008). We accept the duplication because we cannot remove it: mobile is
+offline-first and *must* compute a receipt, a stock decrement, and a COGS snapshot
+locally with no server round-trip, so it can never call the live RPC at write time.
+"Full parity on web" means the same rules, not one shared write path.
+
+The anti-divergence mechanism is a **shared golden-scenario suite**: a set of
+scenario fixtures (input state → expected resulting rows) run in CI against *both*
+the Dart path and the SQL RPC. Any drift between the two implementations fails the
+build. This is the guarantee that keeps money math identical across clients; correctness
+does not rely on humans keeping two code paths in sync by hand.
+
+Rejected: migrating mobile onto the RPCs (breaks the offline selling loop) and a
+portable codegen'd math engine (heavy tooling, FIFO/ledger don't express portably).

--- a/docs/adr/0010-web-client-stack.md
+++ b/docs/adr/0010-web-client-stack.md
@@ -1,0 +1,13 @@
+# Web client stack — Next.js/React + supabase-js
+
+The web app is built in TypeScript with Next.js/React and `supabase-js`, not in
+Flutter Web. Realtime subscriptions, RLS-scoped PostgREST reads, and `rpc()` calls
+are first-class in `supabase-js`, which matches the online-first model (ADR 0007)
+directly. Reusing the Flutter app on web was rejected because the entire mobile
+codebase is wired to Drift-backed DAOs and offline-first providers (invariant #1):
+"reusing" it would mean ripping out its data layer behind hundreds of call sites and
+still shipping a heavy web runtime for a data-grid app.
+
+Because the shared contract is the schema + RPCs (ADR 0008), *no* client code is
+shared with Flutter — so the client language is free to be whatever suits the web,
+and TypeScript + React is the idiomatic live-Supabase choice.

--- a/docs/adr/0011-web-auth-per-user-session.md
+++ b/docs/adr/0011-web-auth-per-user-session.md
@@ -1,0 +1,15 @@
+# Web auth — the per-user Supabase session is the operator
+
+On web, a staff member signs in with their own email-OTP or Google identity, and
+that Supabase session *is* the operator for the browser tab. There is no 6-digit
+PIN and no "Who's working?" shared-till picker on web. RLS resolves the caller's
+business scope server-side from `profiles.business_id` keyed on `auth.uid()`
+(`current_user_business_ids()`), so a valid session is all the web client needs —
+no custom JWT claims to populate.
+
+The PIN and shared-till picker were deliberately *not* ported: invariant #2 says a
+PIN never leaves the device and never reaches the cloud, so a browser fundamentally
+cannot verify one. Sales are attributed to the logged-in user. A shared browser till
+(one machine, many cashiers each re-authing) is accepted for now; a server-side
+"quick-switch operator" factor is a possible later phase, and would need a new
+cloud-verifiable factor — never the device PIN.

--- a/docs/adr/0012-web-app-in-monorepo.md
+++ b/docs/adr/0012-web-app-in-monorepo.md
@@ -1,0 +1,14 @@
+# Web app lives in this repo (monorepo), beside the migrations
+
+The Next.js web app is a new top-level directory in this repository (`web-pos/`),
+alongside `supabase/migrations/` and the Flutter `lib/`. The deciding factor is that
+the shared mobile↔web contract is the DB schema + RPCs (ADR 0008), and those
+migrations already live here. Keeping the web client in the same repo means a
+contract change (a new RPC) and its web caller land in **one atomic PR**, with no
+cross-repo version coordination. The web app deploys to Vercel with its project root
+set to the `web-pos/` subdirectory.
+
+Note the pre-existing `web/` directory is Flutter's own web build output — the new
+app is `web-pos/` to avoid the collision. Workspace tooling (pnpm/turbo) was not set
+up now; it can be introduced if more JS packages (shared types, an admin console)
+later join.

--- a/docs/prd/web-pos.md
+++ b/docs/prd/web-pos.md
@@ -1,0 +1,281 @@
+# PRD — Web POS (online-first browser client)
+
+> Status: draft for review (not yet published to the issue tracker).
+> Grilled 2026-07-04. Decisions recorded in ADRs 0007–0012 and CONTEXT.md (Web section).
+> Scope of this PRD: **Phase 1** of a full-parity roadmap — the selling loop,
+> inventory management, and reports. Later parity phases are in *Out of Scope*.
+
+## Problem Statement
+
+The business runs entirely on the mobile app today. A CEO, manager, or cashier who
+is at a desk — not standing at the shared till — has no way to operate the business
+from a computer. They cannot ring up a sale on a laptop, manage the catalogue on a
+big screen with a keyboard, or pull up reports in a browser tab. Everything requires
+picking up the phone/tablet that runs the offline-first app. As businesses grow past
+a single till, "you must use the mobile device" is a real ceiling: back-office work
+and a second selling station both want a browser.
+
+## Solution
+
+A browser-based version of the app — the **Web POS** — that operates the same
+business, live, from any computer. Unlike the mobile app it is **online-first**: it
+reads the Supabase cloud directly (PostgREST + Realtime) and performs every
+money-write through a **server-authoritative RPC**, with no offline mode. A staff
+member signs in with their own email-OTP or Google identity and that session is the
+**Operator**; they see the same catalogue, customers, and inventory the mobile
+tills see, updated live, and every sale they ring up appears on the mobile devices
+(and vice-versa) through the existing sync path. Phase 1 delivers the full selling
+loop, inventory management, and reports; later phases bring the rest of the app to
+parity.
+
+Because the same money math (FIFO COGS, wallet/crate ledger posting, order
+numbering, revenue recognition) now runs in *two* places — Dart on offline mobile,
+SQL RPC on online web — a **Golden-Scenario Suite** runs the same fixtures against
+both and fails CI on any drift, so the two implementations can never disagree.
+
+## User Stories
+
+### Authentication & session (Operator model, ADR 0011)
+
+1. As a staff member, I want to open the Web POS in a browser and sign in with my
+   email + OTP, so that I can operate my business from a computer.
+2. As a staff member, I want to sign in with Google, so that I can use the identity
+   I already have without waiting for an email code.
+3. As an Operator, I want the app to know my business, stores, and role automatically
+   after sign-in, so that I only see and act on my own business's data.
+4. As an Operator, I want the tab to lock back to the sign-in screen after a period
+   of inactivity, so that a walk-away doesn't leave the business exposed on a shared
+   computer.
+5. As an Operator, I want every sale I make attributed to me, so that activity logs
+   and reports show who did what.
+6. As a business owner, I want a staff member with no permission for an action to not
+   see it in the web UI (hide-don't-block), so that the web honors the same
+   data-driven permissions as mobile.
+
+### Selling loop — POS grid & cart
+
+7. As an Operator, I want to see the live product grid with categories and price
+   tiers (Retailer / Wholesaler), so that I can build a sale the same way as on
+   mobile.
+8. As an Operator, I want out-of-stock products shown as unavailable using the live
+   stock count, so that I don't add something that isn't there.
+9. As an Operator, I want to tap/click a product to add it to the cart, adjust its
+   quantity, and remove it, so that I can assemble the order.
+10. As an Operator, I want the cart to show line totals and an order total in the
+    business currency, so that I can see what the customer owes.
+11. As an Operator, I want to apply a discount within the limit my role allows (and be
+    capped if I exceed it), so that discounting stays governed by permissions.
+12. As an Operator, I want to attach a registered customer to the cart, so that the
+    sale posts to their credit history and wallet.
+13. As an Operator, I want the cart to persist within my session while I look something
+    up, so that I don't lose an in-progress sale on navigation.
+
+### Checkout (server-authoritative `checkout_order` RPC, ADR 0008)
+
+14. As an Operator, I want to check out with Cash/Transfer by entering the amount paid,
+    so that I can settle a normal sale.
+15. As an Operator, I want to check out as Pay-with-Credit against a registered
+    customer's wallet, so that a known customer can pay from their balance.
+16. As an Operator, I want to register a sale as a Credit Sale, so that a customer can
+    take goods now and owe the balance.
+17. As an Operator, I want a sale that would push a customer past their debt limit to be
+    blocked at checkout, so that credit rules are enforced.
+18. As an Operator, I want checkout to reject if the live stock is insufficient at the
+    moment of commit, so that two concurrent tills can't oversell the same units.
+19. As the business, I want checkout to draw down FIFO Cost Batches oldest-first and
+    snapshot per-line COGS server-side, so that web sales value inventory exactly like
+    mobile sales.
+20. As the business, I want checkout to write the wallet ledger legs (debit the order,
+    credit the amount paid) as append-only rows, so that the customer balance stays the
+    single source of truth.
+21. As the business, I want checkout to post crate ledger movements for crate-eligible
+    businesses, so that empties are tracked when a web sale involves deposit-bearing
+    product.
+22. As the business, I want the order number minted server-side in a way that can never
+    collide with a mobile device's offline order number, so that numbering stays unique
+    across clients.
+23. As the business, I want revenue recognized at Checkout (order `pending`), not at
+    Confirm, so that web sales count as recognized Sales identically to mobile.
+24. As an Operator, I want the whole checkout to be atomic — order, items, ledgers, stock,
+    COGS all commit together or not at all — so that a failure never leaves a half-written
+    sale.
+
+### Receipt
+
+25. As an Operator, I want a receipt to open after checkout, so that I can confirm the
+    sale and give the customer a record.
+26. As an Operator, I want to print the receipt from the browser, so that a customer with
+    a paper preference gets one.
+27. As an Operator, I want to share/download the receipt (PDF or link), so that a customer
+    can get it digitally.
+28. As an Operator, I want a "Done — back to POS" action that clears the cart, so that I'm
+    ready for the next sale.
+
+### Live consistency (Realtime)
+
+29. As an Operator, I want a price edited on mobile to appear in the web grid without a
+    manual refresh, so that the two clients agree.
+30. As an Operator, I want a web sale to appear on the mobile devices' orders/stock, so
+    that everyone sees a consistent picture.
+31. As an Operator, I want stock counts in the grid to update live as other tills sell, so
+    that I don't try to sell stock that just ran out.
+
+### Inventory management (Phase 1)
+
+32. As a manager, I want to add a product (name, per-tier prices, opening stock, store) on
+    web, so that I can build the catalogue on a keyboard and big screen.
+33. As a manager, I want to edit a product's prices and details on web, so that pricing is
+    maintainable from a desk.
+34. As a manager, I want to Receive Stock (log a supplier delivery) on web, so that a
+    delivery can be recorded from the office — creating the Cost Batch at the delivery cost.
+35. As a manager, I want to adjust stock on web, so that counts can be corrected.
+36. As a stock keeper, I want my stock adjustment on web to create a pending request rather
+    than change inventory directly, so that the approval gate that exists on mobile is
+    honored on web too.
+37. As a manager, I want to approve or reject a stock adjustment request on web, so that the
+    approval loop can be completed from a computer.
+
+### Reports & dashboards (Phase 1)
+
+38. As a CEO/manager, I want a sales/revenue dashboard on web, so that I can see how the
+    business is doing on a big screen.
+39. As a CEO/manager, I want a profit report that excludes Uncosted units transparently, so
+    that the web report matches the mobile report's costing rules.
+40. As a CEO/manager, I want to view activity logs on web, so that I can audit who did what.
+41. As a CEO/manager, I want reports scoped to the active store or all stores, so that a
+    multi-store business can slice its numbers.
+
+### Correctness guardrail
+
+42. As the business, I want the web money-writes verified against the same fixtures as the
+    mobile money-writes, so that FIFO/ledger/order-number logic can never silently diverge
+    between the two clients.
+
+### Responsiveness & theming (cross-cutting)
+
+43. As an Operator on a phone browser, I want the Web POS to lay out in a single, touch-
+    friendly column, so that I can use it on a small screen.
+44. As an Operator on a tablet, I want a layout that uses the extra width (e.g. product
+    grid beside the cart), so that the tablet form factor is well used.
+45. As an Operator on a PC/laptop, I want a full multi-pane desktop layout with keyboard
+    support, so that ringing up and back-office work are efficient on a big screen.
+46. As an Operator on a very large/wide monitor, I want the content to stay well
+    proportioned (max widths, denser grids) rather than stretch awkwardly, so that big
+    screens are orchestrated, not just scaled.
+47. As a CEO, I want the business colour I set (the synced `business_design_system`
+    choice: blue / amber / purple / green / b&w) to be applied across the Web POS, so
+    that the web matches my brand exactly like the mobile app.
+48. As an Operator, I want a change the CEO makes to the business colour to apply on web
+    live (on the next load / reactively), so that branding stays consistent across
+    clients without a redeploy.
+49. As an Operator, I want business settings that affect what I see (currency, empty-crate
+    tracking on/off, store scope) honored on web, so that the web behaves like the same
+    business, not a generic app.
+
+## Implementation Decisions
+
+- **Online-first web client (ADR 0007).** No Drift, no outbox, no offline mode on web.
+  Reads are live PostgREST queries + Realtime subscriptions; the offline invariants
+  (#1, #4) are mobile-scoped, not app-wide.
+- **RPC Write API (ADR 0008).** Every money-write is a `SECURITY DEFINER` Postgres RPC,
+  one atomic transaction, behind RLS. Phase-1 RPC surface (new unless noted):
+  - `checkout_order(...)` — the keystone. In one transaction: insert the Order at
+    `pending` + line items; draw down FIFO Cost Batches oldest-first under a row lock
+    and snapshot per-line `buying_price_kobo`; **reject if live stock is insufficient at
+    commit**; post wallet ledger legs; post crate ledger movements for crate-eligible
+    businesses; enforce the customer debt limit; mint a **server-side order number** that
+    cannot collide with the mobile device-tag scheme; recognize revenue at checkout.
+  - `receive_stock(...)` — increases stock, posts the supplier invoice/payment/crate
+    returns, pushes a new Cost Batch at the delivery cost.
+  - `add_product(...)` / `update_product(...)` — catalogue writes incl. the opening Cost
+    Batch (costed or Uncosted).
+  - `request_stock_adjustment(...)` / `approve_stock_adjustment(...)` — honor the
+    approval gate (stock keeper → pending request; manager/CEO → apply).
+  - Reuse existing RPCs where they already encode the rule (e.g. the recost family
+    0133) rather than duplicating.
+  - Each RPC **enforces the caller's permission server-side** (defense in depth) in
+    addition to the client hiding the action.
+- **Amounts stay in `*_kobo` bigint** end to end (per the cloud kobo-must-be-bigint
+  rule); the web formats with the business currency, never hard-coding ₦.
+- **Two implementations, one contract (ADR 0009).** The Dart DAO path and the SQL RPC
+  path are independent implementations of the same rules, pinned identical by the
+  Golden-Scenario Suite.
+- **Client stack (ADR 0010).** Next.js/React + `supabase-js`; RLS-scoped reads,
+  `rpc()` writes, Realtime channels. No Flutter Web, no shared client code with mobile.
+- **Auth (ADR 0011).** Per-user Supabase session = Operator; no PIN, no "Who's working?"
+  picker. Business scope resolves server-side from `profiles.business_id`
+  (`current_user_business_ids()`); no custom JWT claims needed.
+- **Permissions.** The web reads the same `role_permissions` / override rows and applies
+  hide-don't-block, mirroring the mobile Gate Registry's *decisions* (not its Dart code).
+- **Responsive/adaptive layout.** The web is designed for four breakpoint bands — phone,
+  tablet, desktop, and large/wide — with orchestrated layouts, not a single scaled view:
+  a single touch column on phones; grid-beside-cart on tablets; multi-pane + keyboard
+  affordances on desktop; max-width/denser composition on very wide screens. Responsive
+  behavior is a **cross-cutting acceptance criterion on every UI slice**, plus a
+  responsive app shell established in the walking skeleton.
+- **Theming parity (CEO business colour).** The web reproduces the five named palettes
+  (blue / amber / purple / green / b&w, with light/dark) as web theme tokens matching the
+  mobile `AppTheme` palettes, applied at the app root. The active palette is read **live
+  from the synced `business_design_system` setting** (value = the `DesignSystem.name`
+  the CEO set) — the same source mobile reads via `businessDesignSystemProvider` — so the
+  CEO's colour applies on web and reacts to changes without a redeploy. Light/dark mode
+  may follow the browser/device preference; the business *colour* is the synced,
+  CEO-authoritative axis. Currency continues to be formatted from the business currency
+  setting, never hard-coded.
+- **Monorepo (ADR 0012).** New `web-pos/` directory beside `supabase/migrations/`;
+  contract change + web caller land in one PR; deploy on Vercel with root `web-pos/`.
+  The pre-existing `web/` dir is Flutter's build output and is left alone.
+- **Cross-client propagation.** Web writes land as ordinary cloud rows with normal
+  `last_updated_at`; mobile picks them up through its existing Realtime-signalled pull.
+  Mobile writes reach web through the web's Realtime subscriptions. No new sync engine.
+
+## Testing Decisions
+
+- **A good test asserts external behavior, not implementation.** For the RPCs, that means
+  asserting the *rows produced* (order, items, ledger legs, batch consumption, stock
+  level, order number shape) from a given starting state — never the internal query plan.
+- **Single primary seam: the RPC contract boundary.** The **Golden-Scenario Suite** is a
+  set of fixtures (input state → expected resulting rows) run in CI against **both** the
+  SQL RPC (web money-writes) and the Dart DAO (mobile money-writes). Drift on either side
+  fails the build. This is the one seam that guarantees parity of the money math.
+- **Web UI** is tested with lighter component tests over a **mocked `supabase-js`** — the
+  UI's job is to call the right RPC with the right args and render the response, not to
+  re-derive money math.
+- **Prior art in this repo:** `test/integration/rpcs/pos_recost_batches_test.dart` (Dart
+  integration test driving a Postgres RPC), the costing suites under `test/costing/`
+  (pure-function + DAO behavior), and the existing v2 sale RPCs (`pos_record_sale_v2`,
+  `pos_recost_pairs`, `pos_recost_product_store`) as models for a transactional
+  `SECURITY DEFINER` write RPC.
+
+## Out of Scope
+
+- **Offline mode on web.** The web is online-first by decision (ADR 0007); a browser with
+  no connection simply cannot operate.
+- **PIN / "Who's working?" shared-till picker on web** (ADR 0011). No cloud-verifiable
+  PIN exists (invariant #2). A server-side "quick-switch operator" factor is a possible
+  later phase.
+- **Migrating the mobile app onto the RPCs.** Mobile stays offline-first with its Dart
+  write path; only web uses the RPCs (ADR 0009).
+- **Later full-parity phases** (this PRD is Phase 1 only): staff/roles management,
+  supplier ledgers & payments, expenses & approvals, crate-management screens, settings /
+  business info, onboarding on web (create-business, join-with-invite — which also need a
+  no-PIN variant of the flow), deliveries. These become their own PRDs.
+- **A separate operator Admin Hub.** The existing subscription console is unchanged.
+
+## Further Notes
+
+- **Full-parity roadmap.** North star is the entire app on web. Suggested phase order after
+  Phase 1: (2) staff/roles + activity, (3) suppliers & wallets, (4) expenses, (5) crate
+  management, (6) settings & business info, (7) onboarding (create-business / join-invite,
+  no-PIN). Each is a live-read screen set plus, where it writes money, a new RPC + its
+  golden fixtures.
+- **Concurrency is a new problem web introduces.** Offline mobile resolved conflicts with
+  LWW after the fact; web sells against live stock, so `checkout_order` must decrement
+  under a row lock and reject at commit. This is why the write path is an RPC (one atomic
+  transaction), not client-side PostgREST writes.
+- **Order numbering.** Mobile uses `ORD-NNNNNN-XXXXXX` with a per-device tag to avoid
+  offline collisions. The web RPC mints server-side with a distinct strategy (server tag
+  or sequence) that is collision-proof against every mobile device tag.
+- **Deployment.** Vercel, project root `web-pos/`. Same Supabase project as mobile; no new
+  backend infrastructure — the "backend" for web is the RPC surface + RLS that already
+  exist plus the new Phase-1 RPCs.

--- a/supabase/migrations/0135_checkout_order.sql
+++ b/supabase/migrations/0135_checkout_order.sql
@@ -1,0 +1,541 @@
+-- 0135_checkout_order.sql
+--
+-- Reebaplus — Web POS Slice 2 (keystone). The server-authoritative cash/transfer
+-- checkout RPC (PRD web-pos, ADR 0008 "RPC Write API", issue #43).
+--
+-- WHY AN RPC (not client-side PostgREST writes): the offline mobile app resolves
+-- stock conflicts with LWW after the fact; the online web client sells against
+-- LIVE stock, so a checkout must decrement inventory + draw down the FIFO cost
+-- queue UNDER A ROW LOCK and reject at commit if stock is insufficient — two
+-- concurrent tills must not oversell the same units. That guarantee only exists
+-- inside one atomic SQL transaction, which is exactly what a SECURITY DEFINER
+-- RPC gives us.
+--
+-- SCOPE (Slice 2): the plain cash/transfer path only — no customer credit / wallet
+-- (Slice 3) and no crate ledger (Slice 4). One registered-customer-free sale:
+--   order (status 'pending') + line items
+--   + FIFO draw-down oldest-first with per-line COGS snapshot onto
+--     order_items.buying_price_kobo  (reuses public.fifo_assign from 0133)
+--   + inventory decrement with the insufficient-stock guard (concurrency)
+--   + stock_transactions ledger rows
+--   + one payment_transactions row
+--   + a SERVER-minted order number that can never collide with the mobile
+--     device-tag scheme (distinct 'WEB-' prefix vs mobile 'ORD-')
+--   + revenue recognized at Checkout (order 'pending', per orderCountsAsSale)
+-- all-or-nothing.
+--
+-- TWO IMPLEMENTATIONS, ONE CONTRACT (ADR 0009): this RPC is the SQL twin of the
+-- mobile Dart checkout (OrdersDao.createOrder + CostBatchesDao.drawDownSale). The
+-- money math here is pinned identical to Dart by the Golden-Scenario Suite
+-- (test/golden/*), which runs the same fixtures against both. In particular the
+-- FIFO per-unit rounding is round(line_total / qty) via public.fifo_assign, byte-
+-- for-byte the same rounding the Dart draw-down uses.
+--
+-- DEFENCE IN DEPTH: the web UI already hides actions the operator's role lacks,
+-- but this RPC ALSO enforces `sales.make` server-side and clamps the order
+-- discount to the caller's role cap (`max_discount_percent`). Both checks mirror
+-- the mobile Gate Registry's *decisions* (not its Dart code, ADR 0009), via two
+-- reusable SECURITY DEFINER helpers added here.
+--
+-- DEPLOY ORDER: after 0133 (public.fifo_assign) and 0132 (cost_batches). No app-
+-- schema change — additive server logic; inert until called by the web client.
+
+BEGIN;
+
+-- ─── 1. caller_has_permission — server-side hide-don't-block, mirrored ───────
+--
+-- Resolves the CURRENT authenticated caller's effective permission for a key,
+-- mirroring the mobile permission resolution (role grants ± user overrides, CEO
+-- all-on). SECURITY DEFINER so it can read the caller's own role/override rows
+-- reliably regardless of RLS (constrained to auth.uid(), so it can only ever
+-- answer about the caller — no data-leak from the definer privilege, same
+-- pattern as current_user_linked_business, 0128).
+--
+-- Store-scope overrides (store_role_permissions, §10.2.1 middle layer) are NOT
+-- consulted here — the web selling loop is single-store-per-sale and the mobile
+-- web permission-read (web-pos/src/lib/permissions.ts) resolves Business ± User
+-- for the same reason. Add the store layer here if/when web goes multi-store.
+CREATE OR REPLACE FUNCTION public.caller_has_permission(
+  p_business_id     uuid,
+  p_permission_key  text
+)
+RETURNS boolean
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+DECLARE
+  v_user_id  uuid;
+  v_role_id  uuid;
+  v_slug     text;
+  v_has      boolean := false;
+  v_override boolean;
+BEGIN
+  SELECT id INTO v_user_id
+    FROM public.users
+   WHERE auth_user_id = auth.uid()
+   LIMIT 1;
+  IF v_user_id IS NULL THEN
+    RETURN false;
+  END IF;
+
+  SELECT ub.role_id, r.slug
+    INTO v_role_id, v_slug
+    FROM public.user_businesses ub
+    JOIN public.roles r ON r.id = ub.role_id
+   WHERE ub.user_id = v_user_id
+     AND ub.business_id = p_business_id
+     AND ub.status = 'active'
+   ORDER BY ub.last_login_at DESC NULLS LAST
+   LIMIT 1;
+
+  -- CEO is all-on and skips every override layer (mirrors resolveEffectivePermissions).
+  IF v_slug = 'ceo' THEN
+    RETURN true;
+  END IF;
+
+  IF v_role_id IS NOT NULL THEN
+    v_has := EXISTS (
+      SELECT 1 FROM public.role_permissions
+       WHERE role_id = v_role_id
+         AND business_id = p_business_id
+         AND permission_key = p_permission_key
+    );
+  END IF;
+
+  -- A user override force-grants (true) or force-revokes (false).
+  SELECT is_granted INTO v_override
+    FROM public.user_permission_overrides
+   WHERE user_id = v_user_id
+     AND business_id = p_business_id
+     AND permission_key = p_permission_key
+   LIMIT 1;
+  IF v_override IS NOT NULL THEN
+    v_has := v_override;
+  END IF;
+
+  RETURN v_has;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.caller_has_permission(uuid, text) FROM public;
+GRANT EXECUTE ON FUNCTION public.caller_has_permission(uuid, text)
+  TO authenticated, service_role;
+
+
+-- ─── 2. caller_max_discount_percent — the role discount cap, mirrored ────────
+--
+-- The max discount % the caller's role may apply (§12.6/§13.2), from
+-- role_settings.max_discount_percent with the same seed defaults the mobile
+-- currentUserMaxDiscountPercentProvider uses (CEO 100, Manager 10, else 0).
+CREATE OR REPLACE FUNCTION public.caller_max_discount_percent(
+  p_business_id uuid
+)
+RETURNS int
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+DECLARE
+  v_user_id uuid;
+  v_role_id uuid;
+  v_slug    text;
+  v_val     text;
+BEGIN
+  SELECT id INTO v_user_id
+    FROM public.users
+   WHERE auth_user_id = auth.uid()
+   LIMIT 1;
+  IF v_user_id IS NULL THEN
+    RETURN 0;
+  END IF;
+
+  SELECT ub.role_id, r.slug
+    INTO v_role_id, v_slug
+    FROM public.user_businesses ub
+    JOIN public.roles r ON r.id = ub.role_id
+   WHERE ub.user_id = v_user_id
+     AND ub.business_id = p_business_id
+     AND ub.status = 'active'
+   ORDER BY ub.last_login_at DESC NULLS LAST
+   LIMIT 1;
+
+  IF v_slug = 'ceo' THEN
+    RETURN 100;
+  END IF;
+
+  IF v_role_id IS NOT NULL THEN
+    SELECT setting_value INTO v_val
+      FROM public.role_settings
+     WHERE role_id = v_role_id
+       AND business_id = p_business_id
+       AND setting_key = 'max_discount_percent'
+     LIMIT 1;
+  END IF;
+
+  IF v_val IS NOT NULL AND v_val ~ '^[0-9]+$' THEN
+    RETURN v_val::int;
+  END IF;
+
+  RETURN CASE v_slug WHEN 'manager' THEN 10 ELSE 0 END;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.caller_max_discount_percent(uuid) FROM public;
+GRANT EXECUTE ON FUNCTION public.caller_max_discount_percent(uuid)
+  TO authenticated, service_role;
+
+
+-- ─── 3. checkout_order — the keystone cash/transfer checkout ─────────────────
+--
+-- p_items : [{ "product_id": <uuid>, "quantity": <int>, "unit_price_kobo": <bigint> }, ...]
+--           (catalogue lines only — no quick-sale / no-product lines on web yet)
+--
+-- Idempotent on p_order_id (the client-minted UUIDv7): a replay returns the
+-- existing order + items + payment without re-applying any side effect.
+CREATE OR REPLACE FUNCTION public.checkout_order(
+  p_business_id      uuid,
+  p_order_id         uuid,          -- idempotency key (client UUIDv7)
+  p_store_id         uuid,
+  p_items            jsonb,
+  p_payment_method   text,          -- 'cash' | 'transfer'
+  p_amount_paid_kobo bigint,
+  p_discount_kobo    bigint DEFAULT 0
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+DECLARE
+  v_now          timestamptz := now();
+  v_actor_id     uuid;
+  v_existing     boolean;
+  v_gross        bigint;
+  v_max_pct      int;
+  v_cap          bigint;
+  v_discount     bigint;
+  v_net          bigint;
+  v_order_count  bigint;
+  v_order_number text;
+  v_item         jsonb;
+  v_item_id      uuid;
+  v_product_id   uuid;
+  v_qty          int;
+  v_unit_price   bigint;
+  v_line_total   bigint;
+  v_new_qty      int;
+  v_stx_id       uuid;
+  v_payment_id   uuid;
+  v_product      uuid;
+  v_batches      jsonb;
+  v_batch_ids    uuid[];
+  v_sales        jsonb;
+  v_assigned     jsonb;
+  v_rem          jsonb;
+  v_line         jsonb;
+  v_i            int;
+  v_products     uuid[];
+  v_oldest_cost  bigint;
+  v_order_row    jsonb;
+  v_items_out    jsonb;
+  v_payment_row  jsonb;
+  v_inv_after    jsonb := '[]'::jsonb;
+BEGIN
+  PERFORM public._assert_caller_owns_business(p_business_id);
+
+  -- Server-side permission enforcement (defence in depth; the web also hides).
+  IF NOT public.caller_has_permission(p_business_id, 'sales.make') THEN
+    RAISE EXCEPTION 'permission_denied: sales.make'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  IF p_order_id IS NULL THEN
+    RAISE EXCEPTION 'order_id_required' USING ERRCODE = 'invalid_parameter_value';
+  END IF;
+  IF p_store_id IS NULL THEN
+    RAISE EXCEPTION 'store_id_required' USING ERRCODE = 'invalid_parameter_value';
+  END IF;
+  IF jsonb_typeof(p_items) <> 'array' OR jsonb_array_length(p_items) = 0 THEN
+    RAISE EXCEPTION 'items_required' USING ERRCODE = 'invalid_parameter_value';
+  END IF;
+  IF p_payment_method IS NULL OR p_payment_method NOT IN ('cash', 'transfer') THEN
+    RAISE EXCEPTION 'payment_method_must_be_cash_or_transfer'
+      USING ERRCODE = 'invalid_parameter_value';
+  END IF;
+
+  -- Idempotent replay: the order already exists → return its current state.
+  SELECT true INTO v_existing FROM public.orders WHERE id = p_order_id;
+  IF v_existing THEN
+    SELECT to_jsonb(o.*) INTO v_order_row FROM public.orders o WHERE o.id = p_order_id;
+    SELECT COALESCE(jsonb_agg(to_jsonb(oi.*) ORDER BY oi.created_at, oi.id), '[]'::jsonb)
+      INTO v_items_out FROM public.order_items oi WHERE oi.order_id = p_order_id;
+    SELECT to_jsonb(pt.*) INTO v_payment_row
+      FROM public.payment_transactions pt
+      WHERE pt.order_id = p_order_id AND pt.type = 'sale'
+      ORDER BY pt.created_at LIMIT 1;
+    RETURN jsonb_build_object(
+      'order',               v_order_row,
+      'order_items',         v_items_out,
+      'payment_transaction', v_payment_row,
+      'inventory_after',     '[]'::jsonb,
+      'replayed',            true
+    );
+  END IF;
+
+  -- Attribute the sale to the caller (staff_id). NULL is tolerated (attribution
+  -- only) — the sale still commits.
+  SELECT id INTO v_actor_id FROM public.users WHERE auth_user_id = auth.uid() LIMIT 1;
+
+  -- Server-computed gross (before discount) from the line prices.
+  SELECT COALESCE(SUM((it->>'quantity')::int * (it->>'unit_price_kobo')::bigint), 0)
+    INTO v_gross
+    FROM jsonb_array_elements(p_items) AS it;
+
+  -- Role discount cap (defence in depth): clamp the requested discount to the
+  -- caller's role percentage of gross. A within-cap discount is unchanged.
+  v_max_pct  := public.caller_max_discount_percent(p_business_id);
+  v_cap      := (v_gross * v_max_pct) / 100;
+  v_discount := LEAST(GREATEST(COALESCE(p_discount_kobo, 0), 0), v_cap);
+  v_net      := v_gross - v_discount;
+
+  -- Cash/transfer is a fully-settled sale; underpayment is a credit sale (Slice 3).
+  IF p_amount_paid_kobo < v_net THEN
+    RAISE EXCEPTION 'amount_paid_below_net'
+      USING ERRCODE = 'P0001',
+            HINT = jsonb_build_object('net_kobo', v_net,
+                                      'amount_paid_kobo', p_amount_paid_kobo)::text;
+  END IF;
+
+  -- Server-minted order number. 'WEB-' prefix makes collision with a mobile
+  -- device-tag number ('ORD-NNNNNN-XXXXXX') impossible regardless of the rest;
+  -- the running count is human-friendly and the 6-hex tail from the (globally
+  -- unique) order id keeps it unique under (business_id, order_number) even for
+  -- two concurrent web tills that computed the same count.
+  SELECT count(*) INTO v_order_count FROM public.orders WHERE business_id = p_business_id;
+  v_order_number := 'WEB-'
+    || lpad((v_order_count + 1)::text, 6, '0')
+    || '-' || upper(right(replace(p_order_id::text, '-', ''), 6));
+
+  -- Order header — status 'pending' recognizes revenue at Checkout (matches
+  -- mobile: orderCountsAsSale includes 'pending'; completed_at stays NULL until
+  -- Confirm). amount_paid is stored as the settled net.
+  INSERT INTO public.orders (
+    id, business_id, order_number, customer_id,
+    total_amount_kobo, discount_kobo, net_amount_kobo, amount_paid_kobo,
+    payment_type, status, staff_id, store_id,
+    completed_at, cancelled_at, created_at, last_updated_at
+  )
+  VALUES (
+    p_order_id, p_business_id, v_order_number, NULL,
+    v_gross, v_discount, v_net, v_net,
+    'cash', 'pending', v_actor_id, p_store_id,
+    NULL, NULL, v_now, v_now
+  );
+
+  -- Items + inventory guard + stock ledger. buying_price_kobo starts 0 and is
+  -- overwritten by the FIFO pass below.
+  v_items_out := '[]'::jsonb;
+  FOR v_item IN SELECT * FROM jsonb_array_elements(p_items) LOOP
+    v_product_id := (v_item->>'product_id')::uuid;
+    v_qty        := (v_item->>'quantity')::int;
+    v_unit_price := (v_item->>'unit_price_kobo')::bigint;
+
+    IF v_product_id IS NULL THEN
+      RAISE EXCEPTION 'product_id_required_per_line'
+        USING ERRCODE = 'invalid_parameter_value';
+    END IF;
+    IF v_qty <= 0 THEN
+      RAISE EXCEPTION 'item_quantity_must_be_positive'
+        USING ERRCODE = 'invalid_parameter_value';
+    END IF;
+
+    v_line_total := v_qty::bigint * v_unit_price;
+    v_item_id    := gen_random_uuid();
+
+    INSERT INTO public.order_items (
+      id, business_id, order_id, product_id, store_id,
+      quantity, unit_price_kobo, buying_price_kobo, total_kobo,
+      created_at, last_updated_at
+    )
+    VALUES (
+      v_item_id, p_business_id, p_order_id, v_product_id, p_store_id,
+      v_qty, v_unit_price, 0, v_line_total,
+      v_now, v_now
+    );
+
+    -- Inventory decrement under the stock guard. The conditional UPDATE takes a
+    -- row lock and only succeeds while quantity >= qty, so two concurrent tills
+    -- cannot oversell — the loser's UPDATE finds no row and we reject at commit.
+    UPDATE public.inventory
+       SET quantity = quantity - v_qty
+     WHERE business_id = p_business_id
+       AND product_id  = v_product_id
+       AND store_id    = p_store_id
+       AND quantity   >= v_qty
+    RETURNING quantity INTO v_new_qty;
+
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'insufficient_stock'
+        USING ERRCODE = 'P0001',
+              HINT = jsonb_build_object(
+                'product_id',    v_product_id,
+                'store_id',      p_store_id,
+                'requested_qty', v_qty
+              )::text;
+    END IF;
+
+    v_inv_after := v_inv_after || jsonb_build_object(
+      'product_id',      v_product_id,
+      'store_id',        p_store_id,
+      'quantity',        v_new_qty,
+      'last_updated_at', v_now
+    );
+
+    v_stx_id := gen_random_uuid();
+    INSERT INTO public.stock_transactions (
+      id, business_id, product_id, location_id, quantity_delta, movement_type,
+      order_id, performed_by, created_at, last_updated_at
+    )
+    VALUES (
+      v_stx_id, p_business_id, v_product_id, p_store_id, -v_qty, 'sale',
+      p_order_id, v_actor_id, v_now, v_now
+    );
+
+    v_items_out := v_items_out || jsonb_build_object(
+      'item_id', v_item_id, 'product_id', v_product_id, 'quantity', v_qty);
+  END LOOP;
+
+  -- FIFO draw-down per distinct product for this (order, store). Reuses the pure
+  -- public.fifo_assign (0133) so the per-unit COGS rounding is byte-for-byte the
+  -- same as the recost pass AND the mobile provisional draw-down. Batches are
+  -- locked FOR UPDATE (oldest-first) so a concurrent checkout of the same product
+  -- serializes on the queue and cannot double-consume a batch.
+  v_products := ARRAY(
+    SELECT DISTINCT (it->>'product_id')::uuid FROM jsonb_array_elements(p_items) AS it
+  );
+
+  FOREACH v_product IN ARRAY v_products LOOP
+    -- Lock + load the live queue (qty_remaining > 0), oldest-first.
+    SELECT
+      COALESCE(jsonb_agg(jsonb_build_object('cost_kobo', cb.cost_kobo, 'qty', cb.qty_remaining)
+                         ORDER BY cb.received_at, cb.id), '[]'::jsonb),
+      COALESCE(array_agg(cb.id ORDER BY cb.received_at, cb.id), ARRAY[]::uuid[])
+    INTO v_batches, v_batch_ids
+    FROM (
+      SELECT id, cost_kobo, qty_remaining, received_at
+        FROM public.cost_batches
+       WHERE business_id = p_business_id
+         AND product_id  = v_product
+         AND store_id    = p_store_id
+         AND qty_remaining > 0
+       ORDER BY received_at, id
+       FOR UPDATE
+    ) cb;
+
+    -- This product's sale lines, in insertion order (order_items.created_at then
+    -- id — a stable order that continues one draw across repeated lines).
+    SELECT COALESCE(jsonb_agg(jsonb_build_object('line_id', oi.id, 'quantity', oi.quantity)
+                              ORDER BY oi.created_at, oi.id), '[]'::jsonb)
+      INTO v_sales
+      FROM public.order_items oi
+     WHERE oi.order_id = p_order_id
+       AND oi.product_id = v_product;
+
+    v_assigned := public.fifo_assign(v_batches, v_sales);
+    v_rem      := v_assigned->'batches_remaining';
+
+    -- Snapshot each line's per-unit COGS.
+    FOR v_line IN SELECT * FROM jsonb_array_elements(v_assigned->'lines') LOOP
+      UPDATE public.order_items
+         SET buying_price_kobo = (v_line->>'cogs_per_unit_kobo')::bigint,
+             last_updated_at   = v_now
+       WHERE id = (v_line->>'line_id')::uuid;
+    END LOOP;
+
+    -- Decrement the consumed batches (only where changed).
+    FOR v_i IN 1 .. COALESCE(array_length(v_batch_ids, 1), 0) LOOP
+      UPDATE public.cost_batches
+         SET qty_remaining = (v_rem->>(v_i - 1))::int
+       WHERE id = v_batch_ids[v_i]
+         AND qty_remaining IS DISTINCT FROM (v_rem->>(v_i - 1))::int;
+    END LOOP;
+
+    -- Re-point the product's scalar buying_price_kobo cache at the oldest
+    -- remaining COSTED batch (across stores) — mirrors CostBatchesDao._recompute
+    -- ScalarCost: skip uncosted (cost 0) batches, and leave the scalar untouched
+    -- when nothing costed remains (never clobber a user-set price to 0).
+    SELECT cb.cost_kobo INTO v_oldest_cost
+      FROM public.cost_batches cb
+     WHERE cb.business_id = p_business_id
+       AND cb.product_id  = v_product
+       AND cb.qty_remaining > 0
+       AND cb.cost_kobo > 0
+     ORDER BY cb.received_at, cb.id
+     LIMIT 1;
+    IF v_oldest_cost IS NOT NULL THEN
+      UPDATE public.products
+         SET buying_price_kobo = v_oldest_cost, last_updated_at = v_now
+       WHERE id = v_product
+         AND business_id = p_business_id
+         AND buying_price_kobo IS DISTINCT FROM v_oldest_cost;
+    END IF;
+  END LOOP;
+
+  -- One payment row for the settled amount (type 'sale').
+  v_payment_id := gen_random_uuid();
+  INSERT INTO public.payment_transactions (
+    id, business_id, amount_kobo, method, type,
+    order_id, performed_by, created_at, last_updated_at
+  )
+  VALUES (
+    v_payment_id, p_business_id, v_net, p_payment_method, 'sale',
+    p_order_id, v_actor_id, v_now, v_now
+  );
+
+  -- Compose the response for the receipt.
+  SELECT to_jsonb(o.*) INTO v_order_row FROM public.orders o WHERE o.id = p_order_id;
+  SELECT COALESCE(jsonb_agg(to_jsonb(oi.*) ORDER BY oi.created_at, oi.id), '[]'::jsonb)
+    INTO v_items_out FROM public.order_items oi WHERE oi.order_id = p_order_id;
+  SELECT to_jsonb(pt.*) INTO v_payment_row
+    FROM public.payment_transactions pt WHERE pt.id = v_payment_id;
+
+  RETURN jsonb_build_object(
+    'order',               v_order_row,
+    'order_items',         v_items_out,
+    'payment_transaction', v_payment_row,
+    'inventory_after',     v_inv_after,
+    'replayed',            false
+  );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.checkout_order(uuid, uuid, uuid, jsonb, text, bigint, bigint) FROM public;
+GRANT EXECUTE ON FUNCTION public.checkout_order(uuid, uuid, uuid, jsonb, text, bigint, bigint)
+  TO authenticated, service_role;
+
+COMMIT;
+
+-- =============================================================================
+-- Verification (paste into the SQL editor while authenticated as a business user):
+--
+--   1. Helpers + RPC exist:
+--        SELECT proname FROM pg_proc
+--         WHERE pronamespace = 'public'::regnamespace
+--           AND proname IN ('checkout_order','caller_has_permission',
+--                           'caller_max_discount_percent')
+--         ORDER BY proname;   -- expect 3 rows
+--
+--   2. Tenant guard fires for another business:
+--        SELECT public.checkout_order('<other-biz>', gen_random_uuid(),
+--          '<store>', '[]'::jsonb, 'cash', 0);
+--        -- expect ERROR: tenant_mismatch
+--
+--   3. A cash sale writes order(pending) + items + payment + FIFO draw-down, and
+--      the order number matches ^WEB-\d{6}-[0-9A-F]{6}$ (never an ORD- number).
+--
+--   4. Idempotent replay: a second call with the same p_order_id returns
+--      replayed=true and applies nothing new.
+-- =============================================================================

--- a/supabase/migrations/0136_checkout_order_credit.sql
+++ b/supabase/migrations/0136_checkout_order_credit.sql
@@ -1,0 +1,570 @@
+-- 0136_checkout_order_credit.sql
+--
+-- Reebaplus — Web POS Slice 3. Extend the server-authoritative `checkout_order`
+-- RPC (0135, ADR 0008) to handle REGISTERED-CUSTOMER CREDIT and the wallet
+-- ledger (PRD web-pos, issue #44).
+--
+-- SCOPE (Slice 3): attach a registered customer to the sale and post the
+-- append-only wallet ledger legs (§14.3, invariant #3), for the two credit
+-- paths the mobile checkout also offers:
+--   • Pay-with-Credit     (p_payment_method = 'wallet') — draw the whole order
+--                          from the customer's existing wallet balance; no cash
+--                          lands. The balance absorbs the debit.
+--   • Register-as-Credit-Sale (p_payment_method = 'credit') — the customer takes
+--                          the goods now and owes the balance; any cash tendered
+--                          part-pays it.
+-- Plus: a registered Cash/Transfer sale now also posts its wallet legs (debit
+-- the order, credit the cash) so the wallet history is complete, exactly like
+-- mobile OrdersDao.createOrder.
+--
+-- WALLET LEDGER LEGS (mirrors mobile createOrder, deposit carve-out is Slice 4):
+--   Leg 1 — debit  the order NET  (goods leave)  → reference 'order_payment'
+--   Leg 2 — credit the cash paid  (money in)     → reference 'topup_cash' /
+--           'topup_transfer'  (skipped when nothing was paid in cash)
+-- The customer balance stays the DERIVED single source of truth:
+--   balance = SUM(signed_amount_kobo) over the customer's non-deposit legs.
+-- Net position change of a sale = cash_paid − net: 0 when fully settled,
+-- negative when the customer owes.
+--
+-- DEBT LIMIT (server-side enforcement, defence in depth — the web also blocks in
+-- the UI): a sale that books NEW debt is rejected when it would push the
+-- customer's balance below −wallet_limit_kobo, mirroring the mobile checkout's
+-- `_overDebtLimit`:
+--   • a fully-settled sale (cash_paid ≥ net) never books debt → never gated,
+--     even if the customer is already in the red;
+--   • otherwise the projected balance (current + cash_paid − net) must not go
+--     below zero UNLESS a positive limit allows it AND it stays ≥ −limit.
+--   • wallet_limit_kobo = 0 means "no credit allowed" (any debt is rejected).
+--
+-- TWO IMPLEMENTATIONS, ONE CONTRACT (ADR 0009): the wallet legs + resulting
+-- balance are pinned identical to the mobile Dart path by the Golden-Scenario
+-- Suite's new credit fixtures (test/golden/*), which run the same fixtures
+-- against both this RPC and OrdersDao.createOrder.
+--
+-- OVERLOAD TRAP (see [[project_rpc_param_add_overload_trap]]): adding
+-- p_customer_id via CREATE OR REPLACE would leave the old 7-arg signature in
+-- place as a second overload → PGRST203 ambiguity for older callers. So DROP the
+-- 0135 signature first, then create the widened one.
+--
+-- DEPLOY ORDER: after 0135 (checkout_order), 0133 (fifo_assign), 0132
+-- (cost_batches). Additive server logic; inert until called by the web client.
+
+BEGIN;
+
+DROP FUNCTION IF EXISTS public.checkout_order(uuid, uuid, uuid, jsonb, text, bigint, bigint);
+
+-- ─── _customer_wallet_balance — the derived spendable balance, mirrored ──────
+--
+-- The customer's SPENDABLE wallet balance (kobo) = SUM(signed_amount_kobo) over
+-- the customer's ledger EXCLUDING the crate-deposit family (a refundable deposit
+-- is money held, never spendable credit nor debt). Byte-for-byte the mobile
+-- CustomersDao.getBalanceKobo derivation — the single source of truth for both
+-- the debt-limit check and the balance the receipt shows. Positive = credit we
+-- hold; negative = the customer owes us.
+--
+-- SECURITY DEFINER + constrained to (business_id, customer_id): no data leak
+-- beyond the caller's tenant, which _assert_caller_owns_business already gates.
+CREATE OR REPLACE FUNCTION public._customer_wallet_balance(
+  p_business_id uuid,
+  p_customer_id uuid
+)
+RETURNS bigint
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+  SELECT COALESCE(SUM(signed_amount_kobo), 0)::bigint
+    FROM public.wallet_transactions
+   WHERE business_id = p_business_id
+     AND customer_id = p_customer_id
+     AND reference_type NOT IN
+         ('crate_deposit', 'crate_deposit_refunded', 'crate_deposit_forfeited');
+$$;
+
+REVOKE ALL ON FUNCTION public._customer_wallet_balance(uuid, uuid) FROM public;
+GRANT EXECUTE ON FUNCTION public._customer_wallet_balance(uuid, uuid)
+  TO authenticated, service_role;
+
+
+-- ─── checkout_order — cash / transfer / credit / wallet, with the wallet ledger ─
+--
+-- p_items : [{ "product_id": <uuid>, "quantity": <int>, "unit_price_kobo": <bigint> }, ...]
+-- p_payment_method :
+--   'cash' | 'transfer'  — fully-settled sale (walk-in or registered).
+--   'credit'             — Register-as-Credit-Sale: cash_paid may be 0..net; the
+--                          rest is booked as debt (requires p_customer_id).
+--   'wallet'             — Pay-with-Credit: cash_paid = 0, drawn from the balance
+--                          (requires p_customer_id).
+-- p_customer_id : the registered customer (NULL = walk-in). credit/wallet require
+--                 a customer; a walk-in can only pay cash/transfer in full.
+--
+-- Idempotent on p_order_id (client-minted UUIDv7): a replay returns the existing
+-- order + items + payment + wallet legs + balance without re-applying anything.
+CREATE OR REPLACE FUNCTION public.checkout_order(
+  p_business_id      uuid,
+  p_order_id         uuid,          -- idempotency key (client UUIDv7)
+  p_store_id         uuid,
+  p_items            jsonb,
+  p_payment_method   text,          -- 'cash' | 'transfer' | 'credit' | 'wallet'
+  p_amount_paid_kobo bigint,
+  p_discount_kobo    bigint DEFAULT 0,
+  p_customer_id      uuid   DEFAULT NULL   -- registered customer (credit/wallet)
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+DECLARE
+  v_now          timestamptz := now();
+  v_actor_id     uuid;
+  v_existing     boolean;
+  v_registered   boolean := p_customer_id IS NOT NULL;
+  v_gross        bigint;
+  v_max_pct      int;
+  v_cap          bigint;
+  v_discount     bigint;
+  v_net          bigint;
+  v_cash_paid    bigint;
+  v_wallet_id    uuid;
+  v_balance      bigint;
+  v_projected    bigint;
+  v_limit        bigint;
+  v_credit_ref   text;
+  v_order_count  bigint;
+  v_order_number text;
+  v_item         jsonb;
+  v_item_id      uuid;
+  v_product_id   uuid;
+  v_qty          int;
+  v_unit_price   bigint;
+  v_line_total   bigint;
+  v_new_qty      int;
+  v_stx_id       uuid;
+  v_payment_id   uuid;
+  v_wtx_id       uuid;
+  v_product      uuid;
+  v_batches      jsonb;
+  v_batch_ids    uuid[];
+  v_sales        jsonb;
+  v_assigned     jsonb;
+  v_rem          jsonb;
+  v_line         jsonb;
+  v_i            int;
+  v_products     uuid[];
+  v_oldest_cost  bigint;
+  v_order_row    jsonb;
+  v_items_out    jsonb;
+  v_payment_row  jsonb;
+  v_wallet_rows  jsonb;
+  v_inv_after    jsonb := '[]'::jsonb;
+BEGIN
+  PERFORM public._assert_caller_owns_business(p_business_id);
+
+  -- Server-side permission enforcement (defence in depth; the web also hides).
+  IF NOT public.caller_has_permission(p_business_id, 'sales.make') THEN
+    RAISE EXCEPTION 'permission_denied: sales.make'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  IF p_order_id IS NULL THEN
+    RAISE EXCEPTION 'order_id_required' USING ERRCODE = 'invalid_parameter_value';
+  END IF;
+  IF p_store_id IS NULL THEN
+    RAISE EXCEPTION 'store_id_required' USING ERRCODE = 'invalid_parameter_value';
+  END IF;
+  IF jsonb_typeof(p_items) <> 'array' OR jsonb_array_length(p_items) = 0 THEN
+    RAISE EXCEPTION 'items_required' USING ERRCODE = 'invalid_parameter_value';
+  END IF;
+  IF p_payment_method IS NULL
+     OR p_payment_method NOT IN ('cash', 'transfer', 'credit', 'wallet') THEN
+    RAISE EXCEPTION 'payment_method_must_be_cash_transfer_credit_or_wallet'
+      USING ERRCODE = 'invalid_parameter_value';
+  END IF;
+  -- The credit paths need a wallet to post to; a walk-in has none (rule #14).
+  IF NOT v_registered AND p_payment_method IN ('credit', 'wallet') THEN
+    RAISE EXCEPTION 'credit_requires_customer'
+      USING ERRCODE = 'invalid_parameter_value';
+  END IF;
+
+  -- Idempotent replay: the order already exists → return its current state.
+  SELECT true INTO v_existing FROM public.orders WHERE id = p_order_id;
+  IF v_existing THEN
+    SELECT to_jsonb(o.*) INTO v_order_row FROM public.orders o WHERE o.id = p_order_id;
+    SELECT COALESCE(jsonb_agg(to_jsonb(oi.*) ORDER BY oi.created_at, oi.id), '[]'::jsonb)
+      INTO v_items_out FROM public.order_items oi WHERE oi.order_id = p_order_id;
+    SELECT to_jsonb(pt.*) INTO v_payment_row
+      FROM public.payment_transactions pt
+      WHERE pt.order_id = p_order_id AND pt.type = 'sale'
+      ORDER BY pt.created_at LIMIT 1;
+    SELECT COALESCE(jsonb_agg(to_jsonb(wt.*) ORDER BY wt.created_at, wt.id), '[]'::jsonb)
+      INTO v_wallet_rows FROM public.wallet_transactions wt WHERE wt.order_id = p_order_id;
+    RETURN jsonb_build_object(
+      'order',               v_order_row,
+      'order_items',         v_items_out,
+      'payment_transaction', v_payment_row,
+      'wallet_transactions', v_wallet_rows,
+      'customer_balance_kobo',
+        CASE WHEN v_registered
+             THEN public._customer_wallet_balance(p_business_id, p_customer_id)
+             ELSE NULL END,
+      'inventory_after',     '[]'::jsonb,
+      'replayed',            true
+    );
+  END IF;
+
+  -- Attribute the sale to the caller (staff_id). NULL is tolerated (attribution
+  -- only) — the sale still commits.
+  SELECT id INTO v_actor_id FROM public.users WHERE auth_user_id = auth.uid() LIMIT 1;
+
+  -- Server-computed gross (before discount) from the line prices.
+  SELECT COALESCE(SUM((it->>'quantity')::int * (it->>'unit_price_kobo')::bigint), 0)
+    INTO v_gross
+    FROM jsonb_array_elements(p_items) AS it;
+
+  -- Role discount cap (defence in depth): clamp the requested discount to the
+  -- caller's role percentage of gross. A within-cap discount is unchanged.
+  v_max_pct  := public.caller_max_discount_percent(p_business_id);
+  v_cap      := (v_gross * v_max_pct) / 100;
+  v_discount := LEAST(GREATEST(COALESCE(p_discount_kobo, 0), 0), v_cap);
+  v_net      := v_gross - v_discount;
+
+  -- The cash actually settled at checkout, by path:
+  --   cash/transfer → fully settled at net (any over-tender is change, not stored)
+  --   credit        → the tendered amount, clamped to [0, net]; the rest is debt
+  --   wallet        → 0 (drawn from the existing balance)
+  v_cash_paid := CASE p_payment_method
+    WHEN 'wallet' THEN 0
+    WHEN 'credit' THEN LEAST(GREATEST(COALESCE(p_amount_paid_kobo, 0), 0), v_net)
+    ELSE v_net
+  END;
+
+  -- A fully-settled cash/transfer sale must actually cover the net (a walk-in
+  -- has nowhere to book a shortfall; a registered under-payment goes via 'credit').
+  IF p_payment_method IN ('cash', 'transfer') AND p_amount_paid_kobo < v_net THEN
+    RAISE EXCEPTION 'amount_paid_below_net'
+      USING ERRCODE = 'P0001',
+            HINT = jsonb_build_object('net_kobo', v_net,
+                                      'amount_paid_kobo', p_amount_paid_kobo)::text;
+  END IF;
+
+  -- Registered sale: resolve the wallet + enforce the debt limit BEFORE any write.
+  IF v_registered THEN
+    SELECT id INTO v_wallet_id
+      FROM public.customer_wallets
+     WHERE business_id = p_business_id
+       AND customer_id = p_customer_id
+       AND is_deleted = false
+     LIMIT 1;
+    IF v_wallet_id IS NULL THEN
+      RAISE EXCEPTION 'customer_wallet_missing'
+        USING ERRCODE = 'P0001',
+              HINT = jsonb_build_object('customer_id', p_customer_id)::text;
+    END IF;
+
+    -- Only a sale that books NEW debt is subject to the limit; a fully-settled
+    -- sale never adds debt so it is never gated (matches mobile _overDebtLimit).
+    IF v_cash_paid < v_net THEN
+      v_balance   := public._customer_wallet_balance(p_business_id, p_customer_id);
+      v_projected := v_balance + v_cash_paid - v_net;
+      IF v_projected < 0 THEN
+        SELECT wallet_limit_kobo INTO v_limit
+          FROM public.customers
+         WHERE id = p_customer_id AND business_id = p_business_id;
+        IF COALESCE(v_limit, 0) <= 0 OR v_projected < -v_limit THEN
+          RAISE EXCEPTION 'debt_limit_exceeded'
+            USING ERRCODE = 'P0001',
+                  HINT = jsonb_build_object(
+                    'customer_id',    p_customer_id,
+                    'limit_kobo',     COALESCE(v_limit, 0),
+                    'projected_kobo', v_projected
+                  )::text;
+        END IF;
+      END IF;
+    END IF;
+  END IF;
+
+  -- Server-minted order number. 'WEB-' prefix makes collision with a mobile
+  -- device-tag number ('ORD-NNNNNN-XXXXXX') impossible regardless of the rest;
+  -- the running count is human-friendly and the 6-hex tail from the (globally
+  -- unique) order id keeps it unique under (business_id, order_number) even for
+  -- two concurrent web tills that computed the same count.
+  SELECT count(*) INTO v_order_count FROM public.orders WHERE business_id = p_business_id;
+  v_order_number := 'WEB-'
+    || lpad((v_order_count + 1)::text, 6, '0')
+    || '-' || upper(right(replace(p_order_id::text, '-', ''), 6));
+
+  -- Order header — status 'pending' recognizes revenue at Checkout (matches
+  -- mobile: orderCountsAsSale includes 'pending'; completed_at stays NULL until
+  -- Confirm). amount_paid is the CASH actually settled (0 on a pay-with-credit).
+  INSERT INTO public.orders (
+    id, business_id, order_number, customer_id,
+    total_amount_kobo, discount_kobo, net_amount_kobo, amount_paid_kobo,
+    payment_type, status, staff_id, store_id,
+    completed_at, cancelled_at, created_at, last_updated_at
+  )
+  VALUES (
+    p_order_id, p_business_id, v_order_number, p_customer_id,
+    v_gross, v_discount, v_net, v_cash_paid,
+    'cash', 'pending', v_actor_id, p_store_id,
+    NULL, NULL, v_now, v_now
+  );
+
+  -- Items + inventory guard + stock ledger. buying_price_kobo starts 0 and is
+  -- overwritten by the FIFO pass below.
+  v_items_out := '[]'::jsonb;
+  FOR v_item IN SELECT * FROM jsonb_array_elements(p_items) LOOP
+    v_product_id := (v_item->>'product_id')::uuid;
+    v_qty        := (v_item->>'quantity')::int;
+    v_unit_price := (v_item->>'unit_price_kobo')::bigint;
+
+    IF v_product_id IS NULL THEN
+      RAISE EXCEPTION 'product_id_required_per_line'
+        USING ERRCODE = 'invalid_parameter_value';
+    END IF;
+    IF v_qty <= 0 THEN
+      RAISE EXCEPTION 'item_quantity_must_be_positive'
+        USING ERRCODE = 'invalid_parameter_value';
+    END IF;
+
+    v_line_total := v_qty::bigint * v_unit_price;
+    v_item_id    := gen_random_uuid();
+
+    INSERT INTO public.order_items (
+      id, business_id, order_id, product_id, store_id,
+      quantity, unit_price_kobo, buying_price_kobo, total_kobo,
+      created_at, last_updated_at
+    )
+    VALUES (
+      v_item_id, p_business_id, p_order_id, v_product_id, p_store_id,
+      v_qty, v_unit_price, 0, v_line_total,
+      v_now, v_now
+    );
+
+    -- Inventory decrement under the stock guard. The conditional UPDATE takes a
+    -- row lock and only succeeds while quantity >= qty, so two concurrent tills
+    -- cannot oversell — the loser's UPDATE finds no row and we reject at commit.
+    UPDATE public.inventory
+       SET quantity = quantity - v_qty
+     WHERE business_id = p_business_id
+       AND product_id  = v_product_id
+       AND store_id    = p_store_id
+       AND quantity   >= v_qty
+    RETURNING quantity INTO v_new_qty;
+
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'insufficient_stock'
+        USING ERRCODE = 'P0001',
+              HINT = jsonb_build_object(
+                'product_id',    v_product_id,
+                'store_id',      p_store_id,
+                'requested_qty', v_qty
+              )::text;
+    END IF;
+
+    v_inv_after := v_inv_after || jsonb_build_object(
+      'product_id',      v_product_id,
+      'store_id',        p_store_id,
+      'quantity',        v_new_qty,
+      'last_updated_at', v_now
+    );
+
+    v_stx_id := gen_random_uuid();
+    INSERT INTO public.stock_transactions (
+      id, business_id, product_id, location_id, quantity_delta, movement_type,
+      order_id, performed_by, created_at, last_updated_at
+    )
+    VALUES (
+      v_stx_id, p_business_id, v_product_id, p_store_id, -v_qty, 'sale',
+      p_order_id, v_actor_id, v_now, v_now
+    );
+
+    v_items_out := v_items_out || jsonb_build_object(
+      'item_id', v_item_id, 'product_id', v_product_id, 'quantity', v_qty);
+  END LOOP;
+
+  -- FIFO draw-down per distinct product for this (order, store). Reuses the pure
+  -- public.fifo_assign (0133) so the per-unit COGS rounding is byte-for-byte the
+  -- same as the recost pass AND the mobile provisional draw-down. Batches are
+  -- locked FOR UPDATE (oldest-first) so a concurrent checkout of the same product
+  -- serializes on the queue and cannot double-consume a batch.
+  v_products := ARRAY(
+    SELECT DISTINCT (it->>'product_id')::uuid FROM jsonb_array_elements(p_items) AS it
+  );
+
+  FOREACH v_product IN ARRAY v_products LOOP
+    -- Lock + load the live queue (qty_remaining > 0), oldest-first.
+    SELECT
+      COALESCE(jsonb_agg(jsonb_build_object('cost_kobo', cb.cost_kobo, 'qty', cb.qty_remaining)
+                         ORDER BY cb.received_at, cb.id), '[]'::jsonb),
+      COALESCE(array_agg(cb.id ORDER BY cb.received_at, cb.id), ARRAY[]::uuid[])
+    INTO v_batches, v_batch_ids
+    FROM (
+      SELECT id, cost_kobo, qty_remaining, received_at
+        FROM public.cost_batches
+       WHERE business_id = p_business_id
+         AND product_id  = v_product
+         AND store_id    = p_store_id
+         AND qty_remaining > 0
+       ORDER BY received_at, id
+       FOR UPDATE
+    ) cb;
+
+    -- This product's sale lines, in insertion order (order_items.created_at then
+    -- id — a stable order that continues one draw across repeated lines).
+    SELECT COALESCE(jsonb_agg(jsonb_build_object('line_id', oi.id, 'quantity', oi.quantity)
+                              ORDER BY oi.created_at, oi.id), '[]'::jsonb)
+      INTO v_sales
+      FROM public.order_items oi
+     WHERE oi.order_id = p_order_id
+       AND oi.product_id = v_product;
+
+    v_assigned := public.fifo_assign(v_batches, v_sales);
+    v_rem      := v_assigned->'batches_remaining';
+
+    -- Snapshot each line's per-unit COGS.
+    FOR v_line IN SELECT * FROM jsonb_array_elements(v_assigned->'lines') LOOP
+      UPDATE public.order_items
+         SET buying_price_kobo = (v_line->>'cogs_per_unit_kobo')::bigint,
+             last_updated_at   = v_now
+       WHERE id = (v_line->>'line_id')::uuid;
+    END LOOP;
+
+    -- Decrement the consumed batches (only where changed).
+    FOR v_i IN 1 .. COALESCE(array_length(v_batch_ids, 1), 0) LOOP
+      UPDATE public.cost_batches
+         SET qty_remaining = (v_rem->>(v_i - 1))::int
+       WHERE id = v_batch_ids[v_i]
+         AND qty_remaining IS DISTINCT FROM (v_rem->>(v_i - 1))::int;
+    END LOOP;
+
+    -- Re-point the product's scalar buying_price_kobo cache at the oldest
+    -- remaining COSTED batch (across stores) — mirrors CostBatchesDao._recompute
+    -- ScalarCost: skip uncosted (cost 0) batches, and leave the scalar untouched
+    -- when nothing costed remains (never clobber a user-set price to 0).
+    SELECT cb.cost_kobo INTO v_oldest_cost
+      FROM public.cost_batches cb
+     WHERE cb.business_id = p_business_id
+       AND cb.product_id  = v_product
+       AND cb.qty_remaining > 0
+       AND cb.cost_kobo > 0
+     ORDER BY cb.received_at, cb.id
+     LIMIT 1;
+    IF v_oldest_cost IS NOT NULL THEN
+      UPDATE public.products
+         SET buying_price_kobo = v_oldest_cost, last_updated_at = v_now
+       WHERE id = v_product
+         AND business_id = p_business_id
+         AND buying_price_kobo IS DISTINCT FROM v_oldest_cost;
+    END IF;
+  END LOOP;
+
+  -- One payment row for the cash actually settled (type 'sale'). Skipped when
+  -- nothing was paid in cash (pure credit sale or pay-with-credit).
+  IF v_cash_paid > 0 THEN
+    v_payment_id := gen_random_uuid();
+    INSERT INTO public.payment_transactions (
+      id, business_id, amount_kobo, method, type,
+      order_id, performed_by, created_at, last_updated_at
+    )
+    VALUES (
+      v_payment_id, p_business_id, v_cash_paid,
+      CASE WHEN p_payment_method = 'transfer' THEN 'transfer' ELSE 'cash' END,
+      'sale', p_order_id, v_actor_id, v_now, v_now
+    );
+  END IF;
+
+  -- §14.3 wallet ledger (invariant #3, registered customers only). Two
+  -- append-only legs, same event so same created_at: debit the order NET (goods
+  -- leave) and credit the cash paid (money in). The net (cash − net) is the
+  -- customer's position. Mirrors mobile OrdersDao.createOrder; the deposit
+  -- carve-out (Leg 3) arrives with crate checkout in Slice 4.
+  IF v_registered THEN
+    -- Leg 1 — debit the order net.
+    v_wtx_id := gen_random_uuid();
+    INSERT INTO public.wallet_transactions (
+      id, business_id, wallet_id, customer_id, type,
+      amount_kobo, signed_amount_kobo, reference_type, order_id,
+      performed_by, customer_verified, created_at, last_updated_at
+    )
+    VALUES (
+      v_wtx_id, p_business_id, v_wallet_id, p_customer_id, 'debit',
+      v_net, -v_net, 'order_payment', p_order_id,
+      v_actor_id, false, v_now, v_now
+    );
+
+    -- Leg 2 — credit the cash applied (money into the wallet). Skipped for a
+    -- pay-with-credit / pure credit sale (nothing paid in cash).
+    IF v_cash_paid > 0 THEN
+      v_credit_ref := CASE WHEN p_payment_method = 'transfer'
+                           THEN 'topup_transfer' ELSE 'topup_cash' END;
+      v_wtx_id := gen_random_uuid();
+      INSERT INTO public.wallet_transactions (
+        id, business_id, wallet_id, customer_id, type,
+        amount_kobo, signed_amount_kobo, reference_type, order_id,
+        performed_by, customer_verified, created_at, last_updated_at
+      )
+      VALUES (
+        v_wtx_id, p_business_id, v_wallet_id, p_customer_id, 'credit',
+        v_cash_paid, v_cash_paid, v_credit_ref, p_order_id,
+        v_actor_id, false, v_now, v_now
+      );
+    END IF;
+  END IF;
+
+  -- Compose the response for the receipt.
+  SELECT to_jsonb(o.*) INTO v_order_row FROM public.orders o WHERE o.id = p_order_id;
+  SELECT COALESCE(jsonb_agg(to_jsonb(oi.*) ORDER BY oi.created_at, oi.id), '[]'::jsonb)
+    INTO v_items_out FROM public.order_items oi WHERE oi.order_id = p_order_id;
+  SELECT to_jsonb(pt.*) INTO v_payment_row
+    FROM public.payment_transactions pt
+    WHERE pt.order_id = p_order_id AND pt.type = 'sale'
+    ORDER BY pt.created_at LIMIT 1;
+  SELECT COALESCE(jsonb_agg(to_jsonb(wt.*) ORDER BY wt.created_at, wt.id), '[]'::jsonb)
+    INTO v_wallet_rows FROM public.wallet_transactions wt WHERE wt.order_id = p_order_id;
+
+  RETURN jsonb_build_object(
+    'order',               v_order_row,
+    'order_items',         v_items_out,
+    'payment_transaction', v_payment_row,
+    'wallet_transactions', v_wallet_rows,
+    'customer_balance_kobo',
+      CASE WHEN v_registered
+           THEN public._customer_wallet_balance(p_business_id, p_customer_id)
+           ELSE NULL END,
+    'inventory_after',     v_inv_after,
+    'replayed',            false
+  );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.checkout_order(uuid, uuid, uuid, jsonb, text, bigint, bigint, uuid) FROM public;
+GRANT EXECUTE ON FUNCTION public.checkout_order(uuid, uuid, uuid, jsonb, text, bigint, bigint, uuid)
+  TO authenticated, service_role;
+
+COMMIT;
+
+-- =============================================================================
+-- Verification (paste into the SQL editor while authenticated as a business user):
+--
+--   1. The 7-arg overload is gone; only the 8-arg version remains:
+--        SELECT pg_get_function_identity_arguments(oid)
+--          FROM pg_proc
+--         WHERE pronamespace = 'public'::regnamespace AND proname = 'checkout_order';
+--        -- expect ONE row ending in ", p_customer_id uuid"
+--
+--   2. Register-as-Credit-Sale (no cash) posts one 'order_payment' debit, no
+--      credit leg, and the derived balance drops by net:
+--        SELECT public.checkout_order('<biz>', gen_random_uuid(), '<store>',
+--          '[{"product_id":"<p>","quantity":1,"unit_price_kobo":100000}]'::jsonb,
+--          'credit', 0, 0, '<customer>');
+--        -- then SUM(signed_amount_kobo) for that customer = old − 100000.
+--
+--   3. A sale past the debt limit is rejected:
+--        -- with wallet_limit_kobo below the projected debt →
+--        -- ERROR: debt_limit_exceeded
+--
+--   4. Pay-with-Credit ('wallet') draws from an existing balance; the credit
+--      customer's balance drops by net, no cash payment_transactions row.
+-- =============================================================================

--- a/supabase/migrations/0137_checkout_order_crate.sql
+++ b/supabase/migrations/0137_checkout_order_crate.sql
@@ -1,0 +1,634 @@
+-- 0137_checkout_order_crate.sql
+--
+-- Reebaplus — Web POS Slice 4. Extend the server-authoritative `checkout_order`
+-- RPC (0135 → widened by 0136) to post EMPTY-CRATE ledger movements for
+-- crate-eligible businesses (PRD web-pos, ADR 0008, issue #45).
+--
+-- SCOPE (Slice 4): the empties-tracking ("crate-track") path. For a REGISTERED
+-- customer at a crate-eligible business that opts into empty-crate tracking, a
+-- sale of deposit-bearing product now records, per manufacturer:
+--   • one order_crate_lines row  — crates taken + the deposit RATE snapshot
+--     (from manufacturers.deposit_amount_kobo, frozen at sale time so a later
+--     CEO rate edit never rewrites historic settlements) + deposit PAID (0 on
+--     the crate-track path — no cash deposit is collected at web checkout);
+--   • one 'issued' crate_ledger row (+crates) and a customer_crate_balances
+--     increment — so the existing return path can net the balance back to zero
+--     (the fix for "returned everything but still shows owing").
+--
+-- COMBINED CRATE GATE (mirrors mobile isCrateBusiness(type) AND
+-- businesses.tracks_empty_crates, §13.4 / rule #13): the whole block is a no-op
+-- unless the business type is Bar / Beer|Beverage distributor AND
+-- tracks_empty_crates is on — even a legacy bottle+track_empties product at a
+-- non-crate business accrues NO crate rows. Crate eligibility per line mirrors
+-- the mobile basis exactly: unit ILIKE 'bottle' AND track_empties AND a
+-- manufacturer. Walk-ins (no customer) hold no crate balance (rule #14).
+--
+-- NO DOUBLE-COUNT (issue AC): the crate legs are wholly separate from the drink
+-- cost/stock legs — they never touch inventory, cost_batches, order_items COGS,
+-- payment_transactions, or the wallet. A crate is an EMPTY the customer owes
+-- back; the drink it held is already priced/stocked/costed by the sale legs.
+--
+-- TWO IMPLEMENTATIONS, ONE CONTRACT (ADR 0009): this crate posting is the SQL
+-- twin of mobile OrdersDao.createOrder's §13.4 crate dispatch (crate-track
+-- branch: depositPaid == 0 → order_crate_lines + recordCrateIssueByCustomer).
+-- The Golden-Scenario Suite's new crate fixtures (test/golden/crate_sale_
+-- scenarios.json) run the SAME fixtures against both this RPC and the Dart DAO;
+-- any drift on the crate rows fails the build.
+--
+-- MONEY-TRACK DEPOSIT CARVE-OUT (paid-in-cash deposit → held 'crate_deposit'
+-- wallet leg, mobile createOrder Ring 6) is deliberately out of Slice 4's scope:
+-- the web collects no deposit money at checkout (no deposit-collection UI, and
+-- the customer-attach UI is Slice 3 / #44), so every web crate sale is
+-- crate-track. When a deposit-collection surface arrives it extends this RPC.
+--
+-- SIGNATURE UNCHANGED: this is a plain CREATE OR REPLACE of the 8-arg 0136
+-- function (same argument list) with the crate block added — no new parameter,
+-- so no overload and no drop is needed (see [[project_rpc_param_add_overload_trap]]).
+--
+-- DEPLOY ORDER: after 0136 (checkout_order + p_customer_id), 0133 (fifo_assign),
+-- 0132 (cost_batches). Additive server logic; inert until called by the web
+-- client with a registered customer at a crate-eligible business.
+
+BEGIN;
+
+-- ─── _is_crate_business — the crate-feature gate, mirrored ───────────────────
+--
+-- Byte-for-byte the mobile isCrateBusiness(type) (lib/core/data/business_types.dart):
+-- case-insensitive + trimmed, Bar / Beer distributor / Beverage distributor only.
+-- Normalising here keeps the gate correct for tenants onboarded by older builds
+-- that stored non-canonical casings (e.g. 'Beer Distributor'). NULL type → false.
+CREATE OR REPLACE FUNCTION public._is_crate_business(p_type text)
+RETURNS boolean
+LANGUAGE sql
+IMMUTABLE
+AS $$
+  SELECT COALESCE(lower(btrim(p_type)) IN
+                    ('bar', 'beer distributor', 'beverage distributor'), false);
+$$;
+
+REVOKE ALL ON FUNCTION public._is_crate_business(text) FROM public;
+GRANT EXECUTE ON FUNCTION public._is_crate_business(text)
+  TO authenticated, service_role;
+
+
+-- ─── checkout_order — cash / transfer / credit / wallet + wallet ledger + crate ─
+--
+-- p_items : [{ "product_id": <uuid>, "quantity": <int>, "unit_price_kobo": <bigint> }, ...]
+-- p_payment_method :
+--   'cash' | 'transfer'  — fully-settled sale (walk-in or registered).
+--   'credit'             — Register-as-Credit-Sale: cash_paid may be 0..net; the
+--                          rest is booked as debt (requires p_customer_id).
+--   'wallet'             — Pay-with-Credit: cash_paid = 0, drawn from the balance
+--                          (requires p_customer_id).
+-- p_customer_id : the registered customer (NULL = walk-in). credit/wallet require
+--                 a customer; a walk-in can only pay cash/transfer in full. A
+--                 registered sale at a crate-eligible business also posts the
+--                 empties (crate) legs for deposit-bearing product.
+--
+-- Idempotent on p_order_id (client-minted UUIDv7): a replay returns the existing
+-- order + items + payment + wallet legs + balance without re-applying anything.
+CREATE OR REPLACE FUNCTION public.checkout_order(
+  p_business_id      uuid,
+  p_order_id         uuid,          -- idempotency key (client UUIDv7)
+  p_store_id         uuid,
+  p_items            jsonb,
+  p_payment_method   text,          -- 'cash' | 'transfer' | 'credit' | 'wallet'
+  p_amount_paid_kobo bigint,
+  p_discount_kobo    bigint DEFAULT 0,
+  p_customer_id      uuid   DEFAULT NULL   -- registered customer (credit/wallet/crate)
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+DECLARE
+  v_now          timestamptz := now();
+  v_actor_id     uuid;
+  v_existing     boolean;
+  v_registered   boolean := p_customer_id IS NOT NULL;
+  v_gross        bigint;
+  v_max_pct      int;
+  v_cap          bigint;
+  v_discount     bigint;
+  v_net          bigint;
+  v_cash_paid    bigint;
+  v_wallet_id    uuid;
+  v_balance      bigint;
+  v_projected    bigint;
+  v_limit        bigint;
+  v_credit_ref   text;
+  v_order_count  bigint;
+  v_order_number text;
+  v_item         jsonb;
+  v_item_id      uuid;
+  v_product_id   uuid;
+  v_qty          int;
+  v_unit_price   bigint;
+  v_line_total   bigint;
+  v_new_qty      int;
+  v_stx_id       uuid;
+  v_payment_id   uuid;
+  v_wtx_id       uuid;
+  v_product      uuid;
+  v_batches      jsonb;
+  v_batch_ids    uuid[];
+  v_sales        jsonb;
+  v_assigned     jsonb;
+  v_rem          jsonb;
+  v_line         jsonb;
+  v_i            int;
+  v_products     uuid[];
+  v_oldest_cost  bigint;
+  -- crate (§13.4) locals
+  v_biz_type     text;
+  v_tracks       boolean;
+  v_crate        record;
+  v_rate         bigint;
+  v_crl_id       uuid;
+  v_order_row    jsonb;
+  v_items_out    jsonb;
+  v_payment_row  jsonb;
+  v_wallet_rows  jsonb;
+  v_inv_after    jsonb := '[]'::jsonb;
+BEGIN
+  PERFORM public._assert_caller_owns_business(p_business_id);
+
+  -- Server-side permission enforcement (defence in depth; the web also hides).
+  IF NOT public.caller_has_permission(p_business_id, 'sales.make') THEN
+    RAISE EXCEPTION 'permission_denied: sales.make'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  IF p_order_id IS NULL THEN
+    RAISE EXCEPTION 'order_id_required' USING ERRCODE = 'invalid_parameter_value';
+  END IF;
+  IF p_store_id IS NULL THEN
+    RAISE EXCEPTION 'store_id_required' USING ERRCODE = 'invalid_parameter_value';
+  END IF;
+  IF jsonb_typeof(p_items) <> 'array' OR jsonb_array_length(p_items) = 0 THEN
+    RAISE EXCEPTION 'items_required' USING ERRCODE = 'invalid_parameter_value';
+  END IF;
+  IF p_payment_method IS NULL
+     OR p_payment_method NOT IN ('cash', 'transfer', 'credit', 'wallet') THEN
+    RAISE EXCEPTION 'payment_method_must_be_cash_transfer_credit_or_wallet'
+      USING ERRCODE = 'invalid_parameter_value';
+  END IF;
+  -- The credit paths need a wallet to post to; a walk-in has none (rule #14).
+  IF NOT v_registered AND p_payment_method IN ('credit', 'wallet') THEN
+    RAISE EXCEPTION 'credit_requires_customer'
+      USING ERRCODE = 'invalid_parameter_value';
+  END IF;
+
+  -- Idempotent replay: the order already exists → return its current state.
+  SELECT true INTO v_existing FROM public.orders WHERE id = p_order_id;
+  IF v_existing THEN
+    SELECT to_jsonb(o.*) INTO v_order_row FROM public.orders o WHERE o.id = p_order_id;
+    SELECT COALESCE(jsonb_agg(to_jsonb(oi.*) ORDER BY oi.created_at, oi.id), '[]'::jsonb)
+      INTO v_items_out FROM public.order_items oi WHERE oi.order_id = p_order_id;
+    SELECT to_jsonb(pt.*) INTO v_payment_row
+      FROM public.payment_transactions pt
+      WHERE pt.order_id = p_order_id AND pt.type = 'sale'
+      ORDER BY pt.created_at LIMIT 1;
+    SELECT COALESCE(jsonb_agg(to_jsonb(wt.*) ORDER BY wt.created_at, wt.id), '[]'::jsonb)
+      INTO v_wallet_rows FROM public.wallet_transactions wt WHERE wt.order_id = p_order_id;
+    RETURN jsonb_build_object(
+      'order',               v_order_row,
+      'order_items',         v_items_out,
+      'payment_transaction', v_payment_row,
+      'wallet_transactions', v_wallet_rows,
+      'customer_balance_kobo',
+        CASE WHEN v_registered
+             THEN public._customer_wallet_balance(p_business_id, p_customer_id)
+             ELSE NULL END,
+      'inventory_after',     '[]'::jsonb,
+      'replayed',            true
+    );
+  END IF;
+
+  -- Attribute the sale to the caller (staff_id). NULL is tolerated (attribution
+  -- only) — the sale still commits.
+  SELECT id INTO v_actor_id FROM public.users WHERE auth_user_id = auth.uid() LIMIT 1;
+
+  -- Server-computed gross (before discount) from the line prices.
+  SELECT COALESCE(SUM((it->>'quantity')::int * (it->>'unit_price_kobo')::bigint), 0)
+    INTO v_gross
+    FROM jsonb_array_elements(p_items) AS it;
+
+  -- Role discount cap (defence in depth): clamp the requested discount to the
+  -- caller's role percentage of gross. A within-cap discount is unchanged.
+  v_max_pct  := public.caller_max_discount_percent(p_business_id);
+  v_cap      := (v_gross * v_max_pct) / 100;
+  v_discount := LEAST(GREATEST(COALESCE(p_discount_kobo, 0), 0), v_cap);
+  v_net      := v_gross - v_discount;
+
+  -- The cash actually settled at checkout, by path:
+  --   cash/transfer → fully settled at net (any over-tender is change, not stored)
+  --   credit        → the tendered amount, clamped to [0, net]; the rest is debt
+  --   wallet        → 0 (drawn from the existing balance)
+  v_cash_paid := CASE p_payment_method
+    WHEN 'wallet' THEN 0
+    WHEN 'credit' THEN LEAST(GREATEST(COALESCE(p_amount_paid_kobo, 0), 0), v_net)
+    ELSE v_net
+  END;
+
+  -- A fully-settled cash/transfer sale must actually cover the net (a walk-in
+  -- has nowhere to book a shortfall; a registered under-payment goes via 'credit').
+  IF p_payment_method IN ('cash', 'transfer') AND p_amount_paid_kobo < v_net THEN
+    RAISE EXCEPTION 'amount_paid_below_net'
+      USING ERRCODE = 'P0001',
+            HINT = jsonb_build_object('net_kobo', v_net,
+                                      'amount_paid_kobo', p_amount_paid_kobo)::text;
+  END IF;
+
+  -- Registered sale: resolve the wallet + enforce the debt limit BEFORE any write.
+  IF v_registered THEN
+    SELECT id INTO v_wallet_id
+      FROM public.customer_wallets
+     WHERE business_id = p_business_id
+       AND customer_id = p_customer_id
+       AND is_deleted = false
+     LIMIT 1;
+    IF v_wallet_id IS NULL THEN
+      RAISE EXCEPTION 'customer_wallet_missing'
+        USING ERRCODE = 'P0001',
+              HINT = jsonb_build_object('customer_id', p_customer_id)::text;
+    END IF;
+
+    -- Only a sale that books NEW debt is subject to the limit; a fully-settled
+    -- sale never adds debt so it is never gated (matches mobile _overDebtLimit).
+    IF v_cash_paid < v_net THEN
+      v_balance   := public._customer_wallet_balance(p_business_id, p_customer_id);
+      v_projected := v_balance + v_cash_paid - v_net;
+      IF v_projected < 0 THEN
+        SELECT wallet_limit_kobo INTO v_limit
+          FROM public.customers
+         WHERE id = p_customer_id AND business_id = p_business_id;
+        IF COALESCE(v_limit, 0) <= 0 OR v_projected < -v_limit THEN
+          RAISE EXCEPTION 'debt_limit_exceeded'
+            USING ERRCODE = 'P0001',
+                  HINT = jsonb_build_object(
+                    'customer_id',    p_customer_id,
+                    'limit_kobo',     COALESCE(v_limit, 0),
+                    'projected_kobo', v_projected
+                  )::text;
+        END IF;
+      END IF;
+    END IF;
+  END IF;
+
+  -- Server-minted order number. 'WEB-' prefix makes collision with a mobile
+  -- device-tag number ('ORD-NNNNNN-XXXXXX') impossible regardless of the rest;
+  -- the running count is human-friendly and the 6-hex tail from the (globally
+  -- unique) order id keeps it unique under (business_id, order_number) even for
+  -- two concurrent web tills that computed the same count.
+  SELECT count(*) INTO v_order_count FROM public.orders WHERE business_id = p_business_id;
+  v_order_number := 'WEB-'
+    || lpad((v_order_count + 1)::text, 6, '0')
+    || '-' || upper(right(replace(p_order_id::text, '-', ''), 6));
+
+  -- Order header — status 'pending' recognizes revenue at Checkout (matches
+  -- mobile: orderCountsAsSale includes 'pending'; completed_at stays NULL until
+  -- Confirm). amount_paid is the CASH actually settled (0 on a pay-with-credit).
+  INSERT INTO public.orders (
+    id, business_id, order_number, customer_id,
+    total_amount_kobo, discount_kobo, net_amount_kobo, amount_paid_kobo,
+    payment_type, status, staff_id, store_id,
+    completed_at, cancelled_at, created_at, last_updated_at
+  )
+  VALUES (
+    p_order_id, p_business_id, v_order_number, p_customer_id,
+    v_gross, v_discount, v_net, v_cash_paid,
+    'cash', 'pending', v_actor_id, p_store_id,
+    NULL, NULL, v_now, v_now
+  );
+
+  -- Items + inventory guard + stock ledger. buying_price_kobo starts 0 and is
+  -- overwritten by the FIFO pass below.
+  v_items_out := '[]'::jsonb;
+  FOR v_item IN SELECT * FROM jsonb_array_elements(p_items) LOOP
+    v_product_id := (v_item->>'product_id')::uuid;
+    v_qty        := (v_item->>'quantity')::int;
+    v_unit_price := (v_item->>'unit_price_kobo')::bigint;
+
+    IF v_product_id IS NULL THEN
+      RAISE EXCEPTION 'product_id_required_per_line'
+        USING ERRCODE = 'invalid_parameter_value';
+    END IF;
+    IF v_qty <= 0 THEN
+      RAISE EXCEPTION 'item_quantity_must_be_positive'
+        USING ERRCODE = 'invalid_parameter_value';
+    END IF;
+
+    v_line_total := v_qty::bigint * v_unit_price;
+    v_item_id    := gen_random_uuid();
+
+    INSERT INTO public.order_items (
+      id, business_id, order_id, product_id, store_id,
+      quantity, unit_price_kobo, buying_price_kobo, total_kobo,
+      created_at, last_updated_at
+    )
+    VALUES (
+      v_item_id, p_business_id, p_order_id, v_product_id, p_store_id,
+      v_qty, v_unit_price, 0, v_line_total,
+      v_now, v_now
+    );
+
+    -- Inventory decrement under the stock guard. The conditional UPDATE takes a
+    -- row lock and only succeeds while quantity >= qty, so two concurrent tills
+    -- cannot oversell — the loser's UPDATE finds no row and we reject at commit.
+    UPDATE public.inventory
+       SET quantity = quantity - v_qty
+     WHERE business_id = p_business_id
+       AND product_id  = v_product_id
+       AND store_id    = p_store_id
+       AND quantity   >= v_qty
+    RETURNING quantity INTO v_new_qty;
+
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'insufficient_stock'
+        USING ERRCODE = 'P0001',
+              HINT = jsonb_build_object(
+                'product_id',    v_product_id,
+                'store_id',      p_store_id,
+                'requested_qty', v_qty
+              )::text;
+    END IF;
+
+    v_inv_after := v_inv_after || jsonb_build_object(
+      'product_id',      v_product_id,
+      'store_id',        p_store_id,
+      'quantity',        v_new_qty,
+      'last_updated_at', v_now
+    );
+
+    v_stx_id := gen_random_uuid();
+    INSERT INTO public.stock_transactions (
+      id, business_id, product_id, location_id, quantity_delta, movement_type,
+      order_id, performed_by, created_at, last_updated_at
+    )
+    VALUES (
+      v_stx_id, p_business_id, v_product_id, p_store_id, -v_qty, 'sale',
+      p_order_id, v_actor_id, v_now, v_now
+    );
+
+    v_items_out := v_items_out || jsonb_build_object(
+      'item_id', v_item_id, 'product_id', v_product_id, 'quantity', v_qty);
+  END LOOP;
+
+  -- FIFO draw-down per distinct product for this (order, store). Reuses the pure
+  -- public.fifo_assign (0133) so the per-unit COGS rounding is byte-for-byte the
+  -- same as the recost pass AND the mobile provisional draw-down. Batches are
+  -- locked FOR UPDATE (oldest-first) so a concurrent checkout of the same product
+  -- serializes on the queue and cannot double-consume a batch.
+  v_products := ARRAY(
+    SELECT DISTINCT (it->>'product_id')::uuid FROM jsonb_array_elements(p_items) AS it
+  );
+
+  FOREACH v_product IN ARRAY v_products LOOP
+    -- Lock + load the live queue (qty_remaining > 0), oldest-first.
+    SELECT
+      COALESCE(jsonb_agg(jsonb_build_object('cost_kobo', cb.cost_kobo, 'qty', cb.qty_remaining)
+                         ORDER BY cb.received_at, cb.id), '[]'::jsonb),
+      COALESCE(array_agg(cb.id ORDER BY cb.received_at, cb.id), ARRAY[]::uuid[])
+    INTO v_batches, v_batch_ids
+    FROM (
+      SELECT id, cost_kobo, qty_remaining, received_at
+        FROM public.cost_batches
+       WHERE business_id = p_business_id
+         AND product_id  = v_product
+         AND store_id    = p_store_id
+         AND qty_remaining > 0
+       ORDER BY received_at, id
+       FOR UPDATE
+    ) cb;
+
+    -- This product's sale lines, in insertion order (order_items.created_at then
+    -- id — a stable order that continues one draw across repeated lines).
+    SELECT COALESCE(jsonb_agg(jsonb_build_object('line_id', oi.id, 'quantity', oi.quantity)
+                              ORDER BY oi.created_at, oi.id), '[]'::jsonb)
+      INTO v_sales
+      FROM public.order_items oi
+     WHERE oi.order_id = p_order_id
+       AND oi.product_id = v_product;
+
+    v_assigned := public.fifo_assign(v_batches, v_sales);
+    v_rem      := v_assigned->'batches_remaining';
+
+    -- Snapshot each line's per-unit COGS.
+    FOR v_line IN SELECT * FROM jsonb_array_elements(v_assigned->'lines') LOOP
+      UPDATE public.order_items
+         SET buying_price_kobo = (v_line->>'cogs_per_unit_kobo')::bigint,
+             last_updated_at   = v_now
+       WHERE id = (v_line->>'line_id')::uuid;
+    END LOOP;
+
+    -- Decrement the consumed batches (only where changed).
+    FOR v_i IN 1 .. COALESCE(array_length(v_batch_ids, 1), 0) LOOP
+      UPDATE public.cost_batches
+         SET qty_remaining = (v_rem->>(v_i - 1))::int
+       WHERE id = v_batch_ids[v_i]
+         AND qty_remaining IS DISTINCT FROM (v_rem->>(v_i - 1))::int;
+    END LOOP;
+
+    -- Re-point the product's scalar buying_price_kobo cache at the oldest
+    -- remaining COSTED batch (across stores) — mirrors CostBatchesDao._recompute
+    -- ScalarCost: skip uncosted (cost 0) batches, and leave the scalar untouched
+    -- when nothing costed remains (never clobber a user-set price to 0).
+    SELECT cb.cost_kobo INTO v_oldest_cost
+      FROM public.cost_batches cb
+     WHERE cb.business_id = p_business_id
+       AND cb.product_id  = v_product
+       AND cb.qty_remaining > 0
+       AND cb.cost_kobo > 0
+     ORDER BY cb.received_at, cb.id
+     LIMIT 1;
+    IF v_oldest_cost IS NOT NULL THEN
+      UPDATE public.products
+         SET buying_price_kobo = v_oldest_cost, last_updated_at = v_now
+       WHERE id = v_product
+         AND business_id = p_business_id
+         AND buying_price_kobo IS DISTINCT FROM v_oldest_cost;
+    END IF;
+  END LOOP;
+
+  -- One payment row for the cash actually settled (type 'sale'). Skipped when
+  -- nothing was paid in cash (pure credit sale or pay-with-credit).
+  IF v_cash_paid > 0 THEN
+    v_payment_id := gen_random_uuid();
+    INSERT INTO public.payment_transactions (
+      id, business_id, amount_kobo, method, type,
+      order_id, performed_by, created_at, last_updated_at
+    )
+    VALUES (
+      v_payment_id, p_business_id, v_cash_paid,
+      CASE WHEN p_payment_method = 'transfer' THEN 'transfer' ELSE 'cash' END,
+      'sale', p_order_id, v_actor_id, v_now, v_now
+    );
+  END IF;
+
+  -- §14.3 wallet ledger (invariant #3, registered customers only). Two
+  -- append-only legs, same event so same created_at: debit the order NET (goods
+  -- leave) and credit the cash paid (money in). The net (cash − net) is the
+  -- customer's position. Mirrors mobile OrdersDao.createOrder. The deposit
+  -- carve-out (a held 'crate_deposit' leg) belongs to the money-track path,
+  -- which the web does not exercise (Slice 4 is crate-track only) — see header.
+  IF v_registered THEN
+    -- Leg 1 — debit the order net.
+    v_wtx_id := gen_random_uuid();
+    INSERT INTO public.wallet_transactions (
+      id, business_id, wallet_id, customer_id, type,
+      amount_kobo, signed_amount_kobo, reference_type, order_id,
+      performed_by, customer_verified, created_at, last_updated_at
+    )
+    VALUES (
+      v_wtx_id, p_business_id, v_wallet_id, p_customer_id, 'debit',
+      v_net, -v_net, 'order_payment', p_order_id,
+      v_actor_id, false, v_now, v_now
+    );
+
+    -- Leg 2 — credit the cash applied (money into the wallet). Skipped for a
+    -- pay-with-credit / pure credit sale (nothing paid in cash).
+    IF v_cash_paid > 0 THEN
+      v_credit_ref := CASE WHEN p_payment_method = 'transfer'
+                           THEN 'topup_transfer' ELSE 'topup_cash' END;
+      v_wtx_id := gen_random_uuid();
+      INSERT INTO public.wallet_transactions (
+        id, business_id, wallet_id, customer_id, type,
+        amount_kobo, signed_amount_kobo, reference_type, order_id,
+        performed_by, customer_verified, created_at, last_updated_at
+      )
+      VALUES (
+        v_wtx_id, p_business_id, v_wallet_id, p_customer_id, 'credit',
+        v_cash_paid, v_cash_paid, v_credit_ref, p_order_id,
+        v_actor_id, false, v_now, v_now
+      );
+    END IF;
+  END IF;
+
+  -- §13.4 empty-crate dispatch (registered customers only). For a crate-eligible
+  -- business that tracks empties, record the crates taken per manufacturer and
+  -- (crate-track path — no deposit collected) post an 'issued' crate_ledger row
+  -- + increment customer_crate_balances so a later return nets to zero. Mirrors
+  -- mobile OrdersDao.createOrder + CrateLedgerDao.recordCrateIssueByCustomer.
+  -- Wholly separate from the drink cost/stock/wallet legs — no double-count.
+  IF v_registered THEN
+    SELECT type, tracks_empty_crates INTO v_biz_type, v_tracks
+      FROM public.businesses WHERE id = p_business_id;
+
+    IF public._is_crate_business(v_biz_type) AND COALESCE(v_tracks, true) THEN
+      -- Crate-eligible lines grouped by manufacturer: unit ILIKE 'bottle' AND
+      -- track_empties AND a manufacturer (mobile's exact basis).
+      FOR v_crate IN
+        SELECT p.manufacturer_id AS mfr_id, SUM(oi.quantity)::int AS crates
+          FROM public.order_items oi
+          JOIN public.products p ON p.id = oi.product_id
+         WHERE oi.order_id = p_order_id
+           AND p.manufacturer_id IS NOT NULL
+           AND lower(p.unit) = 'bottle'
+           AND p.track_empties = true
+         GROUP BY p.manufacturer_id
+      LOOP
+        -- Deposit RATE snapshot (per manufacturer, frozen at sale time).
+        SELECT deposit_amount_kobo INTO v_rate
+          FROM public.manufacturers
+         WHERE id = v_crate.mfr_id AND business_id = p_business_id;
+        v_rate := COALESCE(v_rate, 0);
+
+        -- One order_crate_lines row per manufacturer (deposit_paid 0 =
+        -- crate-track). UNIQUE (business_id, order_id, manufacturer_id) — one
+        -- row per manufacturer per order, so a plain INSERT never conflicts.
+        INSERT INTO public.order_crate_lines (
+          id, business_id, order_id, manufacturer_id,
+          crates_taken, deposit_rate_kobo, deposit_paid_kobo,
+          created_at, last_updated_at
+        )
+        VALUES (
+          gen_random_uuid(), p_business_id, p_order_id, v_crate.mfr_id,
+          v_crate.crates, v_rate, 0, v_now, v_now
+        );
+
+        -- Crate-track: the customer owes the empties. Append an 'issued' ledger
+        -- row (+crates) and increment the per-manufacturer balance.
+        v_crl_id := gen_random_uuid();
+        INSERT INTO public.crate_ledger (
+          id, business_id, customer_id, manufacturer_id,
+          quantity_delta, movement_type, reference_order_id, performed_by,
+          created_at, last_updated_at
+        )
+        VALUES (
+          v_crl_id, p_business_id, p_customer_id, v_crate.mfr_id,
+          v_crate.crates, 'issued', p_order_id, v_actor_id, v_now, v_now
+        );
+
+        INSERT INTO public.customer_crate_balances (
+          id, business_id, customer_id, manufacturer_id, balance,
+          created_at, last_updated_at
+        )
+        VALUES (
+          gen_random_uuid(), p_business_id, p_customer_id, v_crate.mfr_id,
+          v_crate.crates, v_now, v_now
+        )
+        ON CONFLICT (business_id, customer_id, manufacturer_id) DO UPDATE
+          SET balance = customer_crate_balances.balance + EXCLUDED.balance,
+              last_updated_at = v_now;
+      END LOOP;
+    END IF;
+  END IF;
+
+  -- Compose the response for the receipt.
+  SELECT to_jsonb(o.*) INTO v_order_row FROM public.orders o WHERE o.id = p_order_id;
+  SELECT COALESCE(jsonb_agg(to_jsonb(oi.*) ORDER BY oi.created_at, oi.id), '[]'::jsonb)
+    INTO v_items_out FROM public.order_items oi WHERE oi.order_id = p_order_id;
+  SELECT to_jsonb(pt.*) INTO v_payment_row
+    FROM public.payment_transactions pt
+    WHERE pt.order_id = p_order_id AND pt.type = 'sale'
+    ORDER BY pt.created_at LIMIT 1;
+  SELECT COALESCE(jsonb_agg(to_jsonb(wt.*) ORDER BY wt.created_at, wt.id), '[]'::jsonb)
+    INTO v_wallet_rows FROM public.wallet_transactions wt WHERE wt.order_id = p_order_id;
+
+  RETURN jsonb_build_object(
+    'order',               v_order_row,
+    'order_items',         v_items_out,
+    'payment_transaction', v_payment_row,
+    'wallet_transactions', v_wallet_rows,
+    'customer_balance_kobo',
+      CASE WHEN v_registered
+           THEN public._customer_wallet_balance(p_business_id, p_customer_id)
+           ELSE NULL END,
+    'inventory_after',     v_inv_after,
+    'replayed',            false
+  );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.checkout_order(uuid, uuid, uuid, jsonb, text, bigint, bigint, uuid) FROM public;
+GRANT EXECUTE ON FUNCTION public.checkout_order(uuid, uuid, uuid, jsonb, text, bigint, bigint, uuid)
+  TO authenticated, service_role;
+
+COMMIT;
+
+-- =============================================================================
+-- Verification (paste into the SQL editor while authenticated as a business user
+-- at a crate-eligible business — type Bar / Beverage distributor, tracks_empty_
+-- crates on — with a registered customer + wallet + a bottle/track_empties
+-- product that has a manufacturer):
+--
+--   1. A registered crate sale posts one order_crate_lines row (deposit rate
+--      snapshot, deposit_paid 0), one 'issued' crate_ledger row (+crates), and
+--      bumps customer_crate_balances by the crates taken:
+--        SELECT public.checkout_order('<biz>', gen_random_uuid(), '<store>',
+--          '[{"product_id":"<bottle-p>","quantity":3,"unit_price_kobo":100000}]'::jsonb,
+--          'cash', 300000, 0, '<customer>');
+--        SELECT crates_taken, deposit_rate_kobo, deposit_paid_kobo
+--          FROM public.order_crate_lines WHERE order_id = '<that-order>';
+--        SELECT quantity_delta, movement_type FROM public.crate_ledger
+--          WHERE reference_order_id = '<that-order>';   -- +3, 'issued'
+--        SELECT balance FROM public.customer_crate_balances
+--          WHERE customer_id = '<customer>' AND manufacturer_id = '<mfr>';
+--
+--   2. The same sale at a NON-crate business (or with tracks_empty_crates off)
+--      posts NO order_crate_lines / crate_ledger rows.
+--
+--   3. A walk-in (p_customer_id NULL) never posts crate rows.
+-- =============================================================================

--- a/test/golden/dart_dao_golden_test.dart
+++ b/test/golden/dart_dao_golden_test.dart
@@ -1,0 +1,362 @@
+import 'package:drift/drift.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reebaplus_pos/core/database/app_database.dart';
+import 'package:reebaplus_pos/core/database/uuid_v7.dart';
+import 'package:reebaplus_pos/core/utils/order_number.dart';
+
+import '../helpers/dispatch_test_utils.dart';
+import 'golden_scenario.dart';
+
+/// Golden-Scenario Suite — the DART DAO side (ADR 0009, issue #43).
+///
+/// Runs the shared cash-sale fixtures (test/golden/fixtures/*.json) against the
+/// mobile checkout money path (OrdersDao.createOrder + CostBatchesDao.drawDown
+/// Sale) on an in-memory Drift DB. Offline and network-free, so it runs in EVERY
+/// CI build. Its Tier-2 twin (test/integration/rpcs/checkout_order_golden_test)
+/// runs the SAME fixtures against the SQL `checkout_order` RPC; any drift between
+/// the two fails the build.
+void main() {
+  final scenarios = [...loadCashSaleScenarios(), ...loadCrateSaleScenarios()];
+  for (final scenario in scenarios) {
+    test('golden (dart dao): ${scenario.name}', () async {
+      final boot = await bootstrapTestDb();
+      final db = boot.db;
+      final businessId = boot.businessId;
+      addTearDown(db.close);
+
+      // v1 record-sale path so createOrder writes order_items locally (the v2
+      // path defers the line write to the cloud RPC response).
+      await setFlag(db, 'feature.domain_rpcs_v2.record_sale', on: false);
+
+      // ── Seed the input state ────────────────────────────────────────────────
+      final storeId = UuidV7.generate();
+      await db.into(db.stores).insert(
+            StoresCompanion.insert(
+                id: Value(storeId), businessId: businessId, name: 'Main'),
+          );
+      final staffId = UuidV7.generate();
+      await db.into(db.users).insert(
+            UsersCompanion.insert(
+                id: Value(staffId),
+                businessId: businessId,
+                name: 'Cashier',
+                pin: '0000'),
+          );
+
+      // Slice 4 (#45): crate scenarios set the business type (drives
+      // isCrateBusiness) + the empties opt-in, and register the manufacturers
+      // whose deposit rates the sale snapshots. bootstrapTestDb's business has a
+      // null type, so a non-crate fixture leaves the crate gate closed.
+      if (scenario.businessType != null) {
+        await (db.update(db.businesses)..where((b) => b.id.equals(businessId)))
+            .write(BusinessesCompanion(
+          type: Value(scenario.businessType),
+          tracksEmptyCrates: Value(scenario.tracksEmptyCrates),
+        ));
+      }
+      final manufacturerIdByKey = <String, String>{};
+      for (final m in scenario.manufacturers) {
+        final id = UuidV7.generate();
+        manufacturerIdByKey[m.key] = id;
+        await db.into(db.manufacturers).insert(
+              ManufacturersCompanion.insert(
+                id: Value(id),
+                businessId: businessId,
+                name: m.name,
+                depositAmountKobo: Value(m.depositRateKobo),
+              ),
+            );
+      }
+
+      // Slice 3 (#44): a registered customer + wallet, seeded with any opening
+      // balance as one topup_cash credit BEFORE the sale (so Pay-with-Credit has
+      // credit to draw). The opening leg carries no order_id, so the runner's
+      // per-order leg collection below excludes it.
+      String? customerId;
+      if (scenario.customer != null) {
+        customerId = UuidV7.generate();
+        final walletId = UuidV7.generate();
+        await db.into(db.customers).insert(
+              CustomersCompanion.insert(
+                id: Value(customerId),
+                businessId: businessId,
+                name: 'Credit Customer',
+                walletLimitKobo: Value(scenario.customer!.debtLimitKobo),
+              ),
+            );
+        await db.into(db.customerWallets).insert(
+              CustomerWalletsCompanion.insert(
+                id: Value(walletId),
+                businessId: businessId,
+                customerId: customerId,
+              ),
+            );
+        if (scenario.customer!.openingBalanceKobo != 0) {
+          await db.into(db.walletTransactions).insert(
+                WalletTransactionsCompanion.insert(
+                  id: Value(UuidV7.generate()),
+                  businessId: businessId,
+                  walletId: walletId,
+                  customerId: customerId,
+                  type: 'credit',
+                  amountKobo: scenario.customer!.openingBalanceKobo,
+                  signedAmountKobo: scenario.customer!.openingBalanceKobo,
+                  referenceType: 'topup_cash',
+                ),
+              );
+        }
+      }
+
+      final productIdByKey = <String, String>{};
+      for (final p in scenario.products) {
+        final id = UuidV7.generate();
+        productIdByKey[p.key] = id;
+        // A crate-eligible product (manufacturerKey set) is a returnable bottle
+        // with empties tracking on; everything else is a plain 'Piece' product.
+        final crateEligible = p.manufacturerKey != null;
+        await db.into(db.products).insert(
+              ProductsCompanion.insert(
+                id: Value(id),
+                businessId: businessId,
+                name: p.name,
+                retailerPriceKobo: Value(p.unitPriceKobo),
+                buyingPriceKobo: Value(p.scalarCostKobo),
+                unit: Value(crateEligible ? 'Bottle' : 'Piece'),
+                trackEmpties: Value(crateEligible),
+                manufacturerId: crateEligible
+                    ? Value(manufacturerIdByKey[p.manufacturerKey]!)
+                    : const Value.absent(),
+              ),
+            );
+      }
+      for (final inv in scenario.inventory) {
+        await db.into(db.inventory).insert(
+              InventoryCompanion.insert(
+                businessId: businessId,
+                productId: productIdByKey[inv.productKey]!,
+                storeId: storeId,
+                quantity: Value(inv.quantity),
+              ),
+            );
+      }
+      // batchId → (productKey, receivedAt) so remainders can be read back by key.
+      final seededBatches = <(String, String, String)>[];
+      for (final b in scenario.batches) {
+        final id = UuidV7.generate();
+        await db.into(db.costBatches).insert(
+              CostBatchesCompanion.insert(
+                id: Value(id),
+                businessId: businessId,
+                productId: productIdByKey[b.productKey]!,
+                storeId: storeId,
+                qtyRemaining: b.qty,
+                qtyOriginal: b.qty,
+                costKobo: Value(b.costKobo),
+                receivedAt: Value(b.receivedAtUtc),
+              ),
+            );
+        seededBatches.add((id, b.productKey, b.receivedAt));
+      }
+
+      // ── Perform the checkout the mobile way ────────────────────────────────
+      final orderId = UuidV7.generate();
+      final orderNumber =
+          await db.ordersDao.generateOrderNumber(deviceOrderTag('golden-device'));
+
+      var gross = 0;
+      final items = <OrderItemsCompanion>[];
+      for (final line in scenario.checkout.items) {
+        final p = scenario.product(line.productKey);
+        final total = p.unitPriceKobo * line.quantity;
+        gross += total;
+        items.add(OrderItemsCompanion.insert(
+          businessId: businessId,
+          orderId: orderId,
+          productId: Value(productIdByKey[line.productKey]!),
+          storeId: storeId,
+          quantity: line.quantity,
+          unitPriceKobo: p.unitPriceKobo,
+          totalKobo: total,
+        ));
+      }
+      final discount = scenario.checkout.discountKobo;
+      final net = gross - discount;
+
+      // The cash actually settled: for a walk-in cash/transfer it's the net; for
+      // a credit/wallet sale it's exactly what the fixture tendered (0 for a
+      // Pay-with-Credit or a no-cash Credit Sale). The wallet's DEBIT leg is the
+      // net owed, so createOrder's totalAmountKobo arg is [net] (the debit basis,
+      // deposit carve-out is Slice 4), while the order header keeps gross.
+      final cashPaid =
+          customerId != null ? scenario.checkout.amountPaidKobo : net;
+      // createOrder uses paymentMethod only to label the CREDIT leg's reference
+      // (topup_cash / topup_transfer). The RPC maps every non-transfer tender to
+      // topup_cash, so mirror that: 'transfer' stays, everything else → 'cash'.
+      final tenderMethod =
+          scenario.checkout.paymentMethod == 'transfer' ? 'transfer' : 'cash';
+
+      await db.ordersDao.createOrder(
+        order: OrdersCompanion.insert(
+          id: Value(orderId),
+          businessId: businessId,
+          orderNumber: orderNumber,
+          totalAmountKobo: gross,
+          discountKobo: Value(discount),
+          netAmountKobo: net,
+          amountPaidKobo: Value(cashPaid),
+          paymentType: 'cash',
+          status: 'pending',
+          staffId: Value(staffId),
+          storeId: Value(storeId),
+          customerId: Value(customerId),
+        ),
+        items: items,
+        customerId: customerId,
+        amountPaidKobo: cashPaid,
+        totalAmountKobo: net,
+        staffId: staffId,
+        storeId: storeId,
+        paymentMethod: tenderMethod,
+      );
+
+      // ── Collect the resulting rows in fixture terms ────────────────────────
+      final keyByProductId = {
+        for (final e in productIdByKey.entries) e.value: e.key
+      };
+
+      final order =
+          await (db.select(db.orders)..where((o) => o.id.equals(orderId)))
+              .getSingle();
+      final orderItems = await (db.select(db.orderItems)
+            ..where((i) => i.orderId.equals(orderId)))
+          .get();
+      final payment = await (db.select(db.paymentTransactions)
+            ..where((p) => p.orderId.equals(orderId) & p.type.equals('sale')))
+          .getSingleOrNull();
+
+      // Wallet legs THIS sale posted (order_id == this order — excludes the
+      // seeded opening balance) + the customer's derived spendable balance.
+      const crateDepositRefs = {
+        'crate_deposit',
+        'crate_deposit_refunded',
+        'crate_deposit_forfeited',
+      };
+      final walletLegs = <ActualWalletLeg>[];
+      int? customerBalanceAfter;
+      if (customerId != null) {
+        final legRows = await (db.select(db.walletTransactions)
+              ..where((w) => w.orderId.equals(orderId)))
+            .get();
+        for (final l in legRows) {
+          walletLegs.add(ActualWalletLeg(
+            referenceType: l.referenceType,
+            signedAmountKobo: l.signedAmountKobo,
+          ));
+        }
+        final allLegs = await (db.select(db.walletTransactions)
+              ..where((w) => w.customerId.equals(customerId!)))
+            .get();
+        customerBalanceAfter = allLegs
+            .where((l) => !crateDepositRefs.contains(l.referenceType))
+            .fold<int>(0, (s, l) => s + l.signedAmountKobo);
+      }
+
+      // Crate rows THIS sale posted (Slice 4, #45), keyed by manufacturer:
+      // order_crate_lines, the 'issued' crate_ledger movements, and
+      // customer_crate_balances. Empty for a non-crate sale.
+      final keyByManufacturerId = {
+        for (final e in manufacturerIdByKey.entries) e.value: e.key
+      };
+      final crateLines = <String, ActualCrateLine>{};
+      final crateLedgerIssued = <String, int>{};
+      final crateBalances = <String, int>{};
+      if (customerId != null && manufacturerIdByKey.isNotEmpty) {
+        final lineRows = await (db.select(db.orderCrateLines)
+              ..where((l) => l.orderId.equals(orderId)))
+            .get();
+        for (final l in lineRows) {
+          crateLines[keyByManufacturerId[l.manufacturerId]!] = ActualCrateLine(
+            cratesTaken: l.cratesTaken,
+            depositRateKobo: l.depositRateKobo,
+            depositPaidKobo: l.depositPaidKobo,
+          );
+        }
+        final ledgerRows = await (db.select(db.crateLedger)
+              ..where((c) =>
+                  c.referenceOrderId.equals(orderId) &
+                  c.movementType.equals('issued')))
+            .get();
+        for (final c in ledgerRows) {
+          final key = keyByManufacturerId[c.manufacturerId]!;
+          crateLedgerIssued[key] =
+              (crateLedgerIssued[key] ?? 0) + c.quantityDelta;
+        }
+        final balanceRows = await (db.select(db.customerCrateBalances)
+              ..where((b) => b.customerId.equals(customerId!)))
+            .get();
+        for (final b in balanceRows) {
+          crateBalances[keyByManufacturerId[b.manufacturerId]!] = b.balance;
+        }
+      }
+
+      final batchRemaining = <String, int>{};
+      for (final (id, productKey, receivedAt) in seededBatches) {
+        final row = await (db.select(db.costBatches)
+              ..where((b) => b.id.equals(id)))
+            .getSingle();
+        batchRemaining['$productKey|$receivedAt'] = row.qtyRemaining;
+      }
+
+      final inventoryAfter = <String, int>{};
+      final scalarCost = <String, int>{};
+      for (final entry in productIdByKey.entries) {
+        final invRow = await (db.select(db.inventory)
+              ..where((i) =>
+                  i.productId.equals(entry.value) & i.storeId.equals(storeId)))
+            .getSingleOrNull();
+        if (invRow != null) inventoryAfter[entry.key] = invRow.quantity;
+        final prodRow = await (db.select(db.products)
+              ..where((p) => p.id.equals(entry.value)))
+            .getSingle();
+        scalarCost[entry.key] = prodRow.buyingPriceKobo;
+      }
+
+      final outcome = CheckoutOutcome(
+        orderNumber: order.orderNumber,
+        order: ActualOrder(
+          status: order.status,
+          paymentType: order.paymentType,
+          totalAmountKobo: order.totalAmountKobo,
+          discountKobo: order.discountKobo,
+          netAmountKobo: order.netAmountKobo,
+          amountPaidKobo: order.amountPaidKobo,
+          completedAtNull: order.completedAt == null,
+        ),
+        items: [
+          for (final i in orderItems)
+            ActualItem(
+              productKey: keyByProductId[i.productId]!,
+              quantity: i.quantity,
+              unitPriceKobo: i.unitPriceKobo,
+              totalKobo: i.totalKobo,
+              buyingPriceKobo: i.buyingPriceKobo,
+            ),
+        ],
+        batchRemaining: batchRemaining,
+        inventoryAfter: inventoryAfter,
+        productScalarCost: scalarCost,
+        payment: payment == null
+            ? null
+            : ActualPayment(
+                method: payment.method, amountKobo: payment.amountKobo),
+        walletLegs: walletLegs,
+        customerBalanceAfter: customerBalanceAfter,
+        crateLines: crateLines,
+        crateLedgerIssued: crateLedgerIssued,
+        crateBalances: crateBalances,
+      );
+
+      expectGolden(scenario, outcome, orderNumberScheme: mobileOrderNumberScheme);
+    });
+  }
+}

--- a/test/golden/fixtures/cash_sale_scenarios.json
+++ b/test/golden/fixtures/cash_sale_scenarios.json
@@ -1,0 +1,399 @@
+{
+  "_doc": [
+    "Golden-Scenario Suite fixtures for the Web POS Slice 2 cash/transfer checkout",
+    "keystone (PRD web-pos, ADR 0009, issue #43). Each fixture is one scenario:",
+    "an input starting state (products, inventory, FIFO cost batches) + a checkout,",
+    "and the expected resulting rows (order + items + FIFO draw-down + COGS snapshot",
+    "+ inventory + scalar cost cache + payment). The SAME fixtures run against BOTH",
+    "implementations of the money rule:",
+    "  * the Dart DAO path (mobile)  — test/golden/dart_dao_golden_test.dart (offline)",
+    "  * the SQL checkout_order RPC  — test/integration/rpcs/checkout_order_golden_test.dart",
+    "Any drift between the two fails CI. Amounts are *_kobo (bigint). A single store",
+    "is implied; batches are keyed by received_at (unique per product within a",
+    "fixture). The order NUMBER intentionally differs by client (mobile ORD-…, web",
+    "WEB-…) so each runner asserts its own scheme, never equality — the numbering",
+    "strategy is deliberately divergent (collision-proof), the money math is not."
+  ],
+  "scenarios": [
+    {
+      "name": "single costed line, cash, fully paid",
+      "products": [
+        { "key": "P1", "name": "Star 60cl", "unit_price_kobo": 100000, "scalar_cost_kobo": 50000 }
+      ],
+      "inventory": [{ "product": "P1", "quantity": 100 }],
+      "batches": [{ "product": "P1", "qty": 20, "cost_kobo": 50000, "received_at": "2026-01-01" }],
+      "checkout": {
+        "payment_method": "cash",
+        "discount_kobo": 0,
+        "amount_paid_kobo": 300000,
+        "items": [{ "product": "P1", "quantity": 3 }]
+      },
+      "expected": {
+        "order": {
+          "status": "pending", "payment_type": "cash",
+          "total_amount_kobo": 300000, "discount_kobo": 0,
+          "net_amount_kobo": 300000, "amount_paid_kobo": 300000,
+          "completed_at_null": true
+        },
+        "items": [{ "product": "P1", "quantity": 3, "unit_price_kobo": 100000, "total_kobo": 300000, "buying_price_kobo": 50000 }],
+        "batches_remaining": [{ "product": "P1", "received_at": "2026-01-01", "qty_remaining": 17 }],
+        "inventory_after": [{ "product": "P1", "quantity": 97 }],
+        "product_scalar_cost": [{ "product": "P1", "buying_price_kobo": 50000 }],
+        "payment": { "method": "cash", "amount_kobo": 300000 }
+      }
+    },
+    {
+      "name": "line spanning a batch boundary snapshots weighted per-unit COGS",
+      "products": [
+        { "key": "P1", "name": "Star 60cl", "unit_price_kobo": 100000, "scalar_cost_kobo": 50000 }
+      ],
+      "inventory": [{ "product": "P1", "quantity": 100 }],
+      "batches": [
+        { "product": "P1", "qty": 6, "cost_kobo": 50000, "received_at": "2026-01-01" },
+        { "product": "P1", "qty": 10, "cost_kobo": 60000, "received_at": "2026-02-01" }
+      ],
+      "checkout": {
+        "payment_method": "cash",
+        "discount_kobo": 0,
+        "amount_paid_kobo": 1000000,
+        "items": [{ "product": "P1", "quantity": 10 }]
+      },
+      "expected": {
+        "order": {
+          "status": "pending", "payment_type": "cash",
+          "total_amount_kobo": 1000000, "discount_kobo": 0,
+          "net_amount_kobo": 1000000, "amount_paid_kobo": 1000000,
+          "completed_at_null": true
+        },
+        "items": [{ "product": "P1", "quantity": 10, "unit_price_kobo": 100000, "total_kobo": 1000000, "buying_price_kobo": 54000 }],
+        "batches_remaining": [
+          { "product": "P1", "received_at": "2026-01-01", "qty_remaining": 0 },
+          { "product": "P1", "received_at": "2026-02-01", "qty_remaining": 6 }
+        ],
+        "inventory_after": [{ "product": "P1", "quantity": 90 }],
+        "product_scalar_cost": [{ "product": "P1", "buying_price_kobo": 60000 }],
+        "payment": { "method": "cash", "amount_kobo": 1000000 }
+      }
+    },
+    {
+      "name": "two lines of one product continue one FIFO draw across the boundary",
+      "products": [
+        { "key": "P1", "name": "Star 60cl", "unit_price_kobo": 100000, "scalar_cost_kobo": 50000 }
+      ],
+      "inventory": [{ "product": "P1", "quantity": 100 }],
+      "batches": [
+        { "product": "P1", "qty": 3, "cost_kobo": 50000, "received_at": "2026-01-01" },
+        { "product": "P1", "qty": 3, "cost_kobo": 90000, "received_at": "2026-02-01" }
+      ],
+      "checkout": {
+        "payment_method": "cash",
+        "discount_kobo": 0,
+        "amount_paid_kobo": 600000,
+        "items": [
+          { "product": "P1", "quantity": 3 },
+          { "product": "P1", "quantity": 3 }
+        ]
+      },
+      "expected": {
+        "order": {
+          "status": "pending", "payment_type": "cash",
+          "total_amount_kobo": 600000, "discount_kobo": 0,
+          "net_amount_kobo": 600000, "amount_paid_kobo": 600000,
+          "completed_at_null": true
+        },
+        "items": [
+          { "product": "P1", "quantity": 3, "unit_price_kobo": 100000, "total_kobo": 300000, "buying_price_kobo": 50000 },
+          { "product": "P1", "quantity": 3, "unit_price_kobo": 100000, "total_kobo": 300000, "buying_price_kobo": 90000 }
+        ],
+        "batches_remaining": [
+          { "product": "P1", "received_at": "2026-01-01", "qty_remaining": 0 },
+          { "product": "P1", "received_at": "2026-02-01", "qty_remaining": 0 }
+        ],
+        "inventory_after": [{ "product": "P1", "quantity": 94 }],
+        "product_scalar_cost": [{ "product": "P1", "buying_price_kobo": 50000 }],
+        "payment": { "method": "cash", "amount_kobo": 600000 }
+      }
+    },
+    {
+      "name": "partially-covered line: the shortfall is uncosted, dragging per-unit COGS down",
+      "products": [
+        { "key": "P1", "name": "Star 60cl", "unit_price_kobo": 100000, "scalar_cost_kobo": 50000 }
+      ],
+      "inventory": [{ "product": "P1", "quantity": 100 }],
+      "batches": [{ "product": "P1", "qty": 3, "cost_kobo": 50000, "received_at": "2026-01-01" }],
+      "checkout": {
+        "payment_method": "cash",
+        "discount_kobo": 0,
+        "amount_paid_kobo": 500000,
+        "items": [{ "product": "P1", "quantity": 5 }]
+      },
+      "expected": {
+        "order": {
+          "status": "pending", "payment_type": "cash",
+          "total_amount_kobo": 500000, "discount_kobo": 0,
+          "net_amount_kobo": 500000, "amount_paid_kobo": 500000,
+          "completed_at_null": true
+        },
+        "items": [{ "product": "P1", "quantity": 5, "unit_price_kobo": 100000, "total_kobo": 500000, "buying_price_kobo": 30000 }],
+        "batches_remaining": [{ "product": "P1", "received_at": "2026-01-01", "qty_remaining": 0 }],
+        "inventory_after": [{ "product": "P1", "quantity": 95 }],
+        "product_scalar_cost": [{ "product": "P1", "buying_price_kobo": 50000 }],
+        "payment": { "method": "cash", "amount_kobo": 500000 }
+      }
+    },
+    {
+      "name": "product with no cost batch is uncosted (0); scalar cache untouched",
+      "products": [
+        { "key": "P1", "name": "Star 60cl", "unit_price_kobo": 100000, "scalar_cost_kobo": 25000 }
+      ],
+      "inventory": [{ "product": "P1", "quantity": 100 }],
+      "batches": [],
+      "checkout": {
+        "payment_method": "cash",
+        "discount_kobo": 0,
+        "amount_paid_kobo": 300000,
+        "items": [{ "product": "P1", "quantity": 3 }]
+      },
+      "expected": {
+        "order": {
+          "status": "pending", "payment_type": "cash",
+          "total_amount_kobo": 300000, "discount_kobo": 0,
+          "net_amount_kobo": 300000, "amount_paid_kobo": 300000,
+          "completed_at_null": true
+        },
+        "items": [{ "product": "P1", "quantity": 3, "unit_price_kobo": 100000, "total_kobo": 300000, "buying_price_kobo": 0 }],
+        "batches_remaining": [],
+        "inventory_after": [{ "product": "P1", "quantity": 97 }],
+        "product_scalar_cost": [{ "product": "P1", "buying_price_kobo": 25000 }],
+        "payment": { "method": "cash", "amount_kobo": 300000 }
+      }
+    },
+    {
+      "name": "uncosted (cost-0) batch snapshots 0 COGS and never clobbers the scalar to 0",
+      "products": [
+        { "key": "P1", "name": "Star 60cl", "unit_price_kobo": 100000, "scalar_cost_kobo": 25000 }
+      ],
+      "inventory": [{ "product": "P1", "quantity": 100 }],
+      "batches": [{ "product": "P1", "qty": 10, "cost_kobo": 0, "received_at": "2026-01-01" }],
+      "checkout": {
+        "payment_method": "cash",
+        "discount_kobo": 0,
+        "amount_paid_kobo": 400000,
+        "items": [{ "product": "P1", "quantity": 4 }]
+      },
+      "expected": {
+        "order": {
+          "status": "pending", "payment_type": "cash",
+          "total_amount_kobo": 400000, "discount_kobo": 0,
+          "net_amount_kobo": 400000, "amount_paid_kobo": 400000,
+          "completed_at_null": true
+        },
+        "items": [{ "product": "P1", "quantity": 4, "unit_price_kobo": 100000, "total_kobo": 400000, "buying_price_kobo": 0 }],
+        "batches_remaining": [{ "product": "P1", "received_at": "2026-01-01", "qty_remaining": 6 }],
+        "inventory_after": [{ "product": "P1", "quantity": 96 }],
+        "product_scalar_cost": [{ "product": "P1", "buying_price_kobo": 25000 }],
+        "payment": { "method": "cash", "amount_kobo": 400000 }
+      }
+    },
+    {
+      "name": "order-level discount reduces net; COGS is unaffected",
+      "products": [
+        { "key": "P1", "name": "Star 60cl", "unit_price_kobo": 100000, "scalar_cost_kobo": 50000 }
+      ],
+      "inventory": [{ "product": "P1", "quantity": 100 }],
+      "batches": [{ "product": "P1", "qty": 20, "cost_kobo": 50000, "received_at": "2026-01-01" }],
+      "checkout": {
+        "payment_method": "cash",
+        "discount_kobo": 50000,
+        "amount_paid_kobo": 950000,
+        "items": [{ "product": "P1", "quantity": 10 }]
+      },
+      "expected": {
+        "order": {
+          "status": "pending", "payment_type": "cash",
+          "total_amount_kobo": 1000000, "discount_kobo": 50000,
+          "net_amount_kobo": 950000, "amount_paid_kobo": 950000,
+          "completed_at_null": true
+        },
+        "items": [{ "product": "P1", "quantity": 10, "unit_price_kobo": 100000, "total_kobo": 1000000, "buying_price_kobo": 50000 }],
+        "batches_remaining": [{ "product": "P1", "received_at": "2026-01-01", "qty_remaining": 10 }],
+        "inventory_after": [{ "product": "P1", "quantity": 90 }],
+        "product_scalar_cost": [{ "product": "P1", "buying_price_kobo": 50000 }],
+        "payment": { "method": "cash", "amount_kobo": 950000 }
+      }
+    },
+    {
+      "name": "two distinct products each draw their own FIFO queue; transfer payment",
+      "products": [
+        { "key": "P1", "name": "Star 60cl", "unit_price_kobo": 100000, "scalar_cost_kobo": 50000 },
+        { "key": "P2", "name": "Malt 33cl", "unit_price_kobo": 80000, "scalar_cost_kobo": 40000 }
+      ],
+      "inventory": [
+        { "product": "P1", "quantity": 50 },
+        { "product": "P2", "quantity": 50 }
+      ],
+      "batches": [
+        { "product": "P1", "qty": 10, "cost_kobo": 50000, "received_at": "2026-01-01" },
+        { "product": "P2", "qty": 10, "cost_kobo": 40000, "received_at": "2026-01-01" }
+      ],
+      "checkout": {
+        "payment_method": "transfer",
+        "discount_kobo": 0,
+        "amount_paid_kobo": 360000,
+        "items": [
+          { "product": "P1", "quantity": 2 },
+          { "product": "P2", "quantity": 2 }
+        ]
+      },
+      "expected": {
+        "order": {
+          "status": "pending", "payment_type": "cash",
+          "total_amount_kobo": 360000, "discount_kobo": 0,
+          "net_amount_kobo": 360000, "amount_paid_kobo": 360000,
+          "completed_at_null": true
+        },
+        "items": [
+          { "product": "P1", "quantity": 2, "unit_price_kobo": 100000, "total_kobo": 200000, "buying_price_kobo": 50000 },
+          { "product": "P2", "quantity": 2, "unit_price_kobo": 80000, "total_kobo": 160000, "buying_price_kobo": 40000 }
+        ],
+        "batches_remaining": [
+          { "product": "P1", "received_at": "2026-01-01", "qty_remaining": 8 },
+          { "product": "P2", "received_at": "2026-01-01", "qty_remaining": 8 }
+        ],
+        "inventory_after": [
+          { "product": "P1", "quantity": 48 },
+          { "product": "P2", "quantity": 48 }
+        ],
+        "product_scalar_cost": [
+          { "product": "P1", "buying_price_kobo": 50000 },
+          { "product": "P2", "buying_price_kobo": 40000 }
+        ],
+        "payment": { "method": "transfer", "amount_kobo": 360000 }
+      }
+    },
+    {
+      "name": "credit (Slice 3): Pay-with-Credit draws the whole sale from an existing balance",
+      "customer": { "opening_balance_kobo": 500000, "debt_limit_kobo": 0 },
+      "products": [
+        { "key": "P1", "name": "Star 60cl", "unit_price_kobo": 100000, "scalar_cost_kobo": 50000 }
+      ],
+      "inventory": [{ "product": "P1", "quantity": 100 }],
+      "batches": [{ "product": "P1", "qty": 20, "cost_kobo": 50000, "received_at": "2026-01-01" }],
+      "checkout": {
+        "payment_method": "wallet",
+        "discount_kobo": 0,
+        "amount_paid_kobo": 0,
+        "items": [{ "product": "P1", "quantity": 3 }]
+      },
+      "expected": {
+        "order": {
+          "status": "pending", "payment_type": "cash",
+          "total_amount_kobo": 300000, "discount_kobo": 0,
+          "net_amount_kobo": 300000, "amount_paid_kobo": 0,
+          "completed_at_null": true
+        },
+        "items": [{ "product": "P1", "quantity": 3, "unit_price_kobo": 100000, "total_kobo": 300000, "buying_price_kobo": 50000 }],
+        "batches_remaining": [{ "product": "P1", "received_at": "2026-01-01", "qty_remaining": 17 }],
+        "inventory_after": [{ "product": "P1", "quantity": 97 }],
+        "product_scalar_cost": [{ "product": "P1", "buying_price_kobo": 50000 }],
+        "wallet_legs": [{ "reference_type": "order_payment", "signed_amount_kobo": -300000 }],
+        "customer_balance_after_kobo": 200000
+      }
+    },
+    {
+      "name": "credit (Slice 3): Register-as-Credit-Sale (no cash) books the whole balance as debt",
+      "customer": { "opening_balance_kobo": 0, "debt_limit_kobo": 500000 },
+      "products": [
+        { "key": "P1", "name": "Star 60cl", "unit_price_kobo": 100000, "scalar_cost_kobo": 50000 }
+      ],
+      "inventory": [{ "product": "P1", "quantity": 100 }],
+      "batches": [{ "product": "P1", "qty": 20, "cost_kobo": 50000, "received_at": "2026-01-01" }],
+      "checkout": {
+        "payment_method": "credit",
+        "discount_kobo": 0,
+        "amount_paid_kobo": 0,
+        "items": [{ "product": "P1", "quantity": 3 }]
+      },
+      "expected": {
+        "order": {
+          "status": "pending", "payment_type": "cash",
+          "total_amount_kobo": 300000, "discount_kobo": 0,
+          "net_amount_kobo": 300000, "amount_paid_kobo": 0,
+          "completed_at_null": true
+        },
+        "items": [{ "product": "P1", "quantity": 3, "unit_price_kobo": 100000, "total_kobo": 300000, "buying_price_kobo": 50000 }],
+        "batches_remaining": [{ "product": "P1", "received_at": "2026-01-01", "qty_remaining": 17 }],
+        "inventory_after": [{ "product": "P1", "quantity": 97 }],
+        "product_scalar_cost": [{ "product": "P1", "buying_price_kobo": 50000 }],
+        "wallet_legs": [{ "reference_type": "order_payment", "signed_amount_kobo": -300000 }],
+        "customer_balance_after_kobo": -300000
+      }
+    },
+    {
+      "name": "credit (Slice 3): Register-as-Credit-Sale with partial cash posts a debit + a cash credit leg",
+      "customer": { "opening_balance_kobo": 0, "debt_limit_kobo": 500000 },
+      "products": [
+        { "key": "P1", "name": "Star 60cl", "unit_price_kobo": 100000, "scalar_cost_kobo": 50000 }
+      ],
+      "inventory": [{ "product": "P1", "quantity": 100 }],
+      "batches": [{ "product": "P1", "qty": 20, "cost_kobo": 50000, "received_at": "2026-01-01" }],
+      "checkout": {
+        "payment_method": "credit",
+        "discount_kobo": 0,
+        "amount_paid_kobo": 100000,
+        "items": [{ "product": "P1", "quantity": 3 }]
+      },
+      "expected": {
+        "order": {
+          "status": "pending", "payment_type": "cash",
+          "total_amount_kobo": 300000, "discount_kobo": 0,
+          "net_amount_kobo": 300000, "amount_paid_kobo": 100000,
+          "completed_at_null": true
+        },
+        "items": [{ "product": "P1", "quantity": 3, "unit_price_kobo": 100000, "total_kobo": 300000, "buying_price_kobo": 50000 }],
+        "batches_remaining": [{ "product": "P1", "received_at": "2026-01-01", "qty_remaining": 17 }],
+        "inventory_after": [{ "product": "P1", "quantity": 97 }],
+        "product_scalar_cost": [{ "product": "P1", "buying_price_kobo": 50000 }],
+        "payment": { "method": "cash", "amount_kobo": 100000 },
+        "wallet_legs": [
+          { "reference_type": "order_payment", "signed_amount_kobo": -300000 },
+          { "reference_type": "topup_cash", "signed_amount_kobo": 100000 }
+        ],
+        "customer_balance_after_kobo": -200000
+      }
+    },
+    {
+      "name": "credit (Slice 3): a registered fully-paid cash sale posts both legs (net-zero) for a complete history",
+      "customer": { "opening_balance_kobo": 0, "debt_limit_kobo": 0 },
+      "products": [
+        { "key": "P1", "name": "Star 60cl", "unit_price_kobo": 100000, "scalar_cost_kobo": 50000 }
+      ],
+      "inventory": [{ "product": "P1", "quantity": 100 }],
+      "batches": [{ "product": "P1", "qty": 20, "cost_kobo": 50000, "received_at": "2026-01-01" }],
+      "checkout": {
+        "payment_method": "cash",
+        "discount_kobo": 0,
+        "amount_paid_kobo": 300000,
+        "items": [{ "product": "P1", "quantity": 3 }]
+      },
+      "expected": {
+        "order": {
+          "status": "pending", "payment_type": "cash",
+          "total_amount_kobo": 300000, "discount_kobo": 0,
+          "net_amount_kobo": 300000, "amount_paid_kobo": 300000,
+          "completed_at_null": true
+        },
+        "items": [{ "product": "P1", "quantity": 3, "unit_price_kobo": 100000, "total_kobo": 300000, "buying_price_kobo": 50000 }],
+        "batches_remaining": [{ "product": "P1", "received_at": "2026-01-01", "qty_remaining": 17 }],
+        "inventory_after": [{ "product": "P1", "quantity": 97 }],
+        "product_scalar_cost": [{ "product": "P1", "buying_price_kobo": 50000 }],
+        "payment": { "method": "cash", "amount_kobo": 300000 },
+        "wallet_legs": [
+          { "reference_type": "order_payment", "signed_amount_kobo": -300000 },
+          { "reference_type": "topup_cash", "signed_amount_kobo": 300000 }
+        ],
+        "customer_balance_after_kobo": 0
+      }
+    }
+  ]
+}

--- a/test/golden/fixtures/crate_sale_scenarios.json
+++ b/test/golden/fixtures/crate_sale_scenarios.json
@@ -1,0 +1,279 @@
+{
+  "_doc": [
+    "Golden-Scenario Suite fixtures for the Web POS Slice 4 empty-crate ledger at",
+    "checkout (PRD web-pos, ADR 0009, issue #45). Each fixture attaches a",
+    "REGISTERED customer at a crate-eligible business (business_type +",
+    "tracks_empty_crates) and sells deposit-bearing product; the SAME fixtures run",
+    "against BOTH implementations of the money+crate rule:",
+    "  * the Dart DAO path (mobile)  — test/golden/dart_dao_golden_test.dart (offline)",
+    "  * the SQL checkout_order RPC  — test/integration/rpcs/checkout_order_golden_test.dart",
+    "Any drift on the crate rows (order_crate_lines / 'issued' crate_ledger /",
+    "customer_crate_balances) — or on the money legs — fails CI. A product with a",
+    "'manufacturer' key is seeded as a crate-eligible bottle (unit 'Bottle',",
+    "track_empties on) whose manufacturer carries a per-crate deposit RATE; the",
+    "sale snapshots that rate onto order_crate_lines. deposit_paid is 0 — the web",
+    "crate-track path collects no deposit money at checkout (§13.4). Amounts are",
+    "*_kobo (bigint). These are also registered sales, so the wallet legs + derived",
+    "balance are asserted too (order_payment debit + topup_cash credit, balance",
+    "unchanged on a fully-paid cash sale)."
+  ],
+  "scenarios": [
+    {
+      "name": "single deposit-bearing line posts crate legs (issued + balance) at a crate business",
+      "business_type": "Beverage distributor",
+      "tracks_empty_crates": true,
+      "manufacturers": [{ "key": "M1", "name": "Star Co", "deposit_rate_kobo": 50000 }],
+      "customer": { "opening_balance_kobo": 0, "debt_limit_kobo": 0 },
+      "products": [
+        { "key": "P1", "name": "Star 60cl", "unit_price_kobo": 100000, "scalar_cost_kobo": 50000, "manufacturer": "M1" }
+      ],
+      "inventory": [{ "product": "P1", "quantity": 100 }],
+      "batches": [{ "product": "P1", "qty": 20, "cost_kobo": 50000, "received_at": "2026-01-01" }],
+      "checkout": {
+        "payment_method": "cash",
+        "discount_kobo": 0,
+        "amount_paid_kobo": 300000,
+        "items": [{ "product": "P1", "quantity": 3 }]
+      },
+      "expected": {
+        "order": {
+          "status": "pending", "payment_type": "cash",
+          "total_amount_kobo": 300000, "discount_kobo": 0,
+          "net_amount_kobo": 300000, "amount_paid_kobo": 300000,
+          "completed_at_null": true
+        },
+        "items": [{ "product": "P1", "quantity": 3, "unit_price_kobo": 100000, "total_kobo": 300000, "buying_price_kobo": 50000 }],
+        "batches_remaining": [{ "product": "P1", "received_at": "2026-01-01", "qty_remaining": 17 }],
+        "inventory_after": [{ "product": "P1", "quantity": 97 }],
+        "product_scalar_cost": [{ "product": "P1", "buying_price_kobo": 50000 }],
+        "payment": { "method": "cash", "amount_kobo": 300000 },
+        "wallet_legs": [
+          { "reference_type": "order_payment", "signed_amount_kobo": -300000 },
+          { "reference_type": "topup_cash", "signed_amount_kobo": 300000 }
+        ],
+        "customer_balance_after_kobo": 0,
+        "crate_lines": [{ "manufacturer": "M1", "crates_taken": 3, "deposit_rate_kobo": 50000, "deposit_paid_kobo": 0 }],
+        "crate_ledger": [{ "manufacturer": "M1", "quantity_delta": 3 }],
+        "crate_balances": [{ "manufacturer": "M1", "balance": 3 }]
+      }
+    },
+    {
+      "name": "two manufacturers each draw their own crate line, ledger row and balance",
+      "business_type": "Bar",
+      "tracks_empty_crates": true,
+      "manufacturers": [
+        { "key": "M1", "name": "Star Co", "deposit_rate_kobo": 50000 },
+        { "key": "M2", "name": "Guinness Co", "deposit_rate_kobo": 60000 }
+      ],
+      "customer": { "opening_balance_kobo": 0, "debt_limit_kobo": 0 },
+      "products": [
+        { "key": "P1", "name": "Star 60cl", "unit_price_kobo": 100000, "scalar_cost_kobo": 50000, "manufacturer": "M1" },
+        { "key": "P2", "name": "Guinness 60cl", "unit_price_kobo": 120000, "scalar_cost_kobo": 70000, "manufacturer": "M2" }
+      ],
+      "inventory": [
+        { "product": "P1", "quantity": 100 },
+        { "product": "P2", "quantity": 100 }
+      ],
+      "batches": [
+        { "product": "P1", "qty": 20, "cost_kobo": 50000, "received_at": "2026-01-01" },
+        { "product": "P2", "qty": 20, "cost_kobo": 70000, "received_at": "2026-01-01" }
+      ],
+      "checkout": {
+        "payment_method": "cash",
+        "discount_kobo": 0,
+        "amount_paid_kobo": 540000,
+        "items": [
+          { "product": "P1", "quantity": 3 },
+          { "product": "P2", "quantity": 2 }
+        ]
+      },
+      "expected": {
+        "order": {
+          "status": "pending", "payment_type": "cash",
+          "total_amount_kobo": 540000, "discount_kobo": 0,
+          "net_amount_kobo": 540000, "amount_paid_kobo": 540000,
+          "completed_at_null": true
+        },
+        "items": [
+          { "product": "P1", "quantity": 3, "unit_price_kobo": 100000, "total_kobo": 300000, "buying_price_kobo": 50000 },
+          { "product": "P2", "quantity": 2, "unit_price_kobo": 120000, "total_kobo": 240000, "buying_price_kobo": 70000 }
+        ],
+        "batches_remaining": [
+          { "product": "P1", "received_at": "2026-01-01", "qty_remaining": 17 },
+          { "product": "P2", "received_at": "2026-01-01", "qty_remaining": 18 }
+        ],
+        "inventory_after": [
+          { "product": "P1", "quantity": 97 },
+          { "product": "P2", "quantity": 98 }
+        ],
+        "product_scalar_cost": [
+          { "product": "P1", "buying_price_kobo": 50000 },
+          { "product": "P2", "buying_price_kobo": 70000 }
+        ],
+        "payment": { "method": "cash", "amount_kobo": 540000 },
+        "wallet_legs": [
+          { "reference_type": "order_payment", "signed_amount_kobo": -540000 },
+          { "reference_type": "topup_cash", "signed_amount_kobo": 540000 }
+        ],
+        "customer_balance_after_kobo": 0,
+        "crate_lines": [
+          { "manufacturer": "M1", "crates_taken": 3, "deposit_rate_kobo": 50000, "deposit_paid_kobo": 0 },
+          { "manufacturer": "M2", "crates_taken": 2, "deposit_rate_kobo": 60000, "deposit_paid_kobo": 0 }
+        ],
+        "crate_ledger": [
+          { "manufacturer": "M1", "quantity_delta": 3 },
+          { "manufacturer": "M2", "quantity_delta": 2 }
+        ],
+        "crate_balances": [
+          { "manufacturer": "M1", "balance": 3 },
+          { "manufacturer": "M2", "balance": 2 }
+        ]
+      }
+    },
+    {
+      "name": "mixed cart: only the deposit-bearing bottle posts crate legs (no double-count with the non-crate line)",
+      "business_type": "Beverage distributor",
+      "tracks_empty_crates": true,
+      "manufacturers": [{ "key": "M1", "name": "Star Co", "deposit_rate_kobo": 50000 }],
+      "customer": { "opening_balance_kobo": 0, "debt_limit_kobo": 0 },
+      "products": [
+        { "key": "P1", "name": "Star 60cl", "unit_price_kobo": 100000, "scalar_cost_kobo": 50000, "manufacturer": "M1" },
+        { "key": "P2", "name": "Plantain Chips", "unit_price_kobo": 20000, "scalar_cost_kobo": 8000 }
+      ],
+      "inventory": [
+        { "product": "P1", "quantity": 100 },
+        { "product": "P2", "quantity": 100 }
+      ],
+      "batches": [
+        { "product": "P1", "qty": 20, "cost_kobo": 50000, "received_at": "2026-01-01" },
+        { "product": "P2", "qty": 20, "cost_kobo": 8000, "received_at": "2026-01-01" }
+      ],
+      "checkout": {
+        "payment_method": "cash",
+        "discount_kobo": 0,
+        "amount_paid_kobo": 300000,
+        "items": [
+          { "product": "P1", "quantity": 2 },
+          { "product": "P2", "quantity": 5 }
+        ]
+      },
+      "expected": {
+        "order": {
+          "status": "pending", "payment_type": "cash",
+          "total_amount_kobo": 300000, "discount_kobo": 0,
+          "net_amount_kobo": 300000, "amount_paid_kobo": 300000,
+          "completed_at_null": true
+        },
+        "items": [
+          { "product": "P1", "quantity": 2, "unit_price_kobo": 100000, "total_kobo": 200000, "buying_price_kobo": 50000 },
+          { "product": "P2", "quantity": 5, "unit_price_kobo": 20000, "total_kobo": 100000, "buying_price_kobo": 8000 }
+        ],
+        "batches_remaining": [
+          { "product": "P1", "received_at": "2026-01-01", "qty_remaining": 18 },
+          { "product": "P2", "received_at": "2026-01-01", "qty_remaining": 15 }
+        ],
+        "inventory_after": [
+          { "product": "P1", "quantity": 98 },
+          { "product": "P2", "quantity": 95 }
+        ],
+        "product_scalar_cost": [
+          { "product": "P1", "buying_price_kobo": 50000 },
+          { "product": "P2", "buying_price_kobo": 8000 }
+        ],
+        "payment": { "method": "cash", "amount_kobo": 300000 },
+        "wallet_legs": [
+          { "reference_type": "order_payment", "signed_amount_kobo": -300000 },
+          { "reference_type": "topup_cash", "signed_amount_kobo": 300000 }
+        ],
+        "customer_balance_after_kobo": 0,
+        "crate_lines": [{ "manufacturer": "M1", "crates_taken": 2, "deposit_rate_kobo": 50000, "deposit_paid_kobo": 0 }],
+        "crate_ledger": [{ "manufacturer": "M1", "quantity_delta": 2 }],
+        "crate_balances": [{ "manufacturer": "M1", "balance": 2 }]
+      }
+    },
+    {
+      "name": "two lines of one deposit-bearing product sum into a single crate line",
+      "business_type": "Bar",
+      "tracks_empty_crates": true,
+      "manufacturers": [{ "key": "M1", "name": "Star Co", "deposit_rate_kobo": 50000 }],
+      "customer": { "opening_balance_kobo": 0, "debt_limit_kobo": 0 },
+      "products": [
+        { "key": "P1", "name": "Star 60cl", "unit_price_kobo": 100000, "scalar_cost_kobo": 50000, "manufacturer": "M1" }
+      ],
+      "inventory": [{ "product": "P1", "quantity": 100 }],
+      "batches": [{ "product": "P1", "qty": 20, "cost_kobo": 50000, "received_at": "2026-01-01" }],
+      "checkout": {
+        "payment_method": "cash",
+        "discount_kobo": 0,
+        "amount_paid_kobo": 500000,
+        "items": [
+          { "product": "P1", "quantity": 3 },
+          { "product": "P1", "quantity": 2 }
+        ]
+      },
+      "expected": {
+        "order": {
+          "status": "pending", "payment_type": "cash",
+          "total_amount_kobo": 500000, "discount_kobo": 0,
+          "net_amount_kobo": 500000, "amount_paid_kobo": 500000,
+          "completed_at_null": true
+        },
+        "items": [
+          { "product": "P1", "quantity": 3, "unit_price_kobo": 100000, "total_kobo": 300000, "buying_price_kobo": 50000 },
+          { "product": "P1", "quantity": 2, "unit_price_kobo": 100000, "total_kobo": 200000, "buying_price_kobo": 50000 }
+        ],
+        "batches_remaining": [{ "product": "P1", "received_at": "2026-01-01", "qty_remaining": 15 }],
+        "inventory_after": [{ "product": "P1", "quantity": 95 }],
+        "product_scalar_cost": [{ "product": "P1", "buying_price_kobo": 50000 }],
+        "payment": { "method": "cash", "amount_kobo": 500000 },
+        "wallet_legs": [
+          { "reference_type": "order_payment", "signed_amount_kobo": -500000 },
+          { "reference_type": "topup_cash", "signed_amount_kobo": 500000 }
+        ],
+        "customer_balance_after_kobo": 0,
+        "crate_lines": [{ "manufacturer": "M1", "crates_taken": 5, "deposit_rate_kobo": 50000, "deposit_paid_kobo": 0 }],
+        "crate_ledger": [{ "manufacturer": "M1", "quantity_delta": 5 }],
+        "crate_balances": [{ "manufacturer": "M1", "balance": 5 }]
+      }
+    },
+    {
+      "name": "crate gate OFF (tracks_empty_crates false) posts no crate legs even for a bottle",
+      "business_type": "Bar",
+      "tracks_empty_crates": false,
+      "manufacturers": [{ "key": "M1", "name": "Star Co", "deposit_rate_kobo": 50000 }],
+      "customer": { "opening_balance_kobo": 0, "debt_limit_kobo": 0 },
+      "products": [
+        { "key": "P1", "name": "Star 60cl", "unit_price_kobo": 100000, "scalar_cost_kobo": 50000, "manufacturer": "M1" }
+      ],
+      "inventory": [{ "product": "P1", "quantity": 100 }],
+      "batches": [{ "product": "P1", "qty": 20, "cost_kobo": 50000, "received_at": "2026-01-01" }],
+      "checkout": {
+        "payment_method": "cash",
+        "discount_kobo": 0,
+        "amount_paid_kobo": 300000,
+        "items": [{ "product": "P1", "quantity": 3 }]
+      },
+      "expected": {
+        "order": {
+          "status": "pending", "payment_type": "cash",
+          "total_amount_kobo": 300000, "discount_kobo": 0,
+          "net_amount_kobo": 300000, "amount_paid_kobo": 300000,
+          "completed_at_null": true
+        },
+        "items": [{ "product": "P1", "quantity": 3, "unit_price_kobo": 100000, "total_kobo": 300000, "buying_price_kobo": 50000 }],
+        "batches_remaining": [{ "product": "P1", "received_at": "2026-01-01", "qty_remaining": 17 }],
+        "inventory_after": [{ "product": "P1", "quantity": 97 }],
+        "product_scalar_cost": [{ "product": "P1", "buying_price_kobo": 50000 }],
+        "payment": { "method": "cash", "amount_kobo": 300000 },
+        "wallet_legs": [
+          { "reference_type": "order_payment", "signed_amount_kobo": -300000 },
+          { "reference_type": "topup_cash", "signed_amount_kobo": 300000 }
+        ],
+        "customer_balance_after_kobo": 0,
+        "crate_lines": [],
+        "crate_ledger": [],
+        "crate_balances": []
+      }
+    }
+  ]
+}

--- a/test/golden/golden_scenario.dart
+++ b/test/golden/golden_scenario.dart
@@ -1,0 +1,567 @@
+/// The Golden-Scenario Suite model + comparator (ADR 0009, issue #43).
+///
+/// One set of fixtures (input state → expected resulting rows) drives BOTH
+/// implementations of the cash/transfer checkout money rule:
+///   * the Dart DAO path (mobile)      — test/golden/dart_dao_golden_test.dart
+///   * the SQL `checkout_order` RPC     — test/integration/rpcs/checkout_order_golden_test.dart
+/// Each runner seeds the fixture, performs its own checkout, collects the
+/// resulting rows into a [CheckoutOutcome], and calls [expectGolden]. Any drift
+/// between the two implementations fails the build — the anti-divergence
+/// mechanism that keeps the money math identical across clients.
+///
+/// The order NUMBER scheme is deliberately divergent per client (mobile
+/// `ORD-…`, web `WEB-…`, both collision-proof against the other), so the
+/// comparator asserts each runner's own [orderNumberScheme] regex, never
+/// equality. Everything else — totals, per-line FIFO COGS, batch remainders,
+/// stock levels, the scalar cost cache, revenue status — must match exactly.
+library;
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+// ─── Fixtures (input) ────────────────────────────────────────────────────────
+
+class FxProduct {
+  final String key;
+  final String name;
+  final int unitPriceKobo;
+  final int scalarCostKobo;
+
+  /// Crate fixtures only (Slice 4, #45): the manufacturer whose returnable
+  /// empties this product carries. When set, the runners seed the product as a
+  /// crate-eligible bottle (unit 'Bottle', track_empties on) with this
+  /// manufacturer; null (the cash/credit fixtures) ⇒ a plain non-crate product.
+  final String? manufacturerKey;
+  FxProduct(this.key, this.name, this.unitPriceKobo, this.scalarCostKobo,
+      {this.manufacturerKey});
+}
+
+/// A manufacturer with a per-crate deposit rate (Manufacturers.depositAmountKobo).
+/// The crate scenarios snapshot this rate onto order_crate_lines at sale time.
+class FxManufacturer {
+  final String key;
+  final String name;
+  final int depositRateKobo;
+  FxManufacturer(this.key, this.name, this.depositRateKobo);
+}
+
+class FxInventory {
+  final String productKey;
+  final int quantity;
+  FxInventory(this.productKey, this.quantity);
+}
+
+class FxBatch {
+  final String productKey;
+  final int qty;
+  final int costKobo;
+
+  /// Date-only string, e.g. "2026-01-01" — unique per product within a fixture,
+  /// so it doubles as the batch's stable key for the remainder assertion.
+  final String receivedAt;
+  FxBatch(this.productKey, this.qty, this.costKobo, this.receivedAt);
+
+  DateTime get receivedAtUtc {
+    final parts = receivedAt.split('-').map(int.parse).toList();
+    return DateTime.utc(parts[0], parts[1], parts[2]);
+  }
+}
+
+class FxCheckoutLine {
+  final String productKey;
+  final int quantity;
+  FxCheckoutLine(this.productKey, this.quantity);
+}
+
+class FxCheckout {
+  final String paymentMethod; // 'cash' | 'transfer' | 'credit' | 'wallet'
+  final int discountKobo;
+  final int amountPaidKobo;
+  final List<FxCheckoutLine> items;
+  FxCheckout(this.paymentMethod, this.discountKobo, this.amountPaidKobo,
+      this.items);
+}
+
+/// A registered customer attached to a credit/wallet scenario (Slice 3, #44).
+/// [openingBalanceKobo] is seeded as one `topup_cash` credit BEFORE the sale, so
+/// a Pay-with-Credit draw has an existing balance to spend. Absent ⇒ walk-in.
+class FxCustomer {
+  final int openingBalanceKobo;
+  final int debtLimitKobo;
+  FxCustomer(this.openingBalanceKobo, this.debtLimitKobo);
+}
+
+// ─── Expected (output) ───────────────────────────────────────────────────────
+
+class ExpectedOrder {
+  final String status;
+  final String paymentType;
+  final int totalAmountKobo;
+  final int discountKobo;
+  final int netAmountKobo;
+  final int amountPaidKobo;
+  final bool completedAtNull;
+  ExpectedOrder(Map<String, dynamic> j)
+      : status = j['status'] as String,
+        paymentType = j['payment_type'] as String,
+        totalAmountKobo = j['total_amount_kobo'] as int,
+        discountKobo = j['discount_kobo'] as int,
+        netAmountKobo = j['net_amount_kobo'] as int,
+        amountPaidKobo = j['amount_paid_kobo'] as int,
+        completedAtNull = j['completed_at_null'] as bool;
+}
+
+/// A per-line money tuple, order-independent — the runners may return lines in
+/// any order, so [expectGolden] compares the multiset of these.
+class ExpectedItem {
+  final String productKey;
+  final int quantity;
+  final int unitPriceKobo;
+  final int totalKobo;
+  final int buyingPriceKobo;
+  ExpectedItem(Map<String, dynamic> j)
+      : productKey = j['product'] as String,
+        quantity = j['quantity'] as int,
+        unitPriceKobo = j['unit_price_kobo'] as int,
+        totalKobo = j['total_kobo'] as int,
+        buyingPriceKobo = j['buying_price_kobo'] as int;
+
+  String get signature =>
+      '$productKey|$quantity|$unitPriceKobo|$totalKobo|$buyingPriceKobo';
+}
+
+class ExpectedPayment {
+  final String method;
+  final int amountKobo;
+  ExpectedPayment(Map<String, dynamic> j)
+      : method = j['method'] as String,
+        amountKobo = j['amount_kobo'] as int;
+}
+
+/// One wallet ledger leg the checkout is expected to post (Slice 3). Compared as
+/// a multiset by [signature] — the two runners may return legs in any order. The
+/// seeded opening-balance leg is excluded (runners collect only legs whose
+/// order_id is this sale's).
+class ExpectedWalletLeg {
+  final String referenceType;
+  final int signedAmountKobo;
+  ExpectedWalletLeg(Map<String, dynamic> j)
+      : referenceType = j['reference_type'] as String,
+        signedAmountKobo = j['signed_amount_kobo'] as int;
+
+  String get signature => '$referenceType|$signedAmountKobo';
+}
+
+/// One expected order_crate_lines row (Slice 4, #45): the crates the customer
+/// took for a manufacturer, the deposit RATE snapshot (from the manufacturer),
+/// and the deposit PAID (0 on the web crate-track path). Keyed by manufacturer.
+class ExpectedCrateLine {
+  final int cratesTaken;
+  final int depositRateKobo;
+  final int depositPaidKobo;
+  ExpectedCrateLine(Map<String, dynamic> j)
+      : cratesTaken = j['crates_taken'] as int,
+        depositRateKobo = j['deposit_rate_kobo'] as int,
+        depositPaidKobo = j['deposit_paid_kobo'] as int;
+
+  String get signature => '$cratesTaken|$depositRateKobo|$depositPaidKobo';
+}
+
+class GoldenScenario {
+  final String name;
+
+  /// The attached registered customer, or null for a walk-in cash sale (the
+  /// Slice 2 fixtures). When set, the runners seed a customer + wallet and assert
+  /// the wallet legs + derived balance.
+  final FxCustomer? customer;
+
+  /// Crate fixtures (Slice 4, #45). [businessType] drives isCrateBusiness and
+  /// [tracksEmptyCrates] the opt-in — together the crate gate. [manufacturers]
+  /// carry the per-crate deposit rates. Cash/credit fixtures leave these at the
+  /// non-crate defaults (null type ⇒ crate block never fires).
+  final String? businessType;
+  final bool tracksEmptyCrates;
+  final List<FxManufacturer> manufacturers;
+  final List<FxProduct> products;
+  final List<FxInventory> inventory;
+  final List<FxBatch> batches;
+  final FxCheckout checkout;
+  final ExpectedOrder expectedOrder;
+  final List<ExpectedItem> expectedItems;
+
+  /// key "productKey|receivedAt" → expected qty_remaining.
+  final Map<String, int> expectedBatchRemaining;
+
+  /// productKey → expected on-hand after the sale.
+  final Map<String, int> expectedInventory;
+
+  /// productKey → expected recomputed scalar buying_price_kobo cache.
+  final Map<String, int> expectedScalarCost;
+
+  /// The expected cash payment row, or null when the sale settled no cash (a
+  /// pay-with-credit / pure credit sale posts no payment_transactions row).
+  final ExpectedPayment? expectedPayment;
+
+  /// The wallet legs the sale is expected to post (empty for a walk-in).
+  final List<ExpectedWalletLeg> expectedWalletLegs;
+
+  /// The customer's derived spendable balance after the sale, or null (walk-in).
+  final int? expectedCustomerBalanceAfterKobo;
+
+  /// Crate expectations (Slice 4, #45), all keyed by manufacturer (a scenario has
+  /// one customer). Empty for cash/credit fixtures — the runners collect empty
+  /// maps too, so the assertion is a no-op there.
+  ///   manufacturerKey → expected order_crate_lines row.
+  final Map<String, ExpectedCrateLine> expectedCrateLines;
+
+  /// manufacturerKey → expected summed 'issued' crate_ledger quantity_delta.
+  final Map<String, int> expectedCrateLedgerIssued;
+
+  /// manufacturerKey → expected customer_crate_balances.balance after the sale.
+  final Map<String, int> expectedCrateBalances;
+
+  GoldenScenario._({
+    required this.name,
+    required this.customer,
+    required this.businessType,
+    required this.tracksEmptyCrates,
+    required this.manufacturers,
+    required this.products,
+    required this.inventory,
+    required this.batches,
+    required this.checkout,
+    required this.expectedOrder,
+    required this.expectedItems,
+    required this.expectedBatchRemaining,
+    required this.expectedInventory,
+    required this.expectedScalarCost,
+    required this.expectedPayment,
+    required this.expectedWalletLegs,
+    required this.expectedCustomerBalanceAfterKobo,
+    required this.expectedCrateLines,
+    required this.expectedCrateLedgerIssued,
+    required this.expectedCrateBalances,
+  });
+
+  FxProduct product(String key) => products.firstWhere((p) => p.key == key);
+
+  factory GoldenScenario._fromJson(Map<String, dynamic> j) {
+    final exp = j['expected'] as Map<String, dynamic>;
+
+    final batchRemaining = <String, int>{};
+    for (final b in (exp['batches_remaining'] as List)) {
+      final m = b as Map<String, dynamic>;
+      batchRemaining['${m['product']}|${m['received_at']}'] =
+          m['qty_remaining'] as int;
+    }
+    final inv = <String, int>{};
+    for (final r in (exp['inventory_after'] as List)) {
+      final m = r as Map<String, dynamic>;
+      inv[m['product'] as String] = m['quantity'] as int;
+    }
+    final scalar = <String, int>{};
+    for (final r in (exp['product_scalar_cost'] as List)) {
+      final m = r as Map<String, dynamic>;
+      scalar[m['product'] as String] = m['buying_price_kobo'] as int;
+    }
+
+    final customerJson = j['customer'] as Map<String, dynamic>?;
+    final paymentJson = exp['payment'] as Map<String, dynamic>?;
+
+    final crateLines = <String, ExpectedCrateLine>{};
+    for (final r in ((exp['crate_lines'] as List?) ?? const [])) {
+      final m = r as Map<String, dynamic>;
+      crateLines[m['manufacturer'] as String] = ExpectedCrateLine(m);
+    }
+    final crateLedger = <String, int>{};
+    for (final r in ((exp['crate_ledger'] as List?) ?? const [])) {
+      final m = r as Map<String, dynamic>;
+      crateLedger[m['manufacturer'] as String] = m['quantity_delta'] as int;
+    }
+    final crateBalances = <String, int>{};
+    for (final r in ((exp['crate_balances'] as List?) ?? const [])) {
+      final m = r as Map<String, dynamic>;
+      crateBalances[m['manufacturer'] as String] = m['balance'] as int;
+    }
+
+    return GoldenScenario._(
+      name: j['name'] as String,
+      customer: customerJson == null
+          ? null
+          : FxCustomer(customerJson['opening_balance_kobo'] as int,
+              customerJson['debt_limit_kobo'] as int),
+      businessType: j['business_type'] as String?,
+      tracksEmptyCrates: j['tracks_empty_crates'] as bool? ?? true,
+      manufacturers: ((j['manufacturers'] as List?) ?? const [])
+          .map((m) => FxManufacturer(m['key'] as String, m['name'] as String,
+              m['deposit_rate_kobo'] as int))
+          .toList(),
+      products: (j['products'] as List)
+          .map((p) => FxProduct(p['key'] as String, p['name'] as String,
+              p['unit_price_kobo'] as int, p['scalar_cost_kobo'] as int,
+              manufacturerKey: p['manufacturer'] as String?))
+          .toList(),
+      inventory: (j['inventory'] as List)
+          .map((r) =>
+              FxInventory(r['product'] as String, r['quantity'] as int))
+          .toList(),
+      batches: (j['batches'] as List)
+          .map((b) => FxBatch(b['product'] as String, b['qty'] as int,
+              b['cost_kobo'] as int, b['received_at'] as String))
+          .toList(),
+      checkout: FxCheckout(
+        j['checkout']['payment_method'] as String,
+        j['checkout']['discount_kobo'] as int,
+        j['checkout']['amount_paid_kobo'] as int,
+        (j['checkout']['items'] as List)
+            .map((i) =>
+                FxCheckoutLine(i['product'] as String, i['quantity'] as int))
+            .toList(),
+      ),
+      expectedOrder: ExpectedOrder(exp['order'] as Map<String, dynamic>),
+      expectedItems: (exp['items'] as List)
+          .map((i) => ExpectedItem(i as Map<String, dynamic>))
+          .toList(),
+      expectedBatchRemaining: batchRemaining,
+      expectedInventory: inv,
+      expectedScalarCost: scalar,
+      expectedPayment:
+          paymentJson == null ? null : ExpectedPayment(paymentJson),
+      expectedWalletLegs: ((exp['wallet_legs'] as List?) ?? const [])
+          .map((l) => ExpectedWalletLeg(l as Map<String, dynamic>))
+          .toList(),
+      expectedCustomerBalanceAfterKobo:
+          exp['customer_balance_after_kobo'] as int?,
+      expectedCrateLines: crateLines,
+      expectedCrateLedgerIssued: crateLedger,
+      expectedCrateBalances: crateBalances,
+    );
+  }
+}
+
+/// Loads every scenario from a fixtures file under test/golden/fixtures/.
+/// Relative to the package root, where `flutter test` runs.
+List<GoldenScenario> _loadScenarios(String fileName) {
+  final raw =
+      File('test/golden/fixtures/$fileName').readAsStringSync();
+  final json = jsonDecode(raw) as Map<String, dynamic>;
+  return (json['scenarios'] as List)
+      .map((s) => GoldenScenario._fromJson(s as Map<String, dynamic>))
+      .toList();
+}
+
+/// The cash/credit/wallet scenarios (Slices 2–3).
+List<GoldenScenario> loadCashSaleScenarios() =>
+    _loadScenarios('cash_sale_scenarios.json');
+
+/// The empty-crate scenarios (Slice 4, #45). Each attaches a registered customer
+/// at a crate-eligible business and asserts the crate ledger movements.
+List<GoldenScenario> loadCrateSaleScenarios() =>
+    _loadScenarios('crate_sale_scenarios.json');
+
+// ─── Actual (a runner's result, in fixture terms) ────────────────────────────
+
+class ActualOrder {
+  final String status;
+  final String paymentType;
+  final int totalAmountKobo;
+  final int discountKobo;
+  final int netAmountKobo;
+  final int amountPaidKobo;
+  final bool completedAtNull;
+  ActualOrder({
+    required this.status,
+    required this.paymentType,
+    required this.totalAmountKobo,
+    required this.discountKobo,
+    required this.netAmountKobo,
+    required this.amountPaidKobo,
+    required this.completedAtNull,
+  });
+}
+
+class ActualItem {
+  final String productKey;
+  final int quantity;
+  final int unitPriceKobo;
+  final int totalKobo;
+  final int buyingPriceKobo;
+  ActualItem({
+    required this.productKey,
+    required this.quantity,
+    required this.unitPriceKobo,
+    required this.totalKobo,
+    required this.buyingPriceKobo,
+  });
+  String get signature =>
+      '$productKey|$quantity|$unitPriceKobo|$totalKobo|$buyingPriceKobo';
+}
+
+class ActualPayment {
+  final String method;
+  final int amountKobo;
+  ActualPayment({required this.method, required this.amountKobo});
+}
+
+/// One posted wallet leg, in fixture terms. Compared by [signature].
+class ActualWalletLeg {
+  final String referenceType;
+  final int signedAmountKobo;
+  ActualWalletLeg(
+      {required this.referenceType, required this.signedAmountKobo});
+  String get signature => '$referenceType|$signedAmountKobo';
+}
+
+/// One posted order_crate_lines row, in fixture terms (Slice 4).
+class ActualCrateLine {
+  final int cratesTaken;
+  final int depositRateKobo;
+  final int depositPaidKobo;
+  ActualCrateLine({
+    required this.cratesTaken,
+    required this.depositRateKobo,
+    required this.depositPaidKobo,
+  });
+  String get signature => '$cratesTaken|$depositRateKobo|$depositPaidKobo';
+}
+
+/// One checkout's resulting rows, translated back into fixture terms (product
+/// keys, not real ids) so it can be compared to a [GoldenScenario].
+class CheckoutOutcome {
+  final String orderNumber;
+  final ActualOrder order;
+  final List<ActualItem> items;
+
+  /// key "productKey|receivedAt" → qty_remaining.
+  final Map<String, int> batchRemaining;
+
+  /// productKey → on-hand after the sale.
+  final Map<String, int> inventoryAfter;
+
+  /// productKey → scalar buying_price_kobo cache.
+  final Map<String, int> productScalarCost;
+
+  /// The cash payment row, or null when the sale settled no cash.
+  final ActualPayment? payment;
+
+  /// The wallet legs THIS sale posted (order_id == this order); empty walk-in.
+  final List<ActualWalletLeg> walletLegs;
+
+  /// The customer's derived spendable balance after the sale, or null (walk-in).
+  final int? customerBalanceAfter;
+
+  /// Crate rows THIS sale posted, keyed by manufacturerKey (Slice 4). Empty for
+  /// non-crate sales.
+  ///   manufacturerKey → the order_crate_lines row.
+  final Map<String, ActualCrateLine> crateLines;
+
+  /// manufacturerKey → summed 'issued' crate_ledger quantity_delta for this order.
+  final Map<String, int> crateLedgerIssued;
+
+  /// manufacturerKey → customer_crate_balances.balance after the sale.
+  final Map<String, int> crateBalances;
+
+  CheckoutOutcome({
+    required this.orderNumber,
+    required this.order,
+    required this.items,
+    required this.batchRemaining,
+    required this.inventoryAfter,
+    required this.productScalarCost,
+    required this.payment,
+    this.walletLegs = const [],
+    this.customerBalanceAfter,
+    this.crateLines = const {},
+    this.crateLedgerIssued = const {},
+    this.crateBalances = const {},
+  });
+}
+
+/// The shared assertion. Compares a runner's [CheckoutOutcome] to the fixture's
+/// expectations. [orderNumberScheme] is the runner's own numbering regex
+/// (mobile / web) — the one axis that is meant to differ.
+void expectGolden(
+  GoldenScenario s,
+  CheckoutOutcome actual, {
+  required RegExp orderNumberScheme,
+}) {
+  final e = s.expectedOrder;
+  expect(actual.orderNumber, matches(orderNumberScheme),
+      reason: '${s.name}: order number must match this client\'s scheme');
+  expect(actual.order.status, e.status, reason: '${s.name}: order status');
+  expect(actual.order.paymentType, e.paymentType,
+      reason: '${s.name}: payment_type');
+  expect(actual.order.totalAmountKobo, e.totalAmountKobo,
+      reason: '${s.name}: total_amount_kobo (gross)');
+  expect(actual.order.discountKobo, e.discountKobo,
+      reason: '${s.name}: discount_kobo');
+  expect(actual.order.netAmountKobo, e.netAmountKobo,
+      reason: '${s.name}: net_amount_kobo');
+  expect(actual.order.amountPaidKobo, e.amountPaidKobo,
+      reason: '${s.name}: amount_paid_kobo');
+  expect(actual.order.completedAtNull, e.completedAtNull,
+      reason: '${s.name}: revenue recognized at checkout → completed_at NULL');
+
+  // Per-line money tuples compared as a multiset (order-independent).
+  final expectedSigs = s.expectedItems.map((i) => i.signature).toList()..sort();
+  final actualSigs = actual.items.map((i) => i.signature).toList()..sort();
+  expect(actualSigs, equals(expectedSigs),
+      reason: '${s.name}: order line COGS/totals (product|qty|unit|total|cogs)');
+
+  expect(actual.batchRemaining, equals(s.expectedBatchRemaining),
+      reason: '${s.name}: FIFO batch remainders');
+  expect(actual.inventoryAfter, equals(s.expectedInventory),
+      reason: '${s.name}: inventory after sale');
+  expect(actual.productScalarCost, equals(s.expectedScalarCost),
+      reason: '${s.name}: scalar buying_price_kobo cache');
+
+  // Payment row — a no-cash sale (pay-with-credit / pure credit) posts none.
+  if (s.expectedPayment == null) {
+    expect(actual.payment, isNull,
+        reason: '${s.name}: no cash settled → no payment_transactions row');
+  } else {
+    expect(actual.payment, isNotNull,
+        reason: '${s.name}: expected a payment_transactions row');
+    expect(actual.payment!.method, s.expectedPayment!.method,
+        reason: '${s.name}: payment method');
+    expect(actual.payment!.amountKobo, s.expectedPayment!.amountKobo,
+        reason: '${s.name}: payment amount');
+  }
+
+  // Wallet ledger legs (multiset) + the derived balance — the Slice 3 credit
+  // contract. Walk-in scenarios have no customer and assert neither.
+  final expectedLegSigs = s.expectedWalletLegs.map((l) => l.signature).toList()
+    ..sort();
+  final actualLegSigs = actual.walletLegs.map((l) => l.signature).toList()
+    ..sort();
+  expect(actualLegSigs, equals(expectedLegSigs),
+      reason: '${s.name}: wallet ledger legs (reference_type|signed_amount)');
+  expect(actual.customerBalanceAfter, s.expectedCustomerBalanceAfterKobo,
+      reason: '${s.name}: derived customer balance after the sale');
+
+  // Empty-crate legs (Slice 4, #45) — order_crate_lines, the 'issued' crate
+  // ledger, and the customer_crate_balances, all keyed by manufacturer. Empty
+  // maps for a non-crate sale, so this is a no-op there. order_crate_lines is
+  // compared field-for-field (crates + deposit rate snapshot + deposit paid).
+  final expectedLineSigs = {
+    for (final e in s.expectedCrateLines.entries) e.key: e.value.signature
+  };
+  final actualLineSigs = {
+    for (final e in actual.crateLines.entries) e.key: e.value.signature
+  };
+  expect(actualLineSigs, equals(expectedLineSigs),
+      reason: '${s.name}: order_crate_lines (mfr → crates|rate|paid)');
+  expect(actual.crateLedgerIssued, equals(s.expectedCrateLedgerIssued),
+      reason: '${s.name}: crate_ledger issued movements (mfr → +qty)');
+  expect(actual.crateBalances, equals(s.expectedCrateBalances),
+      reason: '${s.name}: customer_crate_balances after the sale (mfr → balance)');
+}
+
+/// The mobile order-number scheme: `ORD-NNNNNN-XXXXXX` (Crockford base32 tag).
+final RegExp mobileOrderNumberScheme = RegExp(r'^ORD-\d{6}-[0-9A-HJKMNP-TV-Z]{6}$');
+
+/// The web (server-minted) scheme: `WEB-NNNNNN-XXXXXX` (hex tail). The `WEB-`
+/// prefix makes collision with any mobile `ORD-…` number impossible.
+final RegExp webOrderNumberScheme = RegExp(r'^WEB-\d{6}-[0-9A-F]{6}$');

--- a/test/integration/rpcs/checkout_order_golden_test.dart
+++ b/test/integration/rpcs/checkout_order_golden_test.dart
@@ -1,0 +1,442 @@
+@Tags(['integration'])
+library;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reebaplus_pos/core/database/uuid_v7.dart';
+
+import '../../golden/golden_scenario.dart';
+import '../../helpers/supabase_test_clients.dart';
+import '../../helpers/supabase_test_env.dart';
+
+/// Golden-Scenario Suite — the SQL `checkout_order` RPC side (ADR 0009, #43).
+///
+/// Runs the SAME shared fixtures (cash/credit + crate, test/golden/fixtures/*.json)
+/// as the Dart DAO runner (test/golden/dart_dao_golden_test.dart), but against the
+/// server-authoritative `checkout_order` RPC (0135 → 0136 credit → 0137 crate) on
+/// real dev Supabase. Any drift between the two implementations of the money +
+/// crate rule fails the build — the anti-divergence guarantee behind "two
+/// implementations, one contract".
+///
+/// Tier-2: hits live Supabase, auto-skipped when the env vars are absent. Seeds
+/// via the service-role adminClient; invokes the RPC via the signed-in userClient
+/// (the RPC reads auth.uid() for the tenant + permission guards). Every row it
+/// creates is torn down by id (children before parents; FKs into orders: order_
+/// items CASCADE, payment/stock NO ACTION → delete those first).
+final String? _skipReason = (() {
+  try {
+    TestEnv.load();
+    return null;
+  } on StateError catch (e) {
+    return e.message;
+  }
+})();
+
+void main() {
+  late TestClients clients;
+  late String businessId;
+
+  // Per-test ids, torn down after each scenario.
+  String? storeId;
+  final productIds = <String>[];
+  final inventoryIds = <String>[];
+  final batchIds = <String>[];
+  final orderIds = <String>[];
+  final customerIds = <String>[];
+  final walletIds = <String>[];
+  final manufacturerIds = <String>[];
+
+  // The shared env business's original crate settings — crate scenarios flip the
+  // business to crate-eligible for the duration of the sale, then tearDown
+  // restores these so the run leaves the dev business exactly as it found it.
+  String? origBizType;
+  bool? origBizTracks;
+
+  setUpAll(() async {
+    if (_skipReason != null) return;
+    clients = await TestClients.setUp();
+    businessId = clients.env.businessId;
+    final biz = await clients.adminClient
+        .from('businesses')
+        .select('type, tracks_empty_crates')
+        .eq('id', businessId)
+        .single();
+    origBizType = biz['type'] as String?;
+    origBizTracks = biz['tracks_empty_crates'] as bool?;
+  });
+
+  tearDown(() async {
+    if (_skipReason != null) return;
+    // Children before parents. wallet/payment/stock FK into orders is NO ACTION,
+    // so they must go before the order; order_items CASCADE with the order. The
+    // wallet legs (incl. the seeded opening credit) go by customer. Crate rows
+    // (order_crate_lines + the 'issued' crate_ledger) reference the order too, so
+    // they go before it; customer_crate_balances goes with the customer.
+    for (final id in customerIds) {
+      await clients.adminClient.from('wallet_transactions').delete().eq('customer_id', id);
+      await clients.adminClient.from('customer_crate_balances').delete().eq('customer_id', id);
+    }
+    for (final id in orderIds) {
+      await clients.adminClient.from('crate_ledger').delete().eq('reference_order_id', id);
+      await clients.adminClient.from('order_crate_lines').delete().eq('order_id', id);
+      await clients.adminClient.from('stock_transactions').delete().eq('order_id', id);
+      await clients.adminClient.from('payment_transactions').delete().eq('order_id', id);
+      await clients.adminClient.from('orders').delete().eq('id', id);
+    }
+    for (final id in walletIds) {
+      await clients.adminClient.from('customer_wallets').delete().eq('id', id);
+    }
+    for (final id in customerIds) {
+      await clients.adminClient.from('customers').delete().eq('id', id);
+    }
+    for (final id in batchIds) {
+      await clients.adminClient.from('cost_batches').delete().eq('id', id);
+    }
+    for (final id in inventoryIds) {
+      await clients.adminClient.from('inventory').delete().eq('id', id);
+    }
+    for (final id in productIds) {
+      await clients.adminClient.from('products').delete().eq('id', id);
+    }
+    // products FK manufacturer_id → manufacturers, so drop manufacturers after.
+    for (final id in manufacturerIds) {
+      await clients.adminClient.from('manufacturers').delete().eq('id', id);
+    }
+    if (storeId != null) {
+      await clients.adminClient.from('stores').delete().eq('id', storeId!);
+    }
+    // Restore the business's crate settings a crate scenario may have flipped.
+    await clients.adminClient.from('businesses').update({
+      'type': origBizType,
+      'tracks_empty_crates': origBizTracks,
+    }).eq('id', businessId);
+    storeId = null;
+    productIds.clear();
+    inventoryIds.clear();
+    batchIds.clear();
+    orderIds.clear();
+    customerIds.clear();
+    walletIds.clear();
+    manufacturerIds.clear();
+  });
+
+  tearDownAll(() async {
+    if (_skipReason != null) return;
+    await clients.dispose();
+  });
+
+  final scenarios = [...loadCashSaleScenarios(), ...loadCrateSaleScenarios()];
+  for (final scenario in scenarios) {
+    test('golden (checkout_order rpc): ${scenario.name}', () async {
+      final admin = clients.adminClient;
+
+      // ── Seed the input state ────────────────────────────────────────────────
+      final store = UuidV7.generate();
+      storeId = store;
+      await admin.from('stores').insert({
+        'id': store,
+        'business_id': businessId,
+        'name': 'Golden Store',
+      });
+
+      // Slice 4 (#45): a crate scenario flips the (shared) business to
+      // crate-eligible + the empties opt-in for this sale (tearDown restores it),
+      // and registers the manufacturers whose deposit rates the sale snapshots.
+      if (scenario.businessType != null) {
+        await admin.from('businesses').update({
+          'type': scenario.businessType,
+          'tracks_empty_crates': scenario.tracksEmptyCrates,
+        }).eq('id', businessId);
+      }
+      final manufacturerIdByKey = <String, String>{};
+      for (final m in scenario.manufacturers) {
+        final id = UuidV7.generate();
+        manufacturerIdByKey[m.key] = id;
+        manufacturerIds.add(id);
+        await admin.from('manufacturers').insert({
+          'id': id,
+          'business_id': businessId,
+          'name': m.name,
+          'deposit_amount_kobo': m.depositRateKobo,
+        });
+      }
+
+      final productIdByKey = <String, String>{};
+      for (final p in scenario.products) {
+        final id = UuidV7.generate();
+        productIdByKey[p.key] = id;
+        productIds.add(id);
+        // A crate-eligible product (manufacturerKey set) is a returnable bottle
+        // with empties tracking on; everything else is a plain product.
+        final crateEligible = p.manufacturerKey != null;
+        await admin.from('products').insert({
+          'id': id,
+          'business_id': businessId,
+          'name': p.name,
+          'retailer_price_kobo': p.unitPriceKobo,
+          'buying_price_kobo': p.scalarCostKobo,
+          if (crateEligible) 'unit': 'Bottle',
+          if (crateEligible) 'track_empties': true,
+          if (crateEligible)
+            'manufacturer_id': manufacturerIdByKey[p.manufacturerKey],
+        });
+      }
+      for (final inv in scenario.inventory) {
+        final id = UuidV7.generate();
+        inventoryIds.add(id);
+        await admin.from('inventory').insert({
+          'id': id,
+          'business_id': businessId,
+          'product_id': productIdByKey[inv.productKey],
+          'store_id': store,
+          'quantity': inv.quantity,
+        });
+      }
+      // batchId → (productKey, receivedAt) for the remainder assertion.
+      final seededBatches = <(String, String, String)>[];
+      for (final b in scenario.batches) {
+        final id = UuidV7.generate();
+        batchIds.add(id);
+        await admin.from('cost_batches').insert({
+          'id': id,
+          'business_id': businessId,
+          'product_id': productIdByKey[b.productKey],
+          'store_id': store,
+          'qty_remaining': b.qty,
+          'qty_original': b.qty,
+          'cost_kobo': b.costKobo,
+          'received_at': b.receivedAtUtc.toIso8601String(),
+        });
+        seededBatches.add((id, b.productKey, b.receivedAt));
+      }
+
+      // Slice 3 (#44): a registered customer + wallet, seeded with any opening
+      // balance as one topup_cash credit BEFORE the sale. The opening leg has no
+      // order_id, so the per-order leg collection below excludes it.
+      String? customerId;
+      if (scenario.customer != null) {
+        customerId = UuidV7.generate();
+        final walletId = UuidV7.generate();
+        customerIds.add(customerId);
+        walletIds.add(walletId);
+        await admin.from('customers').insert({
+          'id': customerId,
+          'business_id': businessId,
+          'name': 'Credit Customer',
+          'wallet_limit_kobo': scenario.customer!.debtLimitKobo,
+        });
+        await admin.from('customer_wallets').insert({
+          'id': walletId,
+          'business_id': businessId,
+          'customer_id': customerId,
+        });
+        if (scenario.customer!.openingBalanceKobo != 0) {
+          await admin.from('wallet_transactions').insert({
+            'id': UuidV7.generate(),
+            'business_id': businessId,
+            'wallet_id': walletId,
+            'customer_id': customerId,
+            'type': 'credit',
+            'amount_kobo': scenario.customer!.openingBalanceKobo,
+            'signed_amount_kobo': scenario.customer!.openingBalanceKobo,
+            'reference_type': 'topup_cash',
+          });
+        }
+      }
+
+      // ── Perform the checkout via the server-authoritative RPC ──────────────
+      final orderId = UuidV7.generate();
+      orderIds.add(orderId);
+      final gross = scenario.checkout.items.fold<int>(
+          0,
+          (s, l) =>
+              s + scenario.product(l.productKey).unitPriceKobo * l.quantity);
+      final net = gross - scenario.checkout.discountKobo;
+      // Walk-in cash/transfer pays the net; a credit/wallet sale passes exactly
+      // what the fixture tendered (the RPC clamps + routes it).
+      final amountPaid =
+          customerId != null ? scenario.checkout.amountPaidKobo : net;
+
+      await clients.userClient.rpc('checkout_order', params: {
+        'p_business_id': businessId,
+        'p_order_id': orderId,
+        'p_store_id': store,
+        'p_items': [
+          for (final l in scenario.checkout.items)
+            {
+              'product_id': productIdByKey[l.productKey],
+              'quantity': l.quantity,
+              'unit_price_kobo': scenario.product(l.productKey).unitPriceKobo,
+            }
+        ],
+        'p_payment_method': scenario.checkout.paymentMethod,
+        'p_amount_paid_kobo': amountPaid,
+        'p_discount_kobo': scenario.checkout.discountKobo,
+        'p_customer_id': customerId,
+      });
+
+      // ── Collect the resulting rows in fixture terms ────────────────────────
+      final keyByProductId = {
+        for (final e in productIdByKey.entries) e.value: e.key
+      };
+
+      final orderRow = await admin
+          .from('orders')
+          .select(
+              'order_number, status, payment_type, total_amount_kobo, discount_kobo, net_amount_kobo, amount_paid_kobo, completed_at')
+          .eq('id', orderId)
+          .single();
+
+      final itemRows = await admin
+          .from('order_items')
+          .select('product_id, quantity, unit_price_kobo, total_kobo, buying_price_kobo')
+          .eq('order_id', orderId);
+
+      final paymentRow = await admin
+          .from('payment_transactions')
+          .select('method, amount_kobo')
+          .eq('order_id', orderId)
+          .eq('type', 'sale')
+          .maybeSingle();
+
+      // Wallet legs THIS sale posted (order_id == this order) + the customer's
+      // derived spendable balance (SUM(signed) excluding the crate-deposit family).
+      const crateDepositRefs = {
+        'crate_deposit',
+        'crate_deposit_refunded',
+        'crate_deposit_forfeited',
+      };
+      final walletLegs = <ActualWalletLeg>[];
+      int? customerBalanceAfter;
+      if (customerId != null) {
+        final legRows = await admin
+            .from('wallet_transactions')
+            .select('reference_type, signed_amount_kobo')
+            .eq('order_id', orderId);
+        for (final l in legRows) {
+          walletLegs.add(ActualWalletLeg(
+            referenceType: l['reference_type'] as String,
+            signedAmountKobo: (l['signed_amount_kobo'] as num).toInt(),
+          ));
+        }
+        final allLegs = await admin
+            .from('wallet_transactions')
+            .select('reference_type, signed_amount_kobo')
+            .eq('customer_id', customerId);
+        customerBalanceAfter = allLegs
+            .where((l) => !crateDepositRefs.contains(l['reference_type']))
+            .fold<int>(
+                0, (s, l) => s + (l['signed_amount_kobo'] as num).toInt());
+      }
+
+      // Crate rows THIS sale posted (Slice 4, #45), keyed by manufacturer.
+      final keyByManufacturerId = {
+        for (final e in manufacturerIdByKey.entries) e.value: e.key
+      };
+      final crateLines = <String, ActualCrateLine>{};
+      final crateLedgerIssued = <String, int>{};
+      final crateBalances = <String, int>{};
+      if (customerId != null && manufacturerIdByKey.isNotEmpty) {
+        final lineRows = await admin
+            .from('order_crate_lines')
+            .select('manufacturer_id, crates_taken, deposit_rate_kobo, deposit_paid_kobo')
+            .eq('order_id', orderId);
+        for (final l in lineRows) {
+          crateLines[keyByManufacturerId[l['manufacturer_id']]!] =
+              ActualCrateLine(
+            cratesTaken: (l['crates_taken'] as num).toInt(),
+            depositRateKobo: (l['deposit_rate_kobo'] as num).toInt(),
+            depositPaidKobo: (l['deposit_paid_kobo'] as num).toInt(),
+          );
+        }
+        final ledgerRows = await admin
+            .from('crate_ledger')
+            .select('manufacturer_id, quantity_delta')
+            .eq('reference_order_id', orderId)
+            .eq('movement_type', 'issued');
+        for (final c in ledgerRows) {
+          final key = keyByManufacturerId[c['manufacturer_id']]!;
+          crateLedgerIssued[key] =
+              (crateLedgerIssued[key] ?? 0) + (c['quantity_delta'] as num).toInt();
+        }
+        final balRows = await admin
+            .from('customer_crate_balances')
+            .select('manufacturer_id, balance')
+            .eq('customer_id', customerId);
+        for (final b in balRows) {
+          crateBalances[keyByManufacturerId[b['manufacturer_id']]!] =
+              (b['balance'] as num).toInt();
+        }
+      }
+
+      final batchRemaining = <String, int>{};
+      for (final (id, productKey, receivedAt) in seededBatches) {
+        final row = await admin
+            .from('cost_batches')
+            .select('qty_remaining')
+            .eq('id', id)
+            .single();
+        batchRemaining['$productKey|$receivedAt'] =
+            (row['qty_remaining'] as num).toInt();
+      }
+
+      final inventoryAfter = <String, int>{};
+      final scalarCost = <String, int>{};
+      for (final entry in productIdByKey.entries) {
+        final invRow = await admin
+            .from('inventory')
+            .select('quantity')
+            .eq('product_id', entry.value)
+            .eq('store_id', store)
+            .maybeSingle();
+        if (invRow != null) {
+          inventoryAfter[entry.key] = (invRow['quantity'] as num).toInt();
+        }
+        final prodRow = await admin
+            .from('products')
+            .select('buying_price_kobo')
+            .eq('id', entry.value)
+            .single();
+        scalarCost[entry.key] = (prodRow['buying_price_kobo'] as num).toInt();
+      }
+
+      final outcome = CheckoutOutcome(
+        orderNumber: orderRow['order_number'] as String,
+        order: ActualOrder(
+          status: orderRow['status'] as String,
+          paymentType: orderRow['payment_type'] as String,
+          totalAmountKobo: (orderRow['total_amount_kobo'] as num).toInt(),
+          discountKobo: (orderRow['discount_kobo'] as num).toInt(),
+          netAmountKobo: (orderRow['net_amount_kobo'] as num).toInt(),
+          amountPaidKobo: (orderRow['amount_paid_kobo'] as num).toInt(),
+          completedAtNull: orderRow['completed_at'] == null,
+        ),
+        items: [
+          for (final i in itemRows)
+            ActualItem(
+              productKey: keyByProductId[i['product_id']]!,
+              quantity: (i['quantity'] as num).toInt(),
+              unitPriceKobo: (i['unit_price_kobo'] as num).toInt(),
+              totalKobo: (i['total_kobo'] as num).toInt(),
+              buyingPriceKobo: (i['buying_price_kobo'] as num).toInt(),
+            ),
+        ],
+        batchRemaining: batchRemaining,
+        inventoryAfter: inventoryAfter,
+        productScalarCost: scalarCost,
+        payment: paymentRow == null
+            ? null
+            : ActualPayment(
+                method: paymentRow['method'] as String,
+                amountKobo: (paymentRow['amount_kobo'] as num).toInt(),
+              ),
+        walletLegs: walletLegs,
+        customerBalanceAfter: customerBalanceAfter,
+        crateLines: crateLines,
+        crateLedgerIssued: crateLedgerIssued,
+        crateBalances: crateBalances,
+      );
+
+      expectGolden(scenario, outcome, orderNumberScheme: webOrderNumberScheme);
+    }, skip: _skipReason);
+  }
+}

--- a/test/integration/rpcs/checkout_order_test.dart
+++ b/test/integration/rpcs/checkout_order_test.dart
@@ -1,0 +1,485 @@
+@Tags(['integration'])
+library;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reebaplus_pos/core/database/uuid_v7.dart';
+
+import '../../helpers/supabase_test_clients.dart';
+import '../../helpers/supabase_test_env.dart';
+
+/// Tier-2 tests for the web-specific server guards of `checkout_order`
+/// (migration 0135, Web POS Slice 2 / issue #43) — the acceptance criteria the
+/// happy-path Golden-Scenario Suite (checkout_order_golden_test) doesn't cover:
+///
+///   * the sale is REJECTED when live stock is insufficient at commit (two
+///     concurrent tills can't oversell);
+///   * the server-minted order number matches `^WEB-…` and can NEVER collide
+///     with a mobile device-tag number (`^ORD-…`);
+///   * the checkout is idempotent on the order id (a replay applies nothing new);
+///   * an order-level discount within the caller's role cap is honored, and the
+///     sale settles at `pending` (revenue recognized at checkout).
+///
+/// Hits real dev Supabase; auto-skipped when env vars are absent. Assumes the
+/// test user is the CEO of TEST_BUSINESS_ID (100% discount cap, sales.make).
+final String? _skipReason = (() {
+  try {
+    TestEnv.load();
+    return null;
+  } on StateError catch (e) {
+    return e.message;
+  }
+})();
+
+void main() {
+  late TestClients clients;
+  late String businessId;
+  late String storeId;
+
+  final productIds = <String>[];
+  final inventoryIds = <String>[];
+  final batchIds = <String>[];
+  final orderIds = <String>[];
+  final customerIds = <String>[];
+  final walletIds = <String>[];
+
+  setUpAll(() async {
+    if (_skipReason != null) return;
+    clients = await TestClients.setUp();
+    businessId = clients.env.businessId;
+    storeId = UuidV7.generate();
+    await clients.adminClient.from('stores').insert({
+      'id': storeId,
+      'business_id': businessId,
+      'name': 'Checkout Guard Store',
+    });
+  });
+
+  tearDown(() async {
+    if (_skipReason != null) return;
+    for (final id in customerIds) {
+      await clients.adminClient.from('wallet_transactions').delete().eq('customer_id', id);
+    }
+    for (final id in orderIds) {
+      await clients.adminClient.from('stock_transactions').delete().eq('order_id', id);
+      await clients.adminClient.from('payment_transactions').delete().eq('order_id', id);
+      await clients.adminClient.from('orders').delete().eq('id', id);
+    }
+    for (final id in walletIds) {
+      await clients.adminClient.from('customer_wallets').delete().eq('id', id);
+    }
+    for (final id in customerIds) {
+      await clients.adminClient.from('customers').delete().eq('id', id);
+    }
+    for (final id in batchIds) {
+      await clients.adminClient.from('cost_batches').delete().eq('id', id);
+    }
+    for (final id in inventoryIds) {
+      await clients.adminClient.from('inventory').delete().eq('id', id);
+    }
+    for (final id in productIds) {
+      await clients.adminClient.from('products').delete().eq('id', id);
+    }
+    orderIds.clear();
+    batchIds.clear();
+    inventoryIds.clear();
+    productIds.clear();
+    customerIds.clear();
+    walletIds.clear();
+  });
+
+  tearDownAll(() async {
+    if (_skipReason != null) return;
+    await clients.adminClient.from('stores').delete().eq('id', storeId);
+    await clients.dispose();
+  });
+
+  Future<String> seedProduct({int scalarCostKobo = 50000}) async {
+    final id = UuidV7.generate();
+    await clients.adminClient.from('products').insert({
+      'id': id,
+      'business_id': businessId,
+      'name': 'Guard Product',
+      'retailer_price_kobo': 100000,
+      'buying_price_kobo': scalarCostKobo,
+    });
+    productIds.add(id);
+    return id;
+  }
+
+  // A registered customer + wallet with a debt limit and an optional opening
+  // balance (seeded as one topup_cash credit).
+  Future<String> seedCustomer({
+    int debtLimitKobo = 0,
+    int openingBalanceKobo = 0,
+  }) async {
+    final customerId = UuidV7.generate();
+    final walletId = UuidV7.generate();
+    customerIds.add(customerId);
+    walletIds.add(walletId);
+    await clients.adminClient.from('customers').insert({
+      'id': customerId,
+      'business_id': businessId,
+      'name': 'Guard Customer',
+      'wallet_limit_kobo': debtLimitKobo,
+    });
+    await clients.adminClient.from('customer_wallets').insert({
+      'id': walletId,
+      'business_id': businessId,
+      'customer_id': customerId,
+    });
+    if (openingBalanceKobo != 0) {
+      await clients.adminClient.from('wallet_transactions').insert({
+        'id': UuidV7.generate(),
+        'business_id': businessId,
+        'wallet_id': walletId,
+        'customer_id': customerId,
+        'type': 'credit',
+        'amount_kobo': openingBalanceKobo,
+        'signed_amount_kobo': openingBalanceKobo,
+        'reference_type': 'topup_cash',
+      });
+    }
+    return customerId;
+  }
+
+  // The customer's derived spendable balance (SUM(signed) excluding deposits).
+  Future<int> balanceOf(String customerId) async {
+    const crateRefs = {
+      'crate_deposit',
+      'crate_deposit_refunded',
+      'crate_deposit_forfeited',
+    };
+    final rows = await clients.adminClient
+        .from('wallet_transactions')
+        .select('reference_type, signed_amount_kobo')
+        .eq('customer_id', customerId);
+    return rows
+        .where((r) => !crateRefs.contains(r['reference_type']))
+        .fold<int>(0, (s, r) => s + (r['signed_amount_kobo'] as num).toInt());
+  }
+
+  Future<void> seedInventory(String productId, int qty) async {
+    final id = UuidV7.generate();
+    await clients.adminClient.from('inventory').insert({
+      'id': id,
+      'business_id': businessId,
+      'product_id': productId,
+      'store_id': storeId,
+      'quantity': qty,
+    });
+    inventoryIds.add(id);
+  }
+
+  Future<void> seedBatch(String productId, int qty, int costKobo) async {
+    final id = UuidV7.generate();
+    await clients.adminClient.from('cost_batches').insert({
+      'id': id,
+      'business_id': businessId,
+      'product_id': productId,
+      'store_id': storeId,
+      'qty_remaining': qty,
+      'qty_original': qty,
+      'cost_kobo': costKobo,
+      'received_at': DateTime.utc(2026, 1, 1).toIso8601String(),
+    });
+    batchIds.add(id);
+  }
+
+  Future<Map<String, dynamic>> checkout({
+    required String orderId,
+    required String productId,
+    required int quantity,
+    int unitPriceKobo = 100000,
+    String method = 'cash',
+    int? amountPaidKobo,
+    int discountKobo = 0,
+    String? customerId,
+  }) async {
+    orderIds.add(orderId);
+    final res = await clients.userClient.rpc('checkout_order', params: {
+      'p_business_id': businessId,
+      'p_order_id': orderId,
+      'p_store_id': storeId,
+      'p_items': [
+        {'product_id': productId, 'quantity': quantity, 'unit_price_kobo': unitPriceKobo}
+      ],
+      'p_payment_method': method,
+      'p_amount_paid_kobo': amountPaidKobo ?? quantity * unitPriceKobo - discountKobo,
+      'p_discount_kobo': discountKobo,
+      'p_customer_id': customerId,
+    });
+    return (res as Map).cast<String, dynamic>();
+  }
+
+  Future<int> onHand(String productId) async {
+    final row = await clients.adminClient
+        .from('inventory')
+        .select('quantity')
+        .eq('product_id', productId)
+        .eq('store_id', storeId)
+        .single();
+    return (row['quantity'] as num).toInt();
+  }
+
+  test('cash sale settles at pending with a WEB- order number, never ORD-', () async {
+    final product = await seedProduct();
+    await seedInventory(product, 10);
+    await seedBatch(product, 10, 50000);
+
+    final res = await checkout(
+        orderId: UuidV7.generate(), productId: product, quantity: 3);
+    final order = res['order'] as Map;
+
+    expect(order['status'], 'pending',
+        reason: 'revenue recognized at checkout, not at confirm');
+    expect(order['completed_at'], isNull);
+    expect(order['order_number'], matches(RegExp(r'^WEB-\d{6}-[0-9A-F]{6}$')));
+    expect(order['order_number'], isNot(startsWith('ORD-')),
+        reason: 'must not collide with the mobile device-tag scheme');
+    expect(res['replayed'], false);
+    expect(await onHand(product), 7, reason: '3 units left the shelf');
+  }, skip: _skipReason);
+
+  test('rejects when live stock is insufficient — no partial write', () async {
+    final product = await seedProduct();
+    await seedInventory(product, 2); // only 2 on hand
+    await seedBatch(product, 2, 50000);
+
+    final orderId = UuidV7.generate();
+    await expectLater(
+      () => checkout(orderId: orderId, productId: product, quantity: 5),
+      throwsA(anything),
+      reason: 'selling 5 against 2 must be rejected at commit',
+    );
+
+    // All-or-nothing: the order never landed and stock is untouched.
+    final order = await clients.adminClient
+        .from('orders')
+        .select('id')
+        .eq('id', orderId)
+        .maybeSingle();
+    expect(order, isNull);
+    expect(await onHand(product), 2);
+  }, skip: _skipReason);
+
+  test('two tills cannot oversell the last units (the concurrency guard)', () async {
+    final product = await seedProduct();
+    await seedInventory(product, 1); // a single unit left
+    await seedBatch(product, 1, 50000);
+
+    // First till takes the unit.
+    await checkout(orderId: UuidV7.generate(), productId: product, quantity: 1);
+    expect(await onHand(product), 0);
+
+    // Second till's checkout for the same unit is rejected.
+    await expectLater(
+      () => checkout(orderId: UuidV7.generate(), productId: product, quantity: 1),
+      throwsA(anything),
+    );
+    expect(await onHand(product), 0, reason: 'never oversold');
+  }, skip: _skipReason);
+
+  test('idempotent replay: same order id twice applies nothing new', () async {
+    final product = await seedProduct();
+    await seedInventory(product, 10);
+    await seedBatch(product, 10, 50000);
+    final orderId = UuidV7.generate();
+
+    final first = await checkout(orderId: orderId, productId: product, quantity: 3);
+    expect(first['replayed'], false);
+    expect(await onHand(product), 7);
+
+    final second = await checkout(orderId: orderId, productId: product, quantity: 3);
+    expect(second['replayed'], true);
+    expect((second['order'] as Map)['order_number'],
+        (first['order'] as Map)['order_number']);
+    expect(await onHand(product), 7, reason: 'stock decremented once, not twice');
+  }, skip: _skipReason);
+
+  test('order-level discount within the role cap reduces net; COGS unaffected',
+      () async {
+    final product = await seedProduct(scalarCostKobo: 50000);
+    await seedInventory(product, 10);
+    await seedBatch(product, 10, 50000);
+
+    // Sell 10 @ ₦1,000 = ₦10,000 gross, ₦500 discount → ₦9,500 net.
+    final res = await checkout(
+      orderId: UuidV7.generate(),
+      productId: product,
+      quantity: 10,
+      discountKobo: 50000,
+    );
+    final order = res['order'] as Map;
+    expect((order['total_amount_kobo'] as num).toInt(), 1000000);
+    expect((order['discount_kobo'] as num).toInt(), 50000);
+    expect((order['net_amount_kobo'] as num).toInt(), 950000);
+
+    final item = (res['order_items'] as List).first as Map;
+    expect((item['buying_price_kobo'] as num).toInt(), 50000,
+        reason: 'discount does not touch COGS');
+  }, skip: _skipReason);
+
+  // ── Slice 3 (#44): registered-customer credit & the wallet ledger ──────────
+
+  test('Register-as-Credit-Sale (no cash) posts one order_payment debit; balance goes negative within the limit',
+      () async {
+    final product = await seedProduct();
+    await seedInventory(product, 10);
+    await seedBatch(product, 10, 50000);
+    final customer = await seedCustomer(debtLimitKobo: 500000);
+
+    final res = await checkout(
+      orderId: UuidV7.generate(),
+      productId: product,
+      quantity: 3,
+      method: 'credit',
+      amountPaidKobo: 0,
+      customerId: customer,
+    );
+
+    final order = res['order'] as Map;
+    expect(order['status'], 'pending');
+    expect((order['amount_paid_kobo'] as num).toInt(), 0,
+        reason: 'no cash settled on a pure credit sale');
+    expect(order['customer_id'], customer);
+
+    final legs = (res['wallet_transactions'] as List).cast<Map>();
+    expect(legs.length, 1, reason: 'debit only — no cash credit leg');
+    expect(legs.single['reference_type'], 'order_payment');
+    expect((legs.single['signed_amount_kobo'] as num).toInt(), -300000);
+
+    expect(res['payment_transaction'], isNull,
+        reason: 'no payment_transactions row when nothing is paid in cash');
+    expect((res['customer_balance_kobo'] as num).toInt(), -300000);
+    expect(await balanceOf(customer), -300000,
+        reason: 'derived balance = the customer now owes the order total');
+  }, skip: _skipReason);
+
+  test('Pay-with-Credit draws the sale from an existing balance; balance drops, no cash payment',
+      () async {
+    final product = await seedProduct();
+    await seedInventory(product, 10);
+    await seedBatch(product, 10, 50000);
+    // Debt limit 0 (no credit allowed) but a covering balance to spend.
+    final customer =
+        await seedCustomer(debtLimitKobo: 0, openingBalanceKobo: 500000);
+
+    final res = await checkout(
+      orderId: UuidV7.generate(),
+      productId: product,
+      quantity: 3,
+      method: 'wallet',
+      amountPaidKobo: 0,
+      customerId: customer,
+    );
+
+    final legs = (res['wallet_transactions'] as List).cast<Map>();
+    expect(legs.length, 1);
+    expect(legs.single['reference_type'], 'order_payment');
+    expect((legs.single['signed_amount_kobo'] as num).toInt(), -300000);
+    expect(res['payment_transaction'], isNull);
+    expect((res['customer_balance_kobo'] as num).toInt(), 200000,
+        reason: '500,000 credit − 300,000 order');
+    expect(await balanceOf(customer), 200000);
+  }, skip: _skipReason);
+
+  test('Register-as-Credit-Sale with partial cash posts a debit + a cash credit leg',
+      () async {
+    final product = await seedProduct();
+    await seedInventory(product, 10);
+    await seedBatch(product, 10, 50000);
+    final customer = await seedCustomer(debtLimitKobo: 500000);
+
+    final res = await checkout(
+      orderId: UuidV7.generate(),
+      productId: product,
+      quantity: 3,
+      method: 'credit',
+      amountPaidKobo: 100000, // ₦1,000 of the ₦3,000 now
+      customerId: customer,
+    );
+
+    final legs = (res['wallet_transactions'] as List)
+        .cast<Map>()
+        .map((l) =>
+            '${l['reference_type']}|${(l['signed_amount_kobo'] as num).toInt()}')
+        .toList()
+      ..sort();
+    expect(legs, ['order_payment|-300000', 'topup_cash|100000']);
+
+    final pay = res['payment_transaction'] as Map;
+    expect(pay['method'], 'cash');
+    expect((pay['amount_kobo'] as num).toInt(), 100000);
+    expect(await balanceOf(customer), -200000);
+  }, skip: _skipReason);
+
+  test('a sale that would exceed the debt limit is rejected — no order written',
+      () async {
+    final product = await seedProduct();
+    await seedInventory(product, 10);
+    await seedBatch(product, 10, 50000);
+    // Limit ₦2,000; the ₦3,000 credit sale would push the balance to −₦3,000.
+    final customer = await seedCustomer(debtLimitKobo: 200000);
+
+    final orderId = UuidV7.generate();
+    await expectLater(
+      () => checkout(
+        orderId: orderId,
+        productId: product,
+        quantity: 3,
+        method: 'credit',
+        amountPaidKobo: 0,
+        customerId: customer,
+      ),
+      throwsA(predicate(
+          (e) => e.toString().contains('debt_limit_exceeded'))),
+    );
+
+    final order = await clients.adminClient
+        .from('orders')
+        .select('id')
+        .eq('id', orderId)
+        .maybeSingle();
+    expect(order, isNull, reason: 'all-or-nothing: nothing committed');
+    expect(await onHand(product), 10, reason: 'stock untouched');
+    expect(await balanceOf(customer), 0, reason: 'no wallet legs posted');
+  }, skip: _skipReason);
+
+  test('a customer with no debt limit cannot go into debt at all', () async {
+    final product = await seedProduct();
+    await seedInventory(product, 10);
+    await seedBatch(product, 10, 50000);
+    final customer = await seedCustomer(debtLimitKobo: 0); // no credit allowed
+
+    await expectLater(
+      () => checkout(
+        orderId: UuidV7.generate(),
+        productId: product,
+        quantity: 3,
+        method: 'credit',
+        amountPaidKobo: 0,
+        customerId: customer,
+      ),
+      throwsA(predicate(
+          (e) => e.toString().contains('debt_limit_exceeded'))),
+    );
+  }, skip: _skipReason);
+
+  test('a credit sale without a customer is rejected', () async {
+    final product = await seedProduct();
+    await seedInventory(product, 10);
+    await seedBatch(product, 10, 50000);
+
+    await expectLater(
+      () => checkout(
+        orderId: UuidV7.generate(),
+        productId: product,
+        quantity: 3,
+        method: 'credit',
+        amountPaidKobo: 0,
+      ),
+      throwsA(predicate(
+          (e) => e.toString().contains('credit_requires_customer'))),
+    );
+  }, skip: _skipReason);
+}

--- a/web-pos/.gitignore
+++ b/web-pos/.gitignore
@@ -1,0 +1,32 @@
+# dependencies
+/node_modules
+/.pnp
+.pnp.js
+
+# next.js
+/.next/
+/out/
+
+# production
+/build
+
+# misc
+.DS_Store
+*.pem
+
+# debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.pnpm-debug.log*
+
+# local env files
+.env
+.env*.local
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts
+
+# vercel
+.vercel

--- a/web-pos/README.md
+++ b/web-pos/README.md
@@ -1,0 +1,84 @@
+# Reebaplus Web POS
+
+The **online-first** browser client for Reebaplus POS. Unlike the Flutter mobile
+app (offline-first, Drift-backed), the Web POS reads the Supabase cloud live over
+RLS-scoped PostgREST and (in later slices) writes money through server RPCs — no
+Drift, no outbox, no offline mode. See the decisions in
+[`../docs/adr/0007`–`0012`](../docs/adr/) and the PRD
+[`../docs/prd/web-pos.md`](../docs/prd/web-pos.md).
+
+## This is Slice 1 — the walking skeleton (issue #47)
+
+Thin but end-to-end through **auth → live read → render**:
+
+- **Auth (ADR 0011).** Email + OTP and Google sign-in. The Supabase session _is_
+  the Operator for the tab; business/store scope resolves server-side from
+  `profiles.business_id` (`current_user_business_ids()`), no custom JWT claims.
+  Idle inactivity re-locks the tab to the sign-in screen.
+- **Live catalogue.** RLS-scoped read of categories + per-tier prices
+  (Retailer / Wholesaler) + on-hand stock, rendered in the POS grid. Realtime
+  hardening is Slice 5 (#49); here a manual **Refresh** re-pulls.
+- **Responsive shell** across four bands — phone / tablet / desktop / large.
+- **Theming parity.** The five business palettes (blue / amber / purple / green /
+  b&w, light + dark) ported from the mobile `AppTheme`, applied at the app root.
+  The active palette is the synced `business_design_system` setting, applied live.
+- **Permission-read layer.** Reads the same `role_permissions` / override rows the
+  mobile Gate Registry reads and applies hide-don't-block (CEO all-on).
+- **Currency** is formatted from the business `default_currency` setting, never
+  hard-coded.
+
+## Stack
+
+Next.js (App Router) + React + TypeScript + `@supabase/supabase-js`. The whole
+data layer is a single browser Supabase client (`src/lib/supabase/`).
+
+## Local development
+
+```bash
+npm install
+npm run dev        # http://localhost:3000
+npm run build      # production build (also runs type-checking)
+npm run typecheck  # tsc --noEmit
+```
+
+Supabase config (URL + anon key) has public defaults baked into
+`src/lib/supabase/config.ts` — the same client-public, RLS-gated values the
+mobile app hardcodes — so the app runs with **zero env setup**. To point at a
+different Supabase project, set `NEXT_PUBLIC_SUPABASE_URL` and
+`NEXT_PUBLIC_SUPABASE_ANON_KEY` in a `.env.local` (git-ignored) or in the Vercel
+project's environment variables.
+
+To sign in you need an account already onboarded to a business on the mobile app
+(a `profiles` row with a `business_id`).
+
+## Deployment (Vercel)
+
+- **Project root:** `web-pos/` (monorepo subdirectory — ADR 0012). Vercel
+  auto-detects Next.js.
+- **Env vars:** optional; set `NEXT_PUBLIC_SUPABASE_URL` /
+  `NEXT_PUBLIC_SUPABASE_ANON_KEY` to override the baked-in defaults.
+- **Supabase Auth config:** add the deployed origin (and
+  `https://<domain>/auth/callback`) to the project's **Auth → URL Configuration →
+  Redirect URLs** so Google OAuth returns to the app.
+
+## Layout
+
+```
+src/
+  app/                 App Router: layout, entry page, /auth/callback
+  components/
+    auth/              LoginForm (email OTP + Google), IdleLock
+    providers/         SessionProvider (session + Operator), ThemeProvider
+    permissions/       Can / useCan — hide-don't-block gate
+    shell/             AppShell — responsive shell + gated nav
+    pos/               PosScreen, ProductCard — the live product grid
+  hooks/               useIdleTimeout, useCurrency
+  lib/
+    supabase/          browser client + public config
+    theme/palettes.ts  the five palettes (ported from mobile colors.dart)
+    operator.ts        loads Operator (business, role, permissions, settings)
+    catalogue.ts       loads categories + products + stock
+    permissions.ts     resolveEffectivePermissions (mirrors mobile)
+    currency.ts        formatCurrency / formatKobo (ported from mobile)
+    types.ts           cloud row shapes (snake_case)
+```

--- a/web-pos/README.md
+++ b/web-pos/README.md
@@ -7,7 +7,30 @@ Drift, no outbox, no offline mode. See the decisions in
 [`../docs/adr/0007`–`0012`](../docs/adr/) and the PRD
 [`../docs/prd/web-pos.md`](../docs/prd/web-pos.md).
 
-## This is Slice 1 — the walking skeleton (issue #47)
+## Slice 2 — cash-sale checkout keystone (issue #43)
+
+The selling loop, end to end, on the server-authoritative write path:
+
+- **Grid → cart → checkout → receipt.** Tapping a product adds it to a
+  session-persistent cart (`CartProvider`); the cart shows qty steppers, remove, a
+  **role-capped discount**, and live line/order totals. Checkout takes
+  cash/transfer + the amount paid; the receipt prints (print-only stylesheet) and
+  shares/downloads (Web Share with a text-file fallback); "Done — back to POS"
+  clears the cart. Grid-beside-cart on tablet+, a sticky bottom bar + sheet on
+  phone.
+- **`checkout_order` RPC (ADR 0008, migration `0135`).** The web's only
+  money-write: one `SECURITY DEFINER` atomic transaction — Order at `pending` +
+  items, FIFO cost-batch draw-down under a row lock with per-line COGS snapshot,
+  inventory guard that **rejects an oversell at commit**, a collision-proof server
+  order number (`WEB-…`, never the mobile `ORD-…`), revenue recognized at
+  Checkout, and server-side `sales.make` + discount-cap enforcement. The sale
+  reaches the mobile tills through their existing Realtime pull.
+- **Golden-Scenario Suite (ADR 0009).** Shared fixtures (`../test/golden/fixtures/`)
+  run against both the Dart DAO (mobile) and the SQL RPC (web) in CI
+  (`.github/workflows/golden-scenarios.yml`); any drift in the money math fails the
+  build.
+
+## Slice 1 — the walking skeleton (issue #47)
 
 Thin but end-to-end through **auth → live read → render**:
 

--- a/web-pos/next.config.mjs
+++ b/web-pos/next.config.mjs
@@ -1,0 +1,9 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  // The Web POS is online-first (ADR 0007): it talks to Supabase live from the
+  // browser. There is no server data layer to build against, so the app runs as
+  // a client-rendered SPA over the App Router.
+};
+
+export default nextConfig;

--- a/web-pos/package-lock.json
+++ b/web-pos/package-lock.json
@@ -1,0 +1,1088 @@
+{
+  "name": "reebaplus-web-pos",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "reebaplus-web-pos",
+      "version": "0.1.0",
+      "dependencies": {
+        "@supabase/supabase-js": "^2.45.4",
+        "next": "15.1.6",
+        "react": "19.0.0",
+        "react-dom": "19.0.0"
+      },
+      "devDependencies": {
+        "@types/node": "^20.14.9",
+        "@types/react": "^19.0.7",
+        "@types/react-dom": "^19.0.3",
+        "typescript": "^5.7.3"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.5.tgz",
+      "integrity": "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.5.tgz",
+      "integrity": "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.4.tgz",
+      "integrity": "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.4.tgz",
+      "integrity": "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.5.tgz",
+      "integrity": "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==",
+      "cpu": [
+        "arm"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.4.tgz",
+      "integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.0.4.tgz",
+      "integrity": "sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==",
+      "cpu": [
+        "s390x"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.4.tgz",
+      "integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.4.tgz",
+      "integrity": "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.4.tgz",
+      "integrity": "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz",
+      "integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
+      "cpu": [
+        "arm"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.0.5"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.5.tgz",
+      "integrity": "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.33.5.tgz",
+      "integrity": "sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.5.tgz",
+      "integrity": "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.5.tgz",
+      "integrity": "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.5.tgz",
+      "integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.33.5.tgz",
+      "integrity": "sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.2.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.33.5.tgz",
+      "integrity": "sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz",
+      "integrity": "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@next/env": {
+      "version": "15.1.6",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.1.6.tgz",
+      "integrity": "sha512-d9AFQVPEYNr+aqokIiPLNK/MTyt3DWa/dpKveiAaVccUadFbhFEvY6FXYX2LJO2Hv7PHnLBu2oWwB4uBuHjr/w==",
+      "license": "MIT"
+    },
+    "node_modules/@next/swc-darwin-arm64": {
+      "version": "15.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.1.6.tgz",
+      "integrity": "sha512-u7lg4Mpl9qWpKgy6NzEkz/w0/keEHtOybmIl0ykgItBxEM5mYotS5PmqTpo+Rhg8FiOiWgwr8USxmKQkqLBCrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "15.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.1.6.tgz",
+      "integrity": "sha512-x1jGpbHbZoZ69nRuogGL2MYPLqohlhnT9OCU6E6QFewwup+z+M6r8oU47BTeJcWsF2sdBahp5cKiAcDbwwK/lg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "15.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.1.6.tgz",
+      "integrity": "sha512-jar9sFw0XewXsBzPf9runGzoivajeWJUc/JkfbLTC4it9EhU8v7tCRLH7l5Y1ReTMN6zKJO0kKAGqDk8YSO2bg==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "15.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.1.6.tgz",
+      "integrity": "sha512-+n3u//bfsrIaZch4cgOJ3tXCTbSxz0s6brJtU3SzLOvkJlPQMJ+eHVRi6qM2kKKKLuMY+tcau8XD9CJ1OjeSQQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "15.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.1.6.tgz",
+      "integrity": "sha512-SpuDEXixM3PycniL4iVCLyUyvcl6Lt0mtv3am08sucskpG0tYkW1KlRhTgj4LI5ehyxriVVcfdoxuuP8csi3kQ==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "15.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.1.6.tgz",
+      "integrity": "sha512-L4druWmdFSZIIRhF+G60API5sFB7suTbDRhYWSjiw0RbE+15igQvE2g2+S973pMGvwN3guw7cJUjA/TmbPWTHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "15.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.1.6.tgz",
+      "integrity": "sha512-s8w6EeqNmi6gdvM19tqKKWbCyOBvXFbndkGHl+c9YrzsLARRdCHsD9S1fMj8gsXm9v8vhC8s3N8rjuC/XrtkEg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "15.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.1.6.tgz",
+      "integrity": "sha512-6xomMuu54FAFxttYr5PJbEfu96godcxBTRk1OhAvJq0/EnmFU/Ybiax30Snis4vdWZ9LGpf7Roy5fSs7v/5ROQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.110.0",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.110.0.tgz",
+      "integrity": "sha512-Mi288WCTp6wxMFCOu/UgzgHEXODjdl2uVTLqK11eanzGZaldU3RyP8Am+ZbNuVzFP+5+iOvppxzv7N5Ym84xTg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.110.0",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.110.0.tgz",
+      "integrity": "sha512-Fde5wlY8ZZy+9yqrWlQHo8MacSyUBArBEtN2boB4thJQigPnQD/cc61qZN0n3I1L0gwhWtHYwIMnOBKxSvF6Hw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@supabase/phoenix": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@supabase/phoenix/-/phoenix-0.4.4.tgz",
+      "integrity": "sha512-Gt0pqoXuIqX/8dvG0OKp/wMCobXNH3klNbUPBNyOfN0YA1IswrM3HyWFMOPk1Jy+BRaIyDPcFx4jLBwHNmlyfQ==",
+      "license": "MIT"
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "2.110.0",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.110.0.tgz",
+      "integrity": "sha512-ZbC1QZL3jcvBUfVKjJbgRM27G4Mg3Zzqdm44m5pJafe1e52Cli793EOnwQucomBAGEUDd03Nzaf7XV3ji/XexQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.110.0",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.110.0.tgz",
+      "integrity": "sha512-Wn2AWpneZuDFTkp/65tqctvoh+3JvyTjMam8sTMqVWy5BgkU8zAvFwilPYPPPhkINeKF8NAJKP7FclJ2iGCUMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/phoenix": "0.4.4",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.110.0",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.110.0.tgz",
+      "integrity": "sha512-71+gU3HrhiylAhftY6FmO5PPdcsScnVcS766CVD+vTYK9qTDLbrx8FhgBYbqGm3iV/wkTfzrNJfjGsMeFRkJRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "iceberg-js": "^0.8.1",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.110.0",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.110.0.tgz",
+      "integrity": "sha512-8yI84VJiEVW4zxZpLUmxXmjzQ7O2St9X/ymzlBETDHTURPWG3LmvbSiibq+7dqAJmyoUfxZnSfXeM4HCM8s4XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.110.0",
+        "@supabase/functions-js": "2.110.0",
+        "@supabase/postgrest-js": "2.110.0",
+        "@supabase/realtime-js": "2.110.0",
+        "@supabase/storage-js": "2.110.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@swc/counter": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
+      "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.15",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
+      "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.17",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
+      "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001800",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001800.tgz",
+      "integrity": "sha512-MMHtuAz9Ys840zAY5F4k6fV5GaivZ9sPk+nz0mY+GYVzRBnYkN0mpqkSR92oWRQ19yQWo4HvBV/FnC16AJX8MA==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/client-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
+      "license": "MIT"
+    },
+    "node_modules/color": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "color-convert": "^2.0.1",
+        "color-string": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=12.5.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/iceberg-js": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
+      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
+      "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/next": {
+      "version": "15.1.6",
+      "resolved": "https://registry.npmjs.org/next/-/next-15.1.6.tgz",
+      "integrity": "sha512-Hch4wzbaX0vKQtalpXvUiw5sYivBy4cm5rzUKrBnUB/y436LGrvOUqYvlSeNVCWFO/770gDlltR9gqZH62ct4Q==",
+      "deprecated": "This version has a security vulnerability. Please upgrade to a patched version. See https://nextjs.org/blog/CVE-2025-66478 for more details.",
+      "license": "MIT",
+      "dependencies": {
+        "@next/env": "15.1.6",
+        "@swc/counter": "0.1.3",
+        "@swc/helpers": "0.5.15",
+        "busboy": "1.6.0",
+        "caniuse-lite": "^1.0.30001579",
+        "postcss": "8.4.31",
+        "styled-jsx": "5.1.6"
+      },
+      "bin": {
+        "next": "dist/bin/next"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
+      },
+      "optionalDependencies": {
+        "@next/swc-darwin-arm64": "15.1.6",
+        "@next/swc-darwin-x64": "15.1.6",
+        "@next/swc-linux-arm64-gnu": "15.1.6",
+        "@next/swc-linux-arm64-musl": "15.1.6",
+        "@next/swc-linux-x64-gnu": "15.1.6",
+        "@next/swc-linux-x64-musl": "15.1.6",
+        "@next/swc-win32-arm64-msvc": "15.1.6",
+        "@next/swc-win32-x64-msvc": "15.1.6",
+        "sharp": "^0.33.5"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.1.0",
+        "@playwright/test": "^1.41.2",
+        "babel-plugin-react-compiler": "*",
+        "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
+        "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
+        "sass": "^1.3.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@playwright/test": {
+          "optional": true
+        },
+        "babel-plugin-react-compiler": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.4.31",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.6",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.0.0.tgz",
+      "integrity": "sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.0.0.tgz",
+      "integrity": "sha512-4GV5sHFG0e/0AD4X+ySy6UJd3jVl1iNsNHdpad0qhABJ11twS3TTBnseqsKurKcsNqCEFeGL3uLpVChpIO3QfQ==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.25.0"
+      },
+      "peerDependencies": {
+        "react": "^19.0.0"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0.tgz",
+      "integrity": "sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.5.tgz",
+      "integrity": "sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "color": "^4.2.3",
+        "detect-libc": "^2.0.3",
+        "semver": "^7.6.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.33.5",
+        "@img/sharp-darwin-x64": "0.33.5",
+        "@img/sharp-libvips-darwin-arm64": "1.0.4",
+        "@img/sharp-libvips-darwin-x64": "1.0.4",
+        "@img/sharp-libvips-linux-arm": "1.0.5",
+        "@img/sharp-libvips-linux-arm64": "1.0.4",
+        "@img/sharp-libvips-linux-s390x": "1.0.4",
+        "@img/sharp-libvips-linux-x64": "1.0.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4",
+        "@img/sharp-linux-arm": "0.33.5",
+        "@img/sharp-linux-arm64": "0.33.5",
+        "@img/sharp-linux-s390x": "0.33.5",
+        "@img/sharp-linux-x64": "0.33.5",
+        "@img/sharp-linuxmusl-arm64": "0.33.5",
+        "@img/sharp-linuxmusl-x64": "0.33.5",
+        "@img/sharp-wasm32": "0.33.5",
+        "@img/sharp-win32-ia32": "0.33.5",
+        "@img/sharp-win32-x64": "0.33.5"
+      }
+    },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
+      "integrity": "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/styled-jsx": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
+      "integrity": "sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==",
+      "license": "MIT",
+      "dependencies": {
+        "client-only": "0.0.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/web-pos/package.json
+++ b/web-pos/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "reebaplus-web-pos",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Reebaplus Web POS — online-first browser client (Slice 1: walking skeleton). See docs/prd/web-pos.md and docs/adr/0007-0012.",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@supabase/supabase-js": "^2.45.4",
+    "next": "15.1.6",
+    "react": "19.0.0",
+    "react-dom": "19.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.14.9",
+    "@types/react": "^19.0.7",
+    "@types/react-dom": "^19.0.3",
+    "typescript": "^5.7.3"
+  },
+  "engines": {
+    "node": ">=18.18.0"
+  }
+}

--- a/web-pos/src/app/auth/callback/page.tsx
+++ b/web-pos/src/app/auth/callback/page.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+
+import { useSession } from '@/components/providers/SessionProvider';
+
+// OAuth return landing. The browser Supabase client (detectSessionInUrl) parses
+// the Google PKCE code from the URL and establishes the session; once the
+// session is present we send the Operator to the app root.
+export default function AuthCallbackPage() {
+  const router = useRouter();
+  const { status } = useSession();
+
+  useEffect(() => {
+    if (status === 'signed-in') {
+      router.replace('/');
+    } else if (status === 'signed-out') {
+      // No session materialised (e.g. user cancelled) — back to sign-in.
+      router.replace('/');
+    }
+  }, [status, router]);
+
+  return (
+    <div className="center-screen">
+      <div style={{ display: 'grid', placeItems: 'center', gap: 16 }}>
+        <div className="spinner" />
+        <p className="muted">Signing you in…</p>
+      </div>
+    </div>
+  );
+}

--- a/web-pos/src/app/globals.css
+++ b/web-pos/src/app/globals.css
@@ -1,0 +1,449 @@
+/*
+ * Web POS global styles.
+ *
+ * Colour tokens are CSS custom properties applied at :root. The values below are
+ * the blue/light defaults so first paint is styled before ThemeProvider runs;
+ * ThemeProvider then overwrites them with the business's palette (light or dark)
+ * live. Every component reads var(--token) — never a hard-coded colour — so a
+ * palette switch re-paints the whole app.
+ *
+ * Responsive bands (PRD "four breakpoint bands"):
+ *   phone   < 640px   — single touch column
+ *   tablet  640–1023  — grid beside a rail
+ *   desktop 1024–1535 — full multi-pane
+ *   large   ≥ 1536     — max-width, denser grid
+ */
+
+:root {
+  --bg: #f8fafc;
+  --surface: #ffffff;
+  --surface2: #f1f5f9;
+  --border: #e2e8f0;
+  --text: #0f172a;
+  --subtext: #64748b;
+  --primary: #2563eb;
+  --primary-hover: #1d4ed8;
+  --on-primary: #ffffff;
+  --secondary: #60a5fa;
+  --danger: #ef4444;
+  --success: #10b981;
+  --warning: #ffb020;
+  --info: #3b82f6;
+
+  --radius: 14px;
+  --radius-lg: 20px;
+  --rail-width: 76px;
+  --sidebar-width: 240px;
+  --content-max: 1600px;
+  --card-min: 150px;
+  --font-sans: system-ui, -apple-system, 'Segoe UI', Roboto, 'Helvetica Neue',
+    Arial, sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  background: var(--bg);
+  color: var(--text);
+  font-family: var(--font-sans);
+  -webkit-font-smoothing: antialiased;
+  min-height: 100dvh;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+button {
+  font-family: inherit;
+  cursor: pointer;
+}
+
+/* ── Buttons ──────────────────────────────────────────────────────────────── */
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  min-height: 48px;
+  padding: 0 20px;
+  border: none;
+  border-radius: 12px;
+  font-size: 15px;
+  font-weight: 600;
+  transition: background 0.15s ease, opacity 0.15s ease;
+}
+
+.btn--primary {
+  background: var(--primary);
+  color: var(--on-primary);
+}
+.btn--primary:hover:not(:disabled) {
+  background: var(--primary-hover);
+}
+.btn--outline {
+  background: transparent;
+  color: var(--text);
+  border: 1.5px solid var(--border);
+}
+.btn--outline:hover:not(:disabled) {
+  border-color: var(--primary);
+  color: var(--primary);
+}
+.btn--block {
+  width: 100%;
+}
+.btn:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+/* ── Inputs ───────────────────────────────────────────────────────────────── */
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.field__label {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--subtext);
+}
+.input {
+  width: 100%;
+  min-height: 48px;
+  padding: 0 16px;
+  background: var(--surface2);
+  border: 1.5px solid transparent;
+  border-radius: var(--radius);
+  color: var(--text);
+  font-size: 15px;
+}
+.input:focus {
+  outline: none;
+  border-color: var(--primary);
+  background: var(--surface);
+}
+
+/* ── Card ─────────────────────────────────────────────────────────────────── */
+
+.card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+}
+
+/* ── App shell ────────────────────────────────────────────────────────────── */
+
+.shell {
+  display: flex;
+  flex-direction: column;
+  min-height: 100dvh;
+}
+
+.shell__topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 16px;
+  background: var(--surface);
+  border-bottom: 1px solid var(--border);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+
+.shell__brand {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-weight: 700;
+  font-size: 16px;
+}
+.shell__brand-dot {
+  width: 26px;
+  height: 26px;
+  border-radius: 8px;
+  background: var(--primary);
+}
+.shell__business {
+  color: var(--subtext);
+  font-weight: 500;
+  font-size: 13px;
+}
+
+.shell__body {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+}
+
+.shell__nav {
+  display: none;
+  flex-direction: column;
+  gap: 4px;
+  padding: 12px 8px;
+  background: var(--surface);
+  border-right: 1px solid var(--border);
+  width: var(--rail-width);
+  flex-shrink: 0;
+}
+
+.shell__nav-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  padding: 12px 4px;
+  border-radius: 12px;
+  color: var(--subtext);
+  font-size: 11px;
+  font-weight: 600;
+}
+.shell__nav-item--active {
+  background: var(--surface2);
+  color: var(--primary);
+}
+.shell__nav-icon {
+  font-size: 20px;
+}
+
+.shell__content {
+  flex: 1;
+  min-width: 0;
+  padding: 16px;
+}
+.shell__content-inner {
+  max-width: var(--content-max);
+  margin: 0 auto;
+}
+
+.shell__account {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+.shell__account-name {
+  font-weight: 600;
+  font-size: 14px;
+}
+.shell__account-role {
+  color: var(--subtext);
+  font-size: 12px;
+}
+
+/* tablet and up: show the left rail */
+@media (min-width: 640px) {
+  .shell__nav {
+    display: flex;
+  }
+  .shell__content {
+    padding: 24px;
+  }
+}
+
+/* desktop: wider sidebar with labels beside icons */
+@media (min-width: 1024px) {
+  :root {
+    --card-min: 170px;
+  }
+  .shell__nav {
+    width: var(--sidebar-width);
+    padding: 16px 12px;
+  }
+  .shell__nav-item {
+    flex-direction: row;
+    justify-content: flex-start;
+    gap: 12px;
+    padding: 12px 16px;
+    font-size: 14px;
+  }
+  .shell__content {
+    padding: 32px;
+  }
+}
+
+/* large/wide: denser product grid, content stays max-width and centred */
+@media (min-width: 1536px) {
+  :root {
+    --card-min: 150px;
+  }
+}
+
+/* ── POS grid ─────────────────────────────────────────────────────────────── */
+
+.pos {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.pos__header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+.pos__title {
+  font-size: 20px;
+  font-weight: 700;
+  margin: 0;
+}
+
+.category-bar {
+  display: flex;
+  gap: 8px;
+  overflow-x: auto;
+  padding-bottom: 4px;
+  scrollbar-width: thin;
+}
+.chip {
+  flex-shrink: 0;
+  padding: 8px 16px;
+  border-radius: 20px;
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: var(--text);
+  font-size: 13px;
+  font-weight: 600;
+  white-space: nowrap;
+}
+.chip--active {
+  background: var(--primary);
+  color: var(--on-primary);
+  border-color: var(--primary);
+}
+
+.product-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(var(--card-min), 1fr));
+  gap: 12px;
+}
+
+.product-card {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 14px;
+  text-align: left;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  transition: border-color 0.15s ease, transform 0.05s ease;
+}
+.product-card:hover:not(:disabled) {
+  border-color: var(--primary);
+}
+.product-card:active:not(:disabled) {
+  transform: scale(0.99);
+}
+.product-card:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+.product-card__name {
+  font-weight: 600;
+  font-size: 14px;
+  line-height: 1.3;
+}
+.product-card__meta {
+  font-size: 12px;
+  color: var(--subtext);
+}
+.product-card__prices {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  margin-top: auto;
+}
+.product-card__price {
+  font-weight: 700;
+  font-size: 15px;
+}
+.product-card__price-tier {
+  color: var(--subtext);
+  font-weight: 500;
+  font-size: 12px;
+}
+.product-card__wholesale {
+  font-size: 12px;
+  color: var(--subtext);
+}
+.product-card__stock {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 12px;
+  font-weight: 600;
+}
+.stock-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--success);
+}
+.stock-dot--low {
+  background: var(--warning);
+}
+.stock-dot--out {
+  background: var(--danger);
+}
+.product-card__badge-out {
+  color: var(--danger);
+}
+
+/* ── Misc ─────────────────────────────────────────────────────────────────── */
+
+.muted {
+  color: var(--subtext);
+}
+.center-screen {
+  min-height: 100dvh;
+  display: grid;
+  place-items: center;
+  padding: 24px;
+}
+.spinner {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  border: 3px solid var(--border);
+  border-top-color: var(--primary);
+  animation: spin 0.8s linear infinite;
+}
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+.empty-state {
+  text-align: center;
+  color: var(--subtext);
+  padding: 48px 16px;
+}
+.banner {
+  padding: 12px 16px;
+  border-radius: var(--radius);
+  font-size: 14px;
+}
+.banner--error {
+  background: color-mix(in srgb, var(--danger) 12%, transparent);
+  color: var(--danger);
+}
+.banner--info {
+  background: var(--surface2);
+  color: var(--subtext);
+}

--- a/web-pos/src/app/globals.css
+++ b/web-pos/src/app/globals.css
@@ -447,3 +447,639 @@ button {
   background: var(--surface2);
   color: var(--subtext);
 }
+
+/* ── POS layout (grid beside cart) ────────────────────────────────────────── */
+
+/* phone: single column; the cart is reached via the sticky bottom bar + sheet */
+.pos-layout {
+  display: block;
+}
+.pos-layout__cart {
+  display: none;
+}
+
+@media (min-width: 900px) {
+  .pos-layout {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) 360px;
+    gap: 20px;
+    align-items: start;
+  }
+  .pos-layout__cart {
+    display: block;
+    position: sticky;
+    top: 84px;
+  }
+  .cart-bar,
+  .cart-sheet-overlay {
+    display: none !important;
+  }
+}
+
+@media (min-width: 1536px) {
+  .pos-layout {
+    grid-template-columns: minmax(0, 1fr) 400px;
+  }
+}
+
+/* ── Cart ─────────────────────────────────────────────────────────────────── */
+
+.cart {
+  display: flex;
+  flex-direction: column;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+}
+.cart__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--border);
+}
+.cart__title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 0;
+  font-size: 16px;
+  font-weight: 700;
+}
+.cart__count {
+  display: inline-grid;
+  place-items: center;
+  min-width: 22px;
+  height: 22px;
+  padding: 0 6px;
+  border-radius: 11px;
+  background: var(--primary);
+  color: var(--on-primary);
+  font-size: 12px;
+}
+.cart__head-actions {
+  display: flex;
+  gap: 12px;
+}
+.cart__link {
+  background: none;
+  border: none;
+  color: var(--subtext);
+  font-size: 13px;
+  font-weight: 600;
+  padding: 4px;
+}
+.cart__link:hover {
+  color: var(--primary);
+}
+.cart__empty {
+  padding: 40px 16px;
+  text-align: center;
+  color: var(--subtext);
+  font-size: 14px;
+}
+.cart__lines {
+  list-style: none;
+  margin: 0;
+  padding: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  overflow-y: auto;
+  max-height: min(48vh, 460px);
+}
+.cart__line {
+  display: grid;
+  grid-template-columns: 1fr auto auto auto;
+  align-items: center;
+  gap: 10px;
+  padding: 8px;
+  border-radius: 12px;
+}
+.cart__line:hover {
+  background: var(--surface2);
+}
+.cart__line-info {
+  min-width: 0;
+}
+.cart__line-name {
+  font-weight: 600;
+  font-size: 14px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.cart__line-unit {
+  font-size: 12px;
+  color: var(--subtext);
+}
+.cart__stepper {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  background: var(--surface2);
+  border-radius: 10px;
+  padding: 2px;
+}
+.cart__step {
+  width: 30px;
+  height: 30px;
+  border: none;
+  background: var(--surface);
+  border-radius: 8px;
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--text);
+  line-height: 1;
+}
+.cart__step:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+.cart__qty {
+  width: 34px;
+  border: none;
+  background: transparent;
+  text-align: center;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text);
+  -moz-appearance: textfield;
+  appearance: textfield;
+}
+.cart__qty::-webkit-outer-spin-button,
+.cart__qty::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+.cart__line-total {
+  font-weight: 700;
+  font-size: 14px;
+  white-space: nowrap;
+}
+.cart__remove {
+  width: 26px;
+  height: 26px;
+  border: none;
+  background: none;
+  color: var(--subtext);
+  font-size: 13px;
+  border-radius: 8px;
+}
+.cart__remove:hover {
+  background: color-mix(in srgb, var(--danger) 12%, transparent);
+  color: var(--danger);
+}
+.cart__foot {
+  border-top: 1px solid var(--border);
+  padding: 14px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.cart__row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 14px;
+}
+.cart__row--muted {
+  color: var(--subtext);
+}
+.cart__row--total {
+  font-size: 18px;
+  font-weight: 800;
+}
+.cart__discount {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.cart__discount-label {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--subtext);
+}
+.cart__discount-cap {
+  font-weight: 500;
+  font-size: 12px;
+}
+.cart__discount-note {
+  font-size: 12px;
+  color: var(--warning);
+}
+.cart__checkout {
+  margin-top: 4px;
+}
+
+/* phone cart bar + sheet */
+.cart-bar {
+  position: fixed;
+  left: 12px;
+  right: 12px;
+  bottom: 12px;
+  z-index: 30;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 0 18px;
+  min-height: 56px;
+  border: none;
+  border-radius: 16px;
+  background: var(--primary);
+  color: var(--on-primary);
+  font-size: 15px;
+  font-weight: 700;
+  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.28);
+}
+.cart-bar__count {
+  display: inline-grid;
+  place-items: center;
+  min-width: 24px;
+  height: 24px;
+  padding: 0 7px;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.25);
+  font-size: 13px;
+}
+.cart-bar__total {
+  margin-left: auto;
+}
+.cart-sheet-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 40;
+  background: rgba(15, 23, 42, 0.5);
+  display: flex;
+  align-items: flex-end;
+}
+.cart-sheet {
+  width: 100%;
+  max-height: 88vh;
+  overflow: hidden;
+  border-radius: 20px 20px 0 0;
+  background: var(--surface);
+  animation: sheet-up 0.18s ease;
+}
+@keyframes sheet-up {
+  from {
+    transform: translateY(24px);
+    opacity: 0.6;
+  }
+}
+.cart-sheet .cart {
+  border: none;
+  border-radius: 0;
+}
+
+/* ── Modal (checkout / receipt) ───────────────────────────────────────────── */
+
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 50;
+  background: rgba(15, 23, 42, 0.5);
+  display: grid;
+  place-items: center;
+  padding: 16px;
+}
+.modal {
+  width: 100%;
+  max-width: 440px;
+  max-height: 92vh;
+  overflow: auto;
+  background: var(--surface);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border);
+}
+.modal__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 20px;
+  border-bottom: 1px solid var(--border);
+}
+.modal__title {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 700;
+}
+.modal__close {
+  width: 32px;
+  height: 32px;
+  border: none;
+  background: var(--surface2);
+  border-radius: 10px;
+  color: var(--subtext);
+}
+.modal__body {
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+.modal__foot {
+  display: flex;
+  gap: 10px;
+  justify-content: flex-end;
+  padding: 16px 20px;
+  border-top: 1px solid var(--border);
+}
+.modal__foot .btn {
+  flex: 0 0 auto;
+}
+
+.checkout__total-line {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 15px;
+}
+.checkout__total-line strong {
+  font-size: 22px;
+}
+.checkout__change {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-weight: 600;
+  color: var(--subtext);
+}
+.segmented {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 4px;
+  padding: 4px;
+  background: var(--surface2);
+  border-radius: 12px;
+}
+.segmented__opt {
+  min-height: 42px;
+  border: none;
+  background: transparent;
+  border-radius: 9px;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--subtext);
+}
+.segmented__opt--active {
+  background: var(--surface);
+  color: var(--primary);
+  box-shadow: 0 1px 3px rgba(15, 23, 42, 0.12);
+}
+
+/* ── Receipt ──────────────────────────────────────────────────────────────── */
+
+.modal--receipt {
+  max-width: 380px;
+}
+.receipt {
+  padding: 24px 22px 12px;
+  text-align: center;
+}
+.receipt__brand {
+  font-size: 18px;
+  font-weight: 800;
+}
+.receipt__muted {
+  font-size: 12px;
+  color: var(--subtext);
+}
+.receipt__divider {
+  border-top: 1px dashed var(--border);
+  margin: 14px 0;
+}
+.receipt__lines {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  text-align: left;
+}
+.receipt__line {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 8px;
+  font-size: 13px;
+}
+.receipt__line-qty {
+  color: var(--subtext);
+  font-variant-numeric: tabular-nums;
+}
+.receipt__line-name {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.receipt__line-amt {
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+.receipt__row {
+  display: flex;
+  justify-content: space-between;
+  font-size: 14px;
+  margin-top: 4px;
+}
+.receipt__row--muted {
+  color: var(--subtext);
+}
+.receipt__row--total {
+  font-size: 17px;
+  font-weight: 800;
+  margin-top: 8px;
+}
+.receipt__thanks {
+  margin: 16px 0 4px;
+  font-size: 13px;
+  color: var(--subtext);
+}
+.receipt__note {
+  margin: 0 20px;
+}
+.receipt__actions {
+  flex-wrap: wrap;
+}
+
+@media print {
+  body * {
+    visibility: hidden;
+  }
+  #receipt-printable,
+  #receipt-printable * {
+    visibility: visible;
+  }
+  #receipt-printable {
+    position: absolute;
+    inset: 0;
+    margin: 0;
+    padding: 12px;
+    width: 100%;
+  }
+  .modal__foot,
+  .receipt__actions {
+    display: none !important;
+  }
+}
+
+/* ── Customer credit (Slice 3, #44) ─────────────────────────────────────────── */
+
+/* Cart: the attach-a-customer bar. */
+.cart__customer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 10px 12px;
+  margin-bottom: 10px;
+  background: var(--surface2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+}
+.cart__customer-info {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+.cart__customer-name {
+  font-weight: 600;
+  font-size: 14px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.cart__customer-balance {
+  font-size: 12px;
+  font-weight: 600;
+}
+.cart__customer-balance--credit,
+.checkout__customer-balance--credit,
+.customer-list__balance--credit {
+  color: var(--success);
+}
+.cart__customer-balance--owed,
+.checkout__customer-balance--owed,
+.customer-list__balance--owed {
+  color: var(--danger);
+}
+.cart__customer-actions {
+  display: flex;
+  gap: 8px;
+  flex-shrink: 0;
+}
+.cart__customer-add {
+  width: 100%;
+  border: 1px dashed var(--border);
+  background: transparent;
+  color: var(--primary);
+  font-weight: 600;
+  font-size: 14px;
+  padding: 10px 12px;
+  border-radius: var(--radius);
+}
+.cart__customer-add:hover {
+  background: var(--surface2);
+}
+
+/* Customer picker modal list. */
+.customer-list {
+  list-style: none;
+  margin: 12px 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  max-height: 340px;
+  overflow-y: auto;
+}
+.customer-list__row {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 12px;
+  border: 1px solid var(--border);
+  background: var(--surface);
+  border-radius: var(--radius);
+  text-align: left;
+}
+.customer-list__row:hover {
+  border-color: var(--primary);
+  background: var(--surface2);
+}
+.customer-list__info {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+.customer-list__name {
+  font-weight: 600;
+  font-size: 14px;
+}
+.customer-list__phone {
+  font-size: 12px;
+  color: var(--subtext);
+}
+.customer-list__balance {
+  font-size: 13px;
+  font-weight: 600;
+  flex-shrink: 0;
+}
+
+/* Checkout: the attached customer + projected balance rows. */
+.checkout__customer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 10px 12px;
+  background: var(--surface2);
+  border-radius: var(--radius);
+}
+.checkout__customer-name {
+  font-weight: 600;
+  font-size: 14px;
+}
+.checkout__customer-balance {
+  font-size: 13px;
+  font-weight: 600;
+}
+.checkout__projected {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 14px;
+  font-weight: 600;
+}
+.checkout__projected .checkout__customer-balance--credit {
+  color: var(--success);
+}
+.checkout__projected .checkout__customer-balance--owed {
+  color: var(--danger);
+}
+
+/* A 4-option payment segmented control wraps instead of forcing two columns. */
+.segmented--wrap {
+  display: flex;
+  flex-wrap: wrap;
+}
+.segmented--wrap .segmented__opt {
+  flex: 1 1 40%;
+  min-width: 120px;
+}
+
+.field__hint {
+  margin: 6px 0 0;
+  font-size: 12px;
+  color: var(--subtext);
+}

--- a/web-pos/src/app/layout.tsx
+++ b/web-pos/src/app/layout.tsx
@@ -1,0 +1,37 @@
+import type { Metadata, Viewport } from 'next';
+
+import './globals.css';
+import { SessionProvider } from '@/components/providers/SessionProvider';
+import { ThemeProvider } from '@/components/providers/ThemeProvider';
+import { IdleLock } from '@/components/auth/IdleLock';
+
+export const metadata: Metadata = {
+  title: 'Reebaplus Web POS',
+  description: 'Operate your business live from any computer.',
+};
+
+export const viewport: Viewport = {
+  width: 'device-width',
+  initialScale: 1,
+  maximumScale: 1,
+};
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en">
+      <body>
+        <SessionProvider>
+          {/* Applies the business palette live at the document root. */}
+          <ThemeProvider />
+          {/* Re-locks the tab to sign-in after inactivity. */}
+          <IdleLock />
+          {children}
+        </SessionProvider>
+      </body>
+    </html>
+  );
+}

--- a/web-pos/src/app/page.tsx
+++ b/web-pos/src/app/page.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import { useSession } from '@/components/providers/SessionProvider';
+import { LoginForm } from '@/components/auth/LoginForm';
+import { AppShell } from '@/components/shell/AppShell';
+import { PosScreen } from '@/components/pos/PosScreen';
+
+// App entry. The signed-in Supabase session is the Operator (ADR 0011): while it
+// resolves we show a spinner; signed-out shows the sign-in screen; signed-in
+// shows the shell + POS. An idle timeout (IdleLock in the layout) drops a
+// signed-in tab back to signed-out, which re-renders the sign-in screen.
+export default function Home() {
+  const { status, operator, operatorLoading } = useSession();
+
+  if (status === 'loading') {
+    return <FullscreenSpinner label="Loading…" />;
+  }
+
+  if (status === 'signed-out') {
+    return <LoginForm />;
+  }
+
+  // Signed in: wait for the first Operator resolution so the shell paints with
+  // the business palette, name, role and permissions in place (no flash).
+  if (operatorLoading && !operator) {
+    return <FullscreenSpinner label="Loading your business…" />;
+  }
+
+  if (operator && !operator.businessId) {
+    return <NoBusinessNotice />;
+  }
+
+  return (
+    <AppShell>
+      <PosScreen />
+    </AppShell>
+  );
+}
+
+function FullscreenSpinner({ label }: { label: string }) {
+  return (
+    <div className="center-screen">
+      <div style={{ display: 'grid', placeItems: 'center', gap: 16 }}>
+        <div className="spinner" />
+        <p className="muted">{label}</p>
+      </div>
+    </div>
+  );
+}
+
+function NoBusinessNotice() {
+  const { signOut } = useSession();
+  return (
+    <div className="center-screen">
+      <div className="card" style={{ maxWidth: 420, padding: 28 }}>
+        <h2 style={{ marginTop: 0 }}>No business found</h2>
+        <p className="muted">
+          This account isn&apos;t linked to a business yet. Finish onboarding on
+          the mobile app, then sign in here again.
+        </p>
+        <button
+          className="btn btn--outline btn--block"
+          onClick={() => void signOut()}
+        >
+          Sign out
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/web-pos/src/components/auth/IdleLock.tsx
+++ b/web-pos/src/components/auth/IdleLock.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import { useCallback } from 'react';
+
+import { useSession } from '@/components/providers/SessionProvider';
+import { useIdleTimeout } from '@/hooks/useIdleTimeout';
+
+// Idle re-lock: signs the Operator out after inactivity, which drops the tab
+// back to the sign-in screen (the app renders <Login/> whenever status is
+// signed-out). Only armed while signed in.
+const IDLE_TIMEOUT_MS = 15 * 60 * 1000; // 15 minutes
+
+export function IdleLock() {
+  const { status, signOut } = useSession();
+
+  const onIdle = useCallback(() => {
+    void signOut();
+  }, [signOut]);
+
+  useIdleTimeout(onIdle, IDLE_TIMEOUT_MS, status === 'signed-in');
+  return null;
+}

--- a/web-pos/src/components/auth/LoginForm.tsx
+++ b/web-pos/src/components/auth/LoginForm.tsx
@@ -1,0 +1,198 @@
+'use client';
+
+import { useState } from 'react';
+
+import { useSession } from '@/components/providers/SessionProvider';
+
+// Sign-in screen (AC: "sign in via email OTP and via Google"). Two factors over
+// the same Supabase session; on success the session becomes the Operator (ADR
+// 0011) and the app entry swaps to the shell. No PIN, no "Who's working?" picker
+// on web — deliberately (ADR 0011).
+type Step = 'enter-email' | 'enter-code';
+
+export function LoginForm() {
+  const { supabase } = useSession();
+  const [step, setStep] = useState<Step>('enter-email');
+  const [email, setEmail] = useState('');
+  const [code, setCode] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+
+  const sendOtp = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setNotice(null);
+    setBusy(true);
+    try {
+      const { error } = await supabase.auth.signInWithOtp({
+        email: email.trim(),
+        options: { shouldCreateUser: false },
+      });
+      if (error) throw error;
+      setStep('enter-code');
+      setNotice(`We sent a 6-digit code to ${email.trim()}.`);
+    } catch (err) {
+      setError(messageOf(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const verifyOtp = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setBusy(true);
+    try {
+      const { error } = await supabase.auth.verifyOtp({
+        email: email.trim(),
+        token: code.trim(),
+        type: 'email',
+      });
+      if (error) throw error;
+      // onAuthStateChange (SessionProvider) takes over from here.
+    } catch (err) {
+      setError(messageOf(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const signInWithGoogle = async () => {
+    setError(null);
+    setBusy(true);
+    try {
+      const redirectTo = `${window.location.origin}/auth/callback`;
+      const { error } = await supabase.auth.signInWithOAuth({
+        provider: 'google',
+        options: { redirectTo },
+      });
+      if (error) throw error;
+      // Browser redirects to Google; no further work here.
+    } catch (err) {
+      setError(messageOf(err));
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="center-screen">
+      <div className="card" style={{ width: '100%', maxWidth: 380, padding: 28 }}>
+        <div className="shell__brand" style={{ marginBottom: 6 }}>
+          <span className="shell__brand-dot" />
+          <span>Reebaplus Web POS</span>
+        </div>
+        <p className="muted" style={{ marginTop: 0, fontSize: 14 }}>
+          Sign in to operate your business.
+        </p>
+
+        {error && (
+          <div className="banner banner--error" style={{ marginBottom: 14 }}>
+            {error}
+          </div>
+        )}
+        {notice && (
+          <div className="banner banner--info" style={{ marginBottom: 14 }}>
+            {notice}
+          </div>
+        )}
+
+        {step === 'enter-email' ? (
+          <form onSubmit={sendOtp} style={{ display: 'grid', gap: 14 }}>
+            <div className="field">
+              <label className="field__label" htmlFor="email">
+                Email
+              </label>
+              <input
+                id="email"
+                className="input"
+                type="email"
+                autoComplete="email"
+                inputMode="email"
+                required
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                placeholder="you@business.com"
+              />
+            </div>
+            <button
+              className="btn btn--primary btn--block"
+              type="submit"
+              disabled={busy || !email.trim()}
+            >
+              {busy ? 'Sending…' : 'Email me a code'}
+            </button>
+          </form>
+        ) : (
+          <form onSubmit={verifyOtp} style={{ display: 'grid', gap: 14 }}>
+            <div className="field">
+              <label className="field__label" htmlFor="code">
+                6-digit code
+              </label>
+              <input
+                id="code"
+                className="input"
+                inputMode="numeric"
+                autoComplete="one-time-code"
+                required
+                value={code}
+                onChange={(e) => setCode(e.target.value)}
+                placeholder="123456"
+              />
+            </div>
+            <button
+              className="btn btn--primary btn--block"
+              type="submit"
+              disabled={busy || code.trim().length < 4}
+            >
+              {busy ? 'Verifying…' : 'Verify & sign in'}
+            </button>
+            <button
+              type="button"
+              className="btn btn--outline btn--block"
+              onClick={() => {
+                setStep('enter-email');
+                setCode('');
+                setNotice(null);
+              }}
+              disabled={busy}
+            >
+              Use a different email
+            </button>
+          </form>
+        )}
+
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 12,
+            margin: '18px 0',
+            color: 'var(--subtext)',
+            fontSize: 12,
+          }}
+        >
+          <span style={{ flex: 1, height: 1, background: 'var(--border)' }} />
+          OR
+          <span style={{ flex: 1, height: 1, background: 'var(--border)' }} />
+        </div>
+
+        <button
+          type="button"
+          className="btn btn--outline btn--block"
+          onClick={signInWithGoogle}
+          disabled={busy}
+        >
+          Continue with Google
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function messageOf(err: unknown): string {
+  if (err && typeof err === 'object' && 'message' in err) {
+    return String((err as { message: unknown }).message);
+  }
+  return 'Something went wrong. Please try again.';
+}

--- a/web-pos/src/components/permissions/Can.tsx
+++ b/web-pos/src/components/permissions/Can.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import type { ReactNode } from 'react';
+
+import { useSession } from '@/components/providers/SessionProvider';
+import { can, type PermissionKey } from '@/lib/permissions';
+
+// hide-don't-block hook: is the current Operator allowed this action? The CEO is
+// always all-on (resolved in loadOperator → resolveEffectivePermissions).
+export function useCan(key: PermissionKey): boolean {
+  const { operator } = useSession();
+  return can(operator?.permissions, key);
+}
+
+// Renders `children` only when the Operator has `perm`; otherwise renders
+// `fallback` (default: nothing). This is the reusable hide-don't-block wrapper
+// later slices use to gate buttons/actions in the web UI.
+export function Can({
+  perm,
+  children,
+  fallback = null,
+}: {
+  perm: PermissionKey;
+  children: ReactNode;
+  fallback?: ReactNode;
+}) {
+  const allowed = useCan(perm);
+  return <>{allowed ? children : fallback}</>;
+}

--- a/web-pos/src/components/pos/Cart.tsx
+++ b/web-pos/src/components/pos/Cart.tsx
@@ -1,0 +1,264 @@
+'use client';
+
+import { useMemo } from 'react';
+
+import { useSession } from '@/components/providers/SessionProvider';
+import { useCurrency } from '@/hooks/useCurrency';
+import { lineUnitPriceKobo } from '@/lib/checkout';
+import { businessTracksCrates, crateSummary } from '@/lib/crate';
+import { useCart } from './CartProvider';
+
+// The cart panel: line items (qty stepper + remove), a role-capped discount, the
+// running order total, and the button into checkout. Grid-beside-cart on tablet+
+// (PRD responsive bands); on phone it's the full-screen sheet PosScreen toggles.
+export function Cart({
+  onCheckout,
+  onClose,
+  onOpenCustomerPicker,
+}: {
+  onCheckout: () => void;
+  onClose?: () => void;
+  onOpenCustomerPicker?: () => void;
+}) {
+  const { operator } = useSession();
+  const { kobo } = useCurrency();
+  const {
+    lines,
+    discountKobo,
+    subtotalKobo,
+    totalKobo,
+    itemCount,
+    customer,
+    setQuantity,
+    remove,
+    setDiscountKobo,
+    detachCustomer,
+    clear,
+  } = useCart();
+
+  const maxPct = operator?.maxDiscountPercent ?? 0;
+  const discountCapKobo = useMemo(
+    () => Math.floor((subtotalKobo * maxPct) / 100),
+    [subtotalKobo, maxPct],
+  );
+  const cappedDiscountKobo = Math.min(discountKobo, discountCapKobo);
+  const overCap = discountKobo > discountCapKobo;
+
+  // Empties surface (Slice 4, #45): hidden entirely unless the business is
+  // crate-eligible AND opts into empty tracking (mirrors mobile's hide). When on,
+  // it summarises the returnable, deposit-bearing crates in the cart.
+  const crateOn = businessTracksCrates(
+    operator?.business?.type,
+    operator?.business?.tracksEmptyCrates ?? false,
+  );
+  const empties = useMemo(
+    () => crateSummary(lines, crateOn),
+    [lines, crateOn],
+  );
+
+  const empty = lines.length === 0;
+
+  return (
+    <aside className="cart" aria-label="Cart">
+      <div className="cart__head">
+        <h2 className="cart__title">
+          Cart{itemCount > 0 && <span className="cart__count">{itemCount}</span>}
+        </h2>
+        <div className="cart__head-actions">
+          {!empty && (
+            <button className="cart__link" onClick={clear} type="button">
+              Clear
+            </button>
+          )}
+          {onClose && (
+            <button
+              className="cart__link"
+              onClick={onClose}
+              type="button"
+              aria-label="Close cart"
+            >
+              Close
+            </button>
+          )}
+        </div>
+      </div>
+
+      {onOpenCustomerPicker && (
+        <div className="cart__customer">
+          {customer ? (
+            <>
+              <div className="cart__customer-info">
+                <span className="cart__customer-name">{customer.name}</span>
+                <span
+                  className={`cart__customer-balance${
+                    customer.balanceKobo < 0
+                      ? ' cart__customer-balance--owed'
+                      : ' cart__customer-balance--credit'
+                  }`}
+                >
+                  {customer.balanceKobo < 0
+                    ? `Owes ${kobo(-customer.balanceKobo)}`
+                    : `${kobo(customer.balanceKobo)} credit`}
+                </span>
+              </div>
+              <div className="cart__customer-actions">
+                <button
+                  className="cart__link"
+                  type="button"
+                  onClick={onOpenCustomerPicker}
+                >
+                  Change
+                </button>
+                <button
+                  className="cart__link"
+                  type="button"
+                  onClick={detachCustomer}
+                >
+                  Remove
+                </button>
+              </div>
+            </>
+          ) : (
+            <button
+              type="button"
+              className="cart__customer-add"
+              onClick={onOpenCustomerPicker}
+            >
+              + Attach customer
+            </button>
+          )}
+        </div>
+      )}
+
+      {empty ? (
+        <div className="cart__empty">
+          Tap products to add them to the sale.
+        </div>
+      ) : (
+        <ul className="cart__lines">
+          {lines.map((l) => {
+            const unit = lineUnitPriceKobo(l.product);
+            return (
+              <li key={l.product.id} className="cart__line">
+                <div className="cart__line-info">
+                  <div className="cart__line-name">{l.product.name}</div>
+                  <div className="cart__line-unit">{kobo(unit)} each</div>
+                </div>
+                <div className="cart__stepper" role="group" aria-label={`Quantity for ${l.product.name}`}>
+                  <button
+                    type="button"
+                    className="cart__step"
+                    onClick={() => setQuantity(l.product.id, l.quantity - 1)}
+                    aria-label="Decrease quantity"
+                  >
+                    −
+                  </button>
+                  <input
+                    className="cart__qty"
+                    type="number"
+                    min={1}
+                    value={l.quantity}
+                    onChange={(e) =>
+                      setQuantity(l.product.id, Number.parseInt(e.target.value, 10) || 0)
+                    }
+                    aria-label={`Quantity for ${l.product.name}`}
+                  />
+                  <button
+                    type="button"
+                    className="cart__step"
+                    onClick={() => setQuantity(l.product.id, l.quantity + 1)}
+                    disabled={l.quantity >= Math.max(l.product.onHand, 1)}
+                    aria-label="Increase quantity"
+                  >
+                    +
+                  </button>
+                </div>
+                <div className="cart__line-total">{kobo(unit * l.quantity)}</div>
+                <button
+                  type="button"
+                  className="cart__remove"
+                  onClick={() => remove(l.product.id)}
+                  aria-label={`Remove ${l.product.name}`}
+                >
+                  ✕
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+
+      {!empty && (
+        <div className="cart__foot">
+          <div className="cart__row">
+            <span>Subtotal</span>
+            <span>{kobo(subtotalKobo)}</span>
+          </div>
+
+          {maxPct > 0 && (
+            <div className="cart__discount">
+              <label className="cart__discount-label" htmlFor="cart-discount">
+                Discount
+                <span className="cart__discount-cap">
+                  up to {maxPct}% ({kobo(discountCapKobo)})
+                </span>
+              </label>
+              <div className="cart__discount-input">
+                <input
+                  id="cart-discount"
+                  className="input"
+                  type="number"
+                  min={0}
+                  step={1}
+                  value={discountKobo === 0 ? '' : Math.round(discountKobo / 100)}
+                  placeholder="0"
+                  onChange={(e) => {
+                    const major = Number.parseFloat(e.target.value) || 0;
+                    setDiscountKobo(Math.round(major * 100));
+                  }}
+                />
+              </div>
+              {overCap && (
+                <div className="cart__discount-note">
+                  Capped at your role limit — {kobo(discountCapKobo)} applied.
+                </div>
+              )}
+            </div>
+          )}
+
+          {cappedDiscountKobo > 0 && (
+            <div className="cart__row cart__row--muted">
+              <span>Discount</span>
+              <span>−{kobo(cappedDiscountKobo)}</span>
+            </div>
+          )}
+
+          <div className="cart__row cart__row--total">
+            <span>Total</span>
+            <span>{kobo(totalKobo)}</span>
+          </div>
+
+          {crateOn && empties.crates > 0 && (
+            <div className="cart__row cart__row--muted">
+              <span>Empties (returnable)</span>
+              <span>
+                {empties.crates} crate{empties.crates === 1 ? '' : 's'}
+                {empties.depositValueKobo > 0 &&
+                  ` · ${kobo(empties.depositValueKobo)} deposit`}
+              </span>
+            </div>
+          )}
+
+          <button
+            type="button"
+            className="btn btn--primary btn--block cart__checkout"
+            onClick={onCheckout}
+            disabled={totalKobo <= 0}
+          >
+            Checkout · {kobo(totalKobo)}
+          </button>
+        </div>
+      )}
+    </aside>
+  );
+}

--- a/web-pos/src/components/pos/CartProvider.tsx
+++ b/web-pos/src/components/pos/CartProvider.tsx
@@ -1,0 +1,153 @@
+'use client';
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+  type ReactNode,
+} from 'react';
+
+import type { CustomerWithBalance, ProductWithStock } from '@/lib/types';
+import { lineUnitPriceKobo } from '@/lib/checkout';
+
+// A Cart is a pre-checkout draft (CONTEXT.md "Cart"): mutable, no revenue, no
+// status. It becomes an Order at Checkout. This provider holds it in React state
+// above the POS screen so it persists across in-screen navigation within the
+// session (user story #13) and is cleared by "Done — back to POS".
+
+export interface CartLine {
+  product: ProductWithStock;
+  quantity: number;
+}
+
+interface CartContextValue {
+  lines: CartLine[];
+  discountKobo: number;
+  itemCount: number;
+  subtotalKobo: number;
+  // Discount clamped to the role cap (see cappedDiscountKobo); totalKobo uses it.
+  totalKobo: number;
+  // The registered customer attached to the sale (Slice 3), or null for a
+  // walk-in. Drives the credit/wallet checkout paths and the debt-limit guard.
+  customer: CustomerWithBalance | null;
+  add: (product: ProductWithStock) => void;
+  setQuantity: (productId: string, quantity: number) => void;
+  remove: (productId: string) => void;
+  setDiscountKobo: (kobo: number) => void;
+  attachCustomer: (customer: CustomerWithBalance) => void;
+  detachCustomer: () => void;
+  clear: () => void;
+}
+
+const CartContext = createContext<CartContextValue | null>(null);
+
+export function CartProvider({ children }: { children: ReactNode }) {
+  const [lines, setLines] = useState<CartLine[]>([]);
+  const [discountKobo, setDiscountRaw] = useState(0);
+  const [customer, setCustomer] = useState<CustomerWithBalance | null>(null);
+
+  const add = useCallback((product: ProductWithStock) => {
+    setLines((prev) => {
+      const existing = prev.find((l) => l.product.id === product.id);
+      if (existing) {
+        // Don't exceed the live on-hand count.
+        const next = Math.min(existing.quantity + 1, Math.max(product.onHand, 1));
+        return prev.map((l) =>
+          l.product.id === product.id ? { ...l, quantity: next } : l,
+        );
+      }
+      return [...prev, { product, quantity: 1 }];
+    });
+  }, []);
+
+  const setQuantity = useCallback((productId: string, quantity: number) => {
+    setLines((prev) => {
+      if (quantity <= 0) return prev.filter((l) => l.product.id !== productId);
+      return prev.map((l) =>
+        l.product.id === productId
+          ? { ...l, quantity: Math.min(quantity, Math.max(l.product.onHand, 1)) }
+          : l,
+      );
+    });
+  }, []);
+
+  const remove = useCallback((productId: string) => {
+    setLines((prev) => prev.filter((l) => l.product.id !== productId));
+  }, []);
+
+  const setDiscountKobo = useCallback((kobo: number) => {
+    setDiscountRaw(Math.max(0, Math.round(kobo)));
+  }, []);
+
+  const attachCustomer = useCallback((c: CustomerWithBalance) => {
+    setCustomer(c);
+  }, []);
+
+  const detachCustomer = useCallback(() => {
+    setCustomer(null);
+  }, []);
+
+  const clear = useCallback(() => {
+    setLines([]);
+    setDiscountRaw(0);
+    setCustomer(null);
+  }, []);
+
+  const subtotalKobo = useMemo(
+    () =>
+      lines.reduce(
+        (sum, l) => sum + lineUnitPriceKobo(l.product) * l.quantity,
+        0,
+      ),
+    [lines],
+  );
+
+  const itemCount = useMemo(
+    () => lines.reduce((n, l) => n + l.quantity, 0),
+    [lines],
+  );
+
+  const cappedDiscount = Math.min(discountKobo, subtotalKobo);
+  const value = useMemo<CartContextValue>(
+    () => ({
+      lines,
+      discountKobo,
+      itemCount,
+      subtotalKobo,
+      totalKobo: Math.max(0, subtotalKobo - cappedDiscount),
+      customer,
+      add,
+      setQuantity,
+      remove,
+      setDiscountKobo,
+      attachCustomer,
+      detachCustomer,
+      clear,
+    }),
+    [
+      lines,
+      discountKobo,
+      itemCount,
+      subtotalKobo,
+      cappedDiscount,
+      customer,
+      add,
+      setQuantity,
+      remove,
+      setDiscountKobo,
+      attachCustomer,
+      detachCustomer,
+      clear,
+    ],
+  );
+
+  return <CartContext.Provider value={value}>{children}</CartContext.Provider>;
+}
+
+export function useCart(): CartContextValue {
+  const ctx = useContext(CartContext);
+  if (!ctx) throw new Error('useCart must be used within a CartProvider');
+  return ctx;
+}

--- a/web-pos/src/components/pos/CheckoutDialog.tsx
+++ b/web-pos/src/components/pos/CheckoutDialog.tsx
@@ -1,0 +1,303 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+
+import { useSession } from '@/components/providers/SessionProvider';
+import { useCurrency } from '@/hooks/useCurrency';
+import {
+  checkoutOrder,
+  lineUnitPriceKobo,
+  type CheckoutResult,
+  type PaymentMethod,
+} from '@/lib/checkout';
+import { businessTracksCrates, crateSummary } from '@/lib/crate';
+import { useCart } from './CartProvider';
+
+// Checkout for all Slice 3 paths. Walk-in ⇒ Cash/Transfer only (Slice 2). With a
+// registered customer attached ⇒ also Pay-with-Credit (draw from their balance)
+// and Register-as-Credit-Sale (they owe the balance). The debt limit is enforced
+// server-side by checkout_order; this dialog mirrors that decision client-side
+// (hide-don't-block) so the operator sees the block before hitting Complete. The
+// write itself stays the server-authoritative RPC — this only gathers inputs.
+export function CheckoutDialog({
+  onCancel,
+  onComplete,
+}: {
+  onCancel: () => void;
+  onComplete: (result: CheckoutResult) => void;
+}) {
+  const { supabase, operator } = useSession();
+  const { kobo } = useCurrency();
+  const { lines, subtotalKobo, totalKobo, customer } = useCart();
+
+  const [method, setMethod] = useState<PaymentMethod>('cash');
+  // Amount tendered (cash/transfer), in major units; defaults to the exact total.
+  const [tendered, setTendered] = useState<string>(
+    String(Math.round(totalKobo / 100)),
+  );
+  // Partial cash taken now on a Register-as-Credit-Sale (major units).
+  const [creditPaid, setCreditPaid] = useState<string>('0');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const isCashLike = method === 'cash' || method === 'transfer';
+  const balanceKobo = customer?.balanceKobo ?? 0;
+  const limitKobo = customer?.debtLimitKobo ?? 0;
+
+  const tenderedKobo = useMemo(
+    () => Math.round((Number.parseFloat(tendered) || 0) * 100),
+    [tendered],
+  );
+  const creditPaidKobo = useMemo(
+    () =>
+      Math.min(
+        Math.max(Math.round((Number.parseFloat(creditPaid) || 0) * 100), 0),
+        totalKobo,
+      ),
+    [creditPaid, totalKobo],
+  );
+
+  // The cash that actually settles, by path (mirrors the RPC's v_cash_paid).
+  const cashPaidKobo =
+    method === 'wallet' ? 0 : method === 'credit' ? creditPaidKobo : totalKobo;
+
+  const changeKobo = Math.max(0, tenderedKobo - totalKobo);
+  const discountAppliedKobo = subtotalKobo - totalKobo;
+  const cashUnderpaid = isCashLike && tenderedKobo < totalKobo;
+
+  // Projected balance after the sale, and the debt-limit block (mirrors the
+  // server's rule: a fully-cash-settled sale never books debt; otherwise the
+  // projected balance must stay ≥ −limit, and limit 0 means no credit at all).
+  const projectedKobo = balanceKobo + cashPaidKobo - totalKobo;
+  const booksNewDebt = cashPaidKobo < totalKobo && projectedKobo < 0;
+  const overDebtLimit =
+    booksNewDebt && (limitKobo <= 0 || projectedKobo < -limitKobo);
+
+  const storeId = operator?.stores?.[0]?.id ?? null;
+  const businessId = operator?.businessId ?? null;
+
+  const canSubmit =
+    !submitting &&
+    totalKobo > 0 &&
+    !cashUnderpaid &&
+    !overDebtLimit &&
+    // credit/wallet require a customer to post the wallet legs against
+    (isCashLike || customer != null);
+
+  async function submit() {
+    if (!businessId || !storeId) {
+      setError('No store is set up for this business yet.');
+      return;
+    }
+    setSubmitting(true);
+    setError(null);
+    try {
+      const result = await checkoutOrder(supabase, {
+        businessId,
+        storeId,
+        paymentMethod: method,
+        amountPaidKobo: cashPaidKobo,
+        discountKobo: discountAppliedKobo,
+        customerId: customer?.id ?? null,
+        customerName: customer?.name ?? null,
+        lines: lines.map((l) => ({
+          productId: l.product.id,
+          quantity: l.quantity,
+          unitPriceKobo: lineUnitPriceKobo(l.product),
+          name: l.product.name,
+        })),
+      });
+      // Empty-crate summary for the receipt (Slice 4): the returnable crates the
+      // customer takes and their deposit value, shown only when the business
+      // tracks crates. The crate LEDGER itself was posted server-side by the RPC.
+      const crateOn = businessTracksCrates(
+        operator?.business?.type,
+        operator?.business?.tracksEmptyCrates ?? false,
+      );
+      const empties = crateSummary(lines, crateOn);
+      const crate = {
+        crateCount: empties.crates,
+        crateDepositKobo: empties.depositValueKobo,
+      };
+      onComplete(
+        isCashLike
+          ? { ...result, tenderedKobo, changeKobo, ...crate }
+          : { ...result, ...crate },
+      );
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Checkout failed.');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  const methodLabel: Record<PaymentMethod, string> = {
+    cash: 'Cash',
+    transfer: 'Transfer',
+    wallet: 'Pay with Credit',
+    credit: 'Credit Sale',
+  };
+
+  const completeLabel =
+    method === 'wallet'
+      ? 'Pay with credit'
+      : method === 'credit'
+        ? 'Register credit sale'
+        : `Complete ${method} sale`;
+
+  return (
+    <div className="modal-overlay" role="dialog" aria-modal="true" aria-label="Checkout">
+      <div className="modal">
+        <div className="modal__head">
+          <h2 className="modal__title">Checkout</h2>
+          <button className="modal__close" onClick={onCancel} aria-label="Close">
+            ✕
+          </button>
+        </div>
+
+        <div className="modal__body">
+          <div className="checkout__total-line">
+            <span>Amount due</span>
+            <strong>{kobo(totalKobo)}</strong>
+          </div>
+
+          {customer && (
+            <div className="checkout__customer">
+              <span className="checkout__customer-name">{customer.name}</span>
+              <span
+                className={
+                  balanceKobo < 0
+                    ? 'checkout__customer-balance checkout__customer-balance--owed'
+                    : 'checkout__customer-balance checkout__customer-balance--credit'
+                }
+              >
+                {balanceKobo < 0
+                  ? `Owes ${kobo(-balanceKobo)}`
+                  : `${kobo(balanceKobo)} credit`}
+              </span>
+            </div>
+          )}
+
+          <div className="field">
+            <span className="field__label">Payment method</span>
+            <div className="segmented segmented--wrap" role="group" aria-label="Payment method">
+              {(['cash', 'transfer'] as PaymentMethod[]).map((m) => (
+                <button
+                  key={m}
+                  type="button"
+                  className={`segmented__opt${method === m ? ' segmented__opt--active' : ''}`}
+                  onClick={() => setMethod(m)}
+                >
+                  {methodLabel[m]}
+                </button>
+              ))}
+              {customer &&
+                (['wallet', 'credit'] as PaymentMethod[]).map((m) => (
+                  <button
+                    key={m}
+                    type="button"
+                    className={`segmented__opt${method === m ? ' segmented__opt--active' : ''}`}
+                    onClick={() => setMethod(m)}
+                  >
+                    {methodLabel[m]}
+                  </button>
+                ))}
+            </div>
+          </div>
+
+          {isCashLike && (
+            <>
+              <div className="field">
+                <label className="field__label" htmlFor="tendered">
+                  Amount paid
+                </label>
+                <input
+                  id="tendered"
+                  className="input"
+                  type="number"
+                  min={0}
+                  inputMode="decimal"
+                  value={tendered}
+                  onChange={(e) => setTendered(e.target.value)}
+                />
+              </div>
+              <div className="checkout__change">
+                <span>Change</span>
+                <span>{kobo(changeKobo)}</span>
+              </div>
+            </>
+          )}
+
+          {method === 'credit' && (
+            <div className="field">
+              <label className="field__label" htmlFor="credit-paid">
+                Paid now (optional)
+              </label>
+              <input
+                id="credit-paid"
+                className="input"
+                type="number"
+                min={0}
+                inputMode="decimal"
+                value={creditPaid}
+                onChange={(e) => setCreditPaid(e.target.value)}
+              />
+              <p className="field__hint">
+                {creditPaidKobo > 0
+                  ? `${kobo(creditPaidKobo)} now, ${kobo(totalKobo - creditPaidKobo)} on credit.`
+                  : 'The whole total is booked to the customer as debt.'}
+              </p>
+            </div>
+          )}
+
+          {method === 'wallet' && (
+            <p className="field__hint">
+              {kobo(totalKobo)} is drawn from {customer?.name}&rsquo;s credit
+              balance — no cash changes hands.
+            </p>
+          )}
+
+          {customer && !isCashLike && (
+            <div className="checkout__projected">
+              <span>Balance after sale</span>
+              <span
+                className={
+                  projectedKobo < 0
+                    ? 'checkout__customer-balance--owed'
+                    : 'checkout__customer-balance--credit'
+                }
+              >
+                {projectedKobo < 0
+                  ? `Owes ${kobo(-projectedKobo)}`
+                  : `${kobo(projectedKobo)} credit`}
+              </span>
+            </div>
+          )}
+
+          {overDebtLimit && (
+            <div className="banner banner--error">
+              {limitKobo <= 0
+                ? `${customer?.name} has no credit limit set — they can’t take goods on credit. Take the full amount or set a limit on mobile.`
+                : `This would push ${customer?.name} to ${kobo(-projectedKobo)} owed, past their ${kobo(limitKobo)} limit. Take a payment or lower the amount.`}
+            </div>
+          )}
+
+          {error && <div className="banner banner--error">{error}</div>}
+        </div>
+
+        <div className="modal__foot">
+          <button className="btn btn--outline" onClick={onCancel} disabled={submitting}>
+            Cancel
+          </button>
+          <button
+            className="btn btn--primary"
+            onClick={() => void submit()}
+            disabled={!canSubmit}
+          >
+            {submitting ? 'Settling…' : completeLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web-pos/src/components/pos/CustomerPicker.tsx
+++ b/web-pos/src/components/pos/CustomerPicker.tsx
@@ -1,0 +1,122 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+
+import { useCurrency } from '@/hooks/useCurrency';
+import type { CustomerWithBalance } from '@/lib/types';
+
+// A searchable modal for attaching a registered customer to the cart (Slice 3,
+// user story #12). Each row shows the customer's live derived wallet balance —
+// positive (credit we hold) in green, negative (they owe us) in red — so the
+// operator can see credit standing before choosing a credit path at checkout.
+// Registering a NEW customer is a mobile flow for now (out of scope for Slice 3).
+export function CustomerPicker({
+  customers,
+  loading,
+  error,
+  onPick,
+  onClose,
+}: {
+  customers: CustomerWithBalance[];
+  loading: boolean;
+  error: string | null;
+  onPick: (customer: CustomerWithBalance) => void;
+  onClose: () => void;
+}) {
+  const { kobo } = useCurrency();
+  const [query, setQuery] = useState('');
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return customers;
+    return customers.filter(
+      (c) =>
+        c.name.toLowerCase().includes(q) ||
+        (c.phone ?? '').toLowerCase().includes(q),
+    );
+  }, [customers, query]);
+
+  return (
+    <div
+      className="modal-overlay"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Attach customer"
+    >
+      <div className="modal">
+        <div className="modal__head">
+          <h2 className="modal__title">Attach a customer</h2>
+          <button className="modal__close" onClick={onClose} aria-label="Close">
+            ✕
+          </button>
+        </div>
+
+        <div className="modal__body">
+          <input
+            className="input"
+            type="search"
+            placeholder="Search by name or phone…"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            autoFocus
+            aria-label="Search customers"
+          />
+
+          {error && <div className="banner banner--error">{error}</div>}
+
+          {loading ? (
+            <div className="empty-state">
+              <div className="spinner" style={{ margin: '0 auto 12px' }} />
+              Loading customers…
+            </div>
+          ) : filtered.length === 0 ? (
+            <div className="empty-state">
+              {customers.length === 0
+                ? 'No registered customers yet. Add one on the mobile app.'
+                : 'No customers match your search.'}
+            </div>
+          ) : (
+            <ul className="customer-list">
+              {filtered.map((c) => {
+                const owes = c.balanceKobo < 0;
+                return (
+                  <li key={c.id}>
+                    <button
+                      type="button"
+                      className="customer-list__row"
+                      onClick={() => onPick(c)}
+                    >
+                      <span className="customer-list__info">
+                        <span className="customer-list__name">{c.name}</span>
+                        {c.phone && (
+                          <span className="customer-list__phone">{c.phone}</span>
+                        )}
+                      </span>
+                      <span
+                        className={`customer-list__balance${
+                          owes
+                            ? ' customer-list__balance--owed'
+                            : ' customer-list__balance--credit'
+                        }`}
+                      >
+                        {owes
+                          ? `Owes ${kobo(-c.balanceKobo)}`
+                          : `${kobo(c.balanceKobo)} credit`}
+                      </span>
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </div>
+
+        <div className="modal__foot">
+          <button className="btn btn--outline" onClick={onClose}>
+            Cancel
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web-pos/src/components/pos/PosScreen.tsx
+++ b/web-pos/src/components/pos/PosScreen.tsx
@@ -4,35 +4,58 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { useSession } from '@/components/providers/SessionProvider';
 import { useCan } from '@/components/permissions/Can';
+import { useCurrency } from '@/hooks/useCurrency';
+import { useCustomers } from '@/hooks/useCustomers';
 import { PermissionKeys } from '@/lib/permissions';
 import { loadCatalogue, type Catalogue } from '@/lib/catalogue';
-import type { ProductWithStock } from '@/lib/types';
+import type { CheckoutResult } from '@/lib/checkout';
+import type { CustomerWithBalance, ProductWithStock } from '@/lib/types';
 import { ProductCard } from './ProductCard';
+import { CartProvider, useCart } from './CartProvider';
+import { Cart } from './Cart';
+import { CheckoutDialog } from './CheckoutDialog';
+import { CustomerPicker } from './CustomerPicker';
+import { Receipt } from './Receipt';
 
 const ALL = 'all';
 
-// The POS product grid — Slice 1's one live, end-to-end screen. It reads the
-// RLS-scoped catalogue (categories + per-tier prices + on-hand stock) over
-// PostgREST and renders it in the responsive grid. Realtime auto-refresh is
-// Slice 5; here a manual Refresh re-pulls. Tapping a product is gated on
-// sales.make (the cart itself lands in Slice 2 / #43).
+// Slice 2 turns the walking-skeleton grid into the full selling loop: grid → cart
+// → checkout (cash/transfer) → receipt → "Done, back to POS". The cart lives in a
+// CartProvider above the screen so it survives in-screen navigation within the
+// session. Realtime auto-refresh is Slice 5; here a manual Refresh (and an
+// automatic one after each sale) re-pulls live stock.
 export function PosScreen() {
+  return (
+    <CartProvider>
+      <PosInner />
+    </CartProvider>
+  );
+}
+
+type Phase = 'shop' | 'checkout' | 'receipt';
+
+function PosInner() {
   const { supabase, operator } = useSession();
   const canSell = useCan(PermissionKeys.salesMake);
+  const { kobo } = useCurrency();
+  const cart = useCart();
+  const customers = useCustomers();
 
   const [catalogue, setCatalogue] = useState<Catalogue | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [category, setCategory] = useState<string>(ALL);
-  const [selected, setSelected] = useState<ProductWithStock | null>(null);
+  const [phase, setPhase] = useState<Phase>('shop');
+  const [cartOpen, setCartOpen] = useState(false);
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [result, setResult] = useState<CheckoutResult | null>(null);
 
   const businessId = operator?.businessId ?? null;
 
   const refresh = useCallback(async () => {
     setError(null);
     try {
-      const next = await loadCatalogue(supabase);
-      setCatalogue(next);
+      setCatalogue(await loadCatalogue(supabase));
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load products.');
     } finally {
@@ -51,73 +74,153 @@ export function PosScreen() {
     return catalogue.products.filter((p) => p.category_id === category);
   }, [catalogue, category]);
 
-  const onSelect = useCallback((p: ProductWithStock) => {
-    // Cart wiring is Slice 2 (#43). For the skeleton, acknowledge the tap.
-    setSelected(p);
+  const onSelect = useCallback(
+    (p: ProductWithStock) => cart.add(p),
+    [cart],
+  );
+
+  const startCheckout = useCallback(() => {
+    setCartOpen(false);
+    setPhase('checkout');
   }, []);
 
+  const onCheckoutComplete = useCallback((r: CheckoutResult) => {
+    setResult(r);
+    setPhase('receipt');
+  }, []);
+
+  const onDone = useCallback(() => {
+    cart.clear();
+    setResult(null);
+    setPhase('shop');
+    setCartOpen(false);
+    // Stock + a customer's wallet balance changed — re-pull both so the grid
+    // and the next customer attach reflect the sale.
+    void refresh();
+    void customers.refresh();
+  }, [cart, refresh, customers]);
+
+  const onPickCustomer = useCallback(
+    (c: CustomerWithBalance) => {
+      cart.attachCustomer(c);
+      setPickerOpen(false);
+    },
+    [cart],
+  );
+
   return (
-    <div className="pos">
-      <div className="pos__header">
-        <h1 className="pos__title">Point of Sale</h1>
-        <button
-          className="btn btn--outline"
-          onClick={() => void refresh()}
-          disabled={loading}
-        >
-          {loading ? 'Loading…' : 'Refresh'}
-        </button>
+    <div className="pos-layout">
+      <div className="pos">
+        <div className="pos__header">
+          <h1 className="pos__title">Point of Sale</h1>
+          <button
+            className="btn btn--outline"
+            onClick={() => void refresh()}
+            disabled={loading}
+          >
+            {loading ? 'Loading…' : 'Refresh'}
+          </button>
+        </div>
+
+        {error && <div className="banner banner--error">{error}</div>}
+
+        {catalogue && catalogue.categories.length > 0 && (
+          <div className="category-bar" role="tablist" aria-label="Categories">
+            <CategoryChip
+              label="All"
+              active={category === ALL}
+              onClick={() => setCategory(ALL)}
+            />
+            {catalogue.categories.map((c) => (
+              <CategoryChip
+                key={c.id}
+                label={c.name}
+                active={category === c.id}
+                onClick={() => setCategory(c.id)}
+              />
+            ))}
+          </div>
+        )}
+
+        {loading && !catalogue ? (
+          <div className="empty-state">
+            <div className="spinner" style={{ margin: '0 auto 12px' }} />
+            Loading your catalogue…
+          </div>
+        ) : filtered.length === 0 ? (
+          <div className="empty-state">
+            {catalogue && catalogue.products.length === 0
+              ? 'No products yet. Add products on the mobile app or (soon) here on web.'
+              : 'No products in this category.'}
+          </div>
+        ) : (
+          <div className="product-grid">
+            {filtered.map((p) => (
+              <ProductCard
+                key={p.id}
+                product={p}
+                canSell={canSell}
+                onSelect={onSelect}
+              />
+            ))}
+          </div>
+        )}
       </div>
 
-      {selected && (
-        <div className="banner banner--info" role="status">
-          Selected <strong>{selected.name}</strong> — the cart & checkout arrive
-          in the next slice.
-        </div>
-      )}
-
-      {error && <div className="banner banner--error">{error}</div>}
-
-      {catalogue && catalogue.categories.length > 0 && (
-        <div className="category-bar" role="tablist" aria-label="Categories">
-          <CategoryChip
-            label="All"
-            active={category === ALL}
-            onClick={() => setCategory(ALL)}
+      {/* Desktop/tablet: cart beside the grid. Hidden on phone (CSS). */}
+      {canSell && (
+        <div className="pos-layout__cart">
+          <Cart
+            onCheckout={startCheckout}
+            onOpenCustomerPicker={() => setPickerOpen(true)}
           />
-          {catalogue.categories.map((c) => (
-            <CategoryChip
-              key={c.id}
-              label={c.name}
-              active={category === c.id}
-              onClick={() => setCategory(c.id)}
-            />
-          ))}
         </div>
       )}
 
-      {loading && !catalogue ? (
-        <div className="empty-state">
-          <div className="spinner" style={{ margin: '0 auto 12px' }} />
-          Loading your catalogue…
-        </div>
-      ) : filtered.length === 0 ? (
-        <div className="empty-state">
-          {catalogue && catalogue.products.length === 0
-            ? 'No products yet. Add products on the mobile app or (soon) here on web.'
-            : 'No products in this category.'}
-        </div>
-      ) : (
-        <div className="product-grid">
-          {filtered.map((p) => (
-            <ProductCard
-              key={p.id}
-              product={p}
-              canSell={canSell}
-              onSelect={onSelect}
+      {/* Phone: a sticky bar summarising the cart; taps open the cart sheet. */}
+      {canSell && cart.itemCount > 0 && (
+        <button
+          type="button"
+          className="cart-bar"
+          onClick={() => setCartOpen(true)}
+        >
+          <span className="cart-bar__count">{cart.itemCount}</span>
+          <span>View cart</span>
+          <span className="cart-bar__total">{kobo(cart.totalKobo)}</span>
+        </button>
+      )}
+
+      {canSell && cartOpen && (
+        <div className="cart-sheet-overlay" onClick={() => setCartOpen(false)}>
+          <div className="cart-sheet" onClick={(e) => e.stopPropagation()}>
+            <Cart
+              onCheckout={startCheckout}
+              onClose={() => setCartOpen(false)}
+              onOpenCustomerPicker={() => setPickerOpen(true)}
             />
-          ))}
+          </div>
         </div>
+      )}
+
+      {canSell && pickerOpen && (
+        <CustomerPicker
+          customers={customers.customers}
+          loading={customers.loading}
+          error={customers.error}
+          onPick={onPickCustomer}
+          onClose={() => setPickerOpen(false)}
+        />
+      )}
+
+      {phase === 'checkout' && (
+        <CheckoutDialog
+          onCancel={() => setPhase('shop')}
+          onComplete={onCheckoutComplete}
+        />
+      )}
+
+      {phase === 'receipt' && result && (
+        <Receipt result={result} onDone={onDone} />
       )}
     </div>
   );

--- a/web-pos/src/components/pos/PosScreen.tsx
+++ b/web-pos/src/components/pos/PosScreen.tsx
@@ -1,0 +1,146 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import { useSession } from '@/components/providers/SessionProvider';
+import { useCan } from '@/components/permissions/Can';
+import { PermissionKeys } from '@/lib/permissions';
+import { loadCatalogue, type Catalogue } from '@/lib/catalogue';
+import type { ProductWithStock } from '@/lib/types';
+import { ProductCard } from './ProductCard';
+
+const ALL = 'all';
+
+// The POS product grid — Slice 1's one live, end-to-end screen. It reads the
+// RLS-scoped catalogue (categories + per-tier prices + on-hand stock) over
+// PostgREST and renders it in the responsive grid. Realtime auto-refresh is
+// Slice 5; here a manual Refresh re-pulls. Tapping a product is gated on
+// sales.make (the cart itself lands in Slice 2 / #43).
+export function PosScreen() {
+  const { supabase, operator } = useSession();
+  const canSell = useCan(PermissionKeys.salesMake);
+
+  const [catalogue, setCatalogue] = useState<Catalogue | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [category, setCategory] = useState<string>(ALL);
+  const [selected, setSelected] = useState<ProductWithStock | null>(null);
+
+  const businessId = operator?.businessId ?? null;
+
+  const refresh = useCallback(async () => {
+    setError(null);
+    try {
+      const next = await loadCatalogue(supabase);
+      setCatalogue(next);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load products.');
+    } finally {
+      setLoading(false);
+    }
+  }, [supabase]);
+
+  useEffect(() => {
+    setLoading(true);
+    void refresh();
+  }, [refresh, businessId]);
+
+  const filtered = useMemo(() => {
+    if (!catalogue) return [];
+    if (category === ALL) return catalogue.products;
+    return catalogue.products.filter((p) => p.category_id === category);
+  }, [catalogue, category]);
+
+  const onSelect = useCallback((p: ProductWithStock) => {
+    // Cart wiring is Slice 2 (#43). For the skeleton, acknowledge the tap.
+    setSelected(p);
+  }, []);
+
+  return (
+    <div className="pos">
+      <div className="pos__header">
+        <h1 className="pos__title">Point of Sale</h1>
+        <button
+          className="btn btn--outline"
+          onClick={() => void refresh()}
+          disabled={loading}
+        >
+          {loading ? 'Loading…' : 'Refresh'}
+        </button>
+      </div>
+
+      {selected && (
+        <div className="banner banner--info" role="status">
+          Selected <strong>{selected.name}</strong> — the cart & checkout arrive
+          in the next slice.
+        </div>
+      )}
+
+      {error && <div className="banner banner--error">{error}</div>}
+
+      {catalogue && catalogue.categories.length > 0 && (
+        <div className="category-bar" role="tablist" aria-label="Categories">
+          <CategoryChip
+            label="All"
+            active={category === ALL}
+            onClick={() => setCategory(ALL)}
+          />
+          {catalogue.categories.map((c) => (
+            <CategoryChip
+              key={c.id}
+              label={c.name}
+              active={category === c.id}
+              onClick={() => setCategory(c.id)}
+            />
+          ))}
+        </div>
+      )}
+
+      {loading && !catalogue ? (
+        <div className="empty-state">
+          <div className="spinner" style={{ margin: '0 auto 12px' }} />
+          Loading your catalogue…
+        </div>
+      ) : filtered.length === 0 ? (
+        <div className="empty-state">
+          {catalogue && catalogue.products.length === 0
+            ? 'No products yet. Add products on the mobile app or (soon) here on web.'
+            : 'No products in this category.'}
+        </div>
+      ) : (
+        <div className="product-grid">
+          {filtered.map((p) => (
+            <ProductCard
+              key={p.id}
+              product={p}
+              canSell={canSell}
+              onSelect={onSelect}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function CategoryChip({
+  label,
+  active,
+  onClick,
+}: {
+  label: string;
+  active: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      role="tab"
+      aria-selected={active}
+      className={`chip${active ? ' chip--active' : ''}`}
+      onClick={onClick}
+    >
+      {label}
+    </button>
+  );
+}

--- a/web-pos/src/components/pos/ProductCard.tsx
+++ b/web-pos/src/components/pos/ProductCard.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import type { ProductWithStock } from '@/lib/types';
+import { useCurrency } from '@/hooks/useCurrency';
+
+// One product tile in the POS grid: name, size/unit, the two price tiers
+// (Retailer primary, Wholesaler secondary), and a live stock indicator. Out of
+// stock (live count) renders unavailable and non-interactive (user story #8).
+export function ProductCard({
+  product,
+  canSell,
+  onSelect,
+}: {
+  product: ProductWithStock;
+  canSell: boolean;
+  onSelect: (product: ProductWithStock) => void;
+}) {
+  const { kobo } = useCurrency();
+
+  const outOfStock = product.onHand <= 0;
+  const low =
+    !outOfStock &&
+    product.low_stock_threshold != null &&
+    product.onHand <= product.low_stock_threshold;
+
+  const stockClass = outOfStock
+    ? 'stock-dot stock-dot--out'
+    : low
+      ? 'stock-dot stock-dot--low'
+      : 'stock-dot';
+
+  const meta = [product.size, product.unit].filter(Boolean).join(' · ');
+
+  return (
+    <button
+      type="button"
+      className="product-card"
+      disabled={outOfStock || !canSell}
+      onClick={() => onSelect(product)}
+      title={
+        !canSell
+          ? 'You do not have permission to sell'
+          : outOfStock
+            ? 'Out of stock'
+            : `Add ${product.name}`
+      }
+    >
+      <div>
+        <div className="product-card__name">{product.name}</div>
+        {meta && <div className="product-card__meta">{meta}</div>}
+      </div>
+
+      <div className="product-card__prices">
+        <div className="product-card__price">
+          {kobo(product.retailer_price_kobo)}
+        </div>
+        {product.wholesaler_price_kobo != null &&
+          product.wholesaler_price_kobo !== product.retailer_price_kobo && (
+            <div className="product-card__wholesale">
+              Wholesale {kobo(product.wholesaler_price_kobo)}
+            </div>
+          )}
+      </div>
+
+      <div
+        className={`product-card__stock${
+          outOfStock ? ' product-card__badge-out' : ''
+        }`}
+      >
+        <span className={stockClass} aria-hidden />
+        {outOfStock ? 'Out of stock' : `${product.onHand} in stock`}
+      </div>
+    </button>
+  );
+}

--- a/web-pos/src/components/pos/Receipt.tsx
+++ b/web-pos/src/components/pos/Receipt.tsx
@@ -1,0 +1,212 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+
+import { useSession } from '@/components/providers/SessionProvider';
+import { useCurrency } from '@/hooks/useCurrency';
+import { formatKobo } from '@/lib/currency';
+import type { CheckoutResult } from '@/lib/checkout';
+
+// The receipt shown after a successful checkout: order number, lines, totals,
+// and the actions — Print (browser print with the receipt-only print stylesheet),
+// Share/Download (Web Share where available, else a downloaded text receipt), and
+// "Done — back to POS" which clears the cart and returns to the grid.
+export function Receipt({
+  result,
+  onDone,
+}: {
+  result: CheckoutResult;
+  onDone: () => void;
+}) {
+  const { operator } = useSession();
+  const { kobo, code } = useCurrency();
+  const [shareNote, setShareNote] = useState<string | null>(null);
+
+  const businessName = operator?.business?.name ?? 'Receipt';
+  const when = new Date(result.createdAt).toLocaleString();
+
+  // The amount still owed on this sale (0 unless it was a credit / partial sale).
+  const onCreditKobo = Math.max(0, result.netAmountKobo - result.amountPaidKobo);
+
+  const plainText = useCallback(() => {
+    const lines = result.lines
+      .map(
+        (l) =>
+          `${l.quantity} x ${l.name}  ${formatKobo(l.unitPriceKobo * l.quantity, code)}`,
+      )
+      .join('\n');
+    return [
+      businessName,
+      `Order ${result.orderNumber}`,
+      when,
+      result.customerName ? `Customer: ${result.customerName}` : null,
+      '',
+      lines,
+      '',
+      `Subtotal: ${formatKobo(result.totalAmountKobo, code)}`,
+      result.discountKobo > 0
+        ? `Discount: -${formatKobo(result.discountKobo, code)}`
+        : null,
+      `Total: ${formatKobo(result.netAmountKobo, code)}`,
+      result.paymentMethod === 'wallet'
+        ? `Paid with credit: ${formatKobo(result.netAmountKobo, code)}`
+        : `Paid (${result.paymentMethod}): ${formatKobo(result.tenderedKobo ?? result.amountPaidKobo, code)}`,
+      (result.changeKobo ?? 0) > 0
+        ? `Change: ${formatKobo(result.changeKobo ?? 0, code)}`
+        : null,
+      onCreditKobo > 0 ? `On credit: ${formatKobo(onCreditKobo, code)}` : null,
+      result.customerName && result.customerBalanceKobo != null
+        ? `Balance: ${
+            result.customerBalanceKobo < 0
+              ? `owes ${formatKobo(-result.customerBalanceKobo, code)}`
+              : `${formatKobo(result.customerBalanceKobo, code)} credit`
+          }`
+        : null,
+      (result.crateCount ?? 0) > 0
+        ? `Empties (returnable): ${result.crateCount} crate${result.crateCount === 1 ? '' : 's'}${
+            (result.crateDepositKobo ?? 0) > 0
+              ? ` — ${formatKobo(result.crateDepositKobo ?? 0, code)} deposit`
+              : ''
+          }`
+        : null,
+    ]
+      .filter(Boolean)
+      .join('\n');
+  }, [result, businessName, when, code, onCreditKobo]);
+
+  const onShare = useCallback(async () => {
+    setShareNote(null);
+    const text = plainText();
+    const filename = `receipt-${result.orderNumber}.txt`;
+    try {
+      if (typeof navigator !== 'undefined' && 'share' in navigator) {
+        const file = new File([text], filename, { type: 'text/plain' });
+        const canFiles =
+          'canShare' in navigator &&
+          (navigator as Navigator).canShare?.({ files: [file] });
+        if (canFiles) {
+          await (navigator as Navigator).share({ files: [file], title: `Order ${result.orderNumber}` });
+          return;
+        }
+        await (navigator as Navigator).share({ title: `Order ${result.orderNumber}`, text });
+        return;
+      }
+    } catch {
+      // Fall through to download on cancel/failure.
+    }
+    // Fallback: download the receipt as a text file.
+    const blob = new Blob([text], { type: 'text/plain' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = filename;
+    a.click();
+    URL.revokeObjectURL(url);
+    setShareNote('Receipt downloaded.');
+  }, [plainText, result.orderNumber]);
+
+  return (
+    <div className="modal-overlay" role="dialog" aria-modal="true" aria-label="Receipt">
+      <div className="modal modal--receipt">
+        <div className="receipt" id="receipt-printable">
+          <div className="receipt__brand">{businessName}</div>
+          <div className="receipt__muted">Order {result.orderNumber}</div>
+          <div className="receipt__muted">{when}</div>
+          {result.customerName && (
+            <div className="receipt__muted">Customer: {result.customerName}</div>
+          )}
+
+          <div className="receipt__divider" />
+
+          <ul className="receipt__lines">
+            {result.lines.map((l, i) => (
+              <li key={i} className="receipt__line">
+                <span className="receipt__line-qty">{l.quantity}×</span>
+                <span className="receipt__line-name">{l.name}</span>
+                <span className="receipt__line-amt">
+                  {kobo(l.unitPriceKobo * l.quantity)}
+                </span>
+              </li>
+            ))}
+          </ul>
+
+          <div className="receipt__divider" />
+
+          <div className="receipt__row">
+            <span>Subtotal</span>
+            <span>{kobo(result.totalAmountKobo)}</span>
+          </div>
+          {result.discountKobo > 0 && (
+            <div className="receipt__row receipt__row--muted">
+              <span>Discount</span>
+              <span>−{kobo(result.discountKobo)}</span>
+            </div>
+          )}
+          <div className="receipt__row receipt__row--total">
+            <span>Total</span>
+            <span>{kobo(result.netAmountKobo)}</span>
+          </div>
+          {result.paymentMethod === 'wallet' ? (
+            <div className="receipt__row receipt__row--muted">
+              <span>Paid with credit</span>
+              <span>{kobo(result.netAmountKobo)}</span>
+            </div>
+          ) : (
+            <div className="receipt__row receipt__row--muted">
+              <span>Paid ({result.paymentMethod})</span>
+              <span>{kobo(result.tenderedKobo ?? result.amountPaidKobo)}</span>
+            </div>
+          )}
+          {(result.changeKobo ?? 0) > 0 && (
+            <div className="receipt__row receipt__row--muted">
+              <span>Change</span>
+              <span>{kobo(result.changeKobo ?? 0)}</span>
+            </div>
+          )}
+          {onCreditKobo > 0 && (
+            <div className="receipt__row receipt__row--muted">
+              <span>On credit</span>
+              <span>{kobo(onCreditKobo)}</span>
+            </div>
+          )}
+          {result.customerName && result.customerBalanceKobo != null && (
+            <div className="receipt__row receipt__row--muted">
+              <span>Balance</span>
+              <span>
+                {result.customerBalanceKobo < 0
+                  ? `owes ${kobo(-result.customerBalanceKobo)}`
+                  : `${kobo(result.customerBalanceKobo)} credit`}
+              </span>
+            </div>
+          )}
+          {(result.crateCount ?? 0) > 0 && (
+            <div className="receipt__row receipt__row--muted">
+              <span>Empties (returnable)</span>
+              <span>
+                {result.crateCount} crate{result.crateCount === 1 ? '' : 's'}
+                {(result.crateDepositKobo ?? 0) > 0 &&
+                  ` · ${kobo(result.crateDepositKobo ?? 0)}`}
+              </span>
+            </div>
+          )}
+
+          <div className="receipt__thanks">Thank you!</div>
+        </div>
+
+        {shareNote && <div className="banner banner--info receipt__note">{shareNote}</div>}
+
+        <div className="modal__foot receipt__actions">
+          <button className="btn btn--outline" onClick={() => window.print()} type="button">
+            Print
+          </button>
+          <button className="btn btn--outline" onClick={() => void onShare()} type="button">
+            Share / Download
+          </button>
+          <button className="btn btn--primary" onClick={onDone} type="button">
+            Done — back to POS
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web-pos/src/components/providers/SessionProvider.tsx
+++ b/web-pos/src/components/providers/SessionProvider.tsx
@@ -1,0 +1,123 @@
+'use client';
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
+import type { Session, SupabaseClient } from '@supabase/supabase-js';
+
+import { getSupabaseBrowserClient } from '@/lib/supabase/client';
+import { loadOperator, type Operator } from '@/lib/operator';
+
+type AuthStatus = 'loading' | 'signed-out' | 'signed-in';
+
+interface SessionContextValue {
+  supabase: SupabaseClient;
+  status: AuthStatus;
+  session: Session | null;
+  operator: Operator | null;
+  operatorLoading: boolean;
+  signOut: () => Promise<void>;
+  reloadOperator: () => Promise<void>;
+}
+
+const SessionContext = createContext<SessionContextValue | null>(null);
+
+// Central session/Operator context. The signed-in Supabase session is the
+// Operator for the tab (ADR 0011); when it resolves we load the full Operator
+// (business, role, permissions, currency, palette) once and re-expose it.
+export function SessionProvider({ children }: { children: ReactNode }) {
+  const supabase = useMemo(() => getSupabaseBrowserClient(), []);
+  const [status, setStatus] = useState<AuthStatus>('loading');
+  const [session, setSession] = useState<Session | null>(null);
+  const [operator, setOperator] = useState<Operator | null>(null);
+  const [operatorLoading, setOperatorLoading] = useState(false);
+
+  // Guards against a stale operator load resolving after a newer session change.
+  const loadTokenRef = useRef(0);
+
+  const refreshOperator = useCallback(
+    async (activeSession: Session | null) => {
+      const token = ++loadTokenRef.current;
+      if (!activeSession?.user) {
+        setOperator(null);
+        setOperatorLoading(false);
+        return;
+      }
+      setOperatorLoading(true);
+      try {
+        const next = await loadOperator(supabase, activeSession.user);
+        if (loadTokenRef.current === token) setOperator(next);
+      } catch {
+        if (loadTokenRef.current === token) setOperator(null);
+      } finally {
+        if (loadTokenRef.current === token) setOperatorLoading(false);
+      }
+    },
+    [supabase],
+  );
+
+  useEffect(() => {
+    let mounted = true;
+
+    supabase.auth.getSession().then(({ data }) => {
+      if (!mounted) return;
+      const s = data.session ?? null;
+      setSession(s);
+      setStatus(s ? 'signed-in' : 'signed-out');
+      void refreshOperator(s);
+    });
+
+    const { data: sub } = supabase.auth.onAuthStateChange((_event, s) => {
+      if (!mounted) return;
+      setSession(s);
+      setStatus(s ? 'signed-in' : 'signed-out');
+      void refreshOperator(s);
+    });
+
+    return () => {
+      mounted = false;
+      sub.subscription.unsubscribe();
+    };
+  }, [supabase, refreshOperator]);
+
+  const signOut = useCallback(async () => {
+    await supabase.auth.signOut();
+  }, [supabase]);
+
+  const reloadOperator = useCallback(
+    () => refreshOperator(session),
+    [refreshOperator, session],
+  );
+
+  const value = useMemo<SessionContextValue>(
+    () => ({
+      supabase,
+      status,
+      session,
+      operator,
+      operatorLoading,
+      signOut,
+      reloadOperator,
+    }),
+    [supabase, status, session, operator, operatorLoading, signOut, reloadOperator],
+  );
+
+  return (
+    <SessionContext.Provider value={value}>{children}</SessionContext.Provider>
+  );
+}
+
+export function useSession(): SessionContextValue {
+  const ctx = useContext(SessionContext);
+  if (!ctx) {
+    throw new Error('useSession must be used within a SessionProvider');
+  }
+  return ctx;
+}

--- a/web-pos/src/components/providers/ThemeProvider.tsx
+++ b/web-pos/src/components/providers/ThemeProvider.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import { useEffect } from 'react';
+
+import { useSession } from './SessionProvider';
+import {
+  DEFAULT_PALETTE,
+  PALETTES,
+  tokensToCssVars,
+  type PaletteName,
+  type ThemeMode,
+} from '@/lib/theme/palettes';
+
+// Applies the active business palette live at the document root (AC: "The
+// palette set by the CEO (business_design_system) is applied app-wide ...
+// reactively"). The colour axis is the synced, CEO-authoritative
+// business_design_system value (via the Operator); light/dark follows the
+// browser/device preference (ADR-noted split). Because we set CSS custom
+// properties, a palette change re-paints the whole app with no reload.
+export function ThemeProvider() {
+  const { operator } = useSession();
+  const palette: PaletteName = operator?.paletteName ?? DEFAULT_PALETTE;
+
+  useEffect(() => {
+    const root = document.documentElement;
+
+    const apply = (mode: ThemeMode) => {
+      const tokens = PALETTES[palette][mode];
+      const vars = tokensToCssVars(tokens);
+      for (const [k, v] of Object.entries(vars)) {
+        root.style.setProperty(k, v);
+      }
+      root.dataset.palette = palette;
+      root.dataset.theme = mode;
+      root.style.colorScheme = mode;
+    };
+
+    const mql = window.matchMedia('(prefers-color-scheme: dark)');
+    apply(mql.matches ? 'dark' : 'light');
+
+    const onChange = (e: MediaQueryListEvent) =>
+      apply(e.matches ? 'dark' : 'light');
+    mql.addEventListener('change', onChange);
+    return () => mql.removeEventListener('change', onChange);
+  }, [palette]);
+
+  return null;
+}

--- a/web-pos/src/components/shell/AppShell.tsx
+++ b/web-pos/src/components/shell/AppShell.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import type { ReactNode } from 'react';
+
+import { useSession } from '@/components/providers/SessionProvider';
+import { useCan } from '@/components/permissions/Can';
+import { PermissionKeys } from '@/lib/permissions';
+
+// The responsive app shell every later slice slots its UI into. It lays out a
+// sticky top bar + a left nav rail + a max-width content column, adapting across
+// the four breakpoint bands (CSS in globals.css): a single column on phones, a
+// rail from tablet up, labelled sidebar on desktop, centred max-width on wide
+// screens.
+//
+// Nav items are permission-gated (hide-don't-block): an Operator only sees the
+// sections their role allows. Slice 1 ships the POS section; Inventory and
+// Reports are placeholders for #48/#51 but demonstrate the gate now.
+export function AppShell({ children }: { children: ReactNode }) {
+  const { operator, signOut } = useSession();
+  const canInventory =
+    useCan(PermissionKeys.stockView) || useCan(PermissionKeys.productsAdd);
+  const canReports = useCan(PermissionKeys.reportsView);
+
+  const roleLabel = operator?.role?.name ?? operator?.role?.slug ?? 'Operator';
+
+  return (
+    <div className="shell">
+      <header className="shell__topbar">
+        <div className="shell__brand">
+          <span className="shell__brand-dot" />
+          <span>Web POS</span>
+          {operator?.business && (
+            <span className="shell__business">· {operator.business.name}</span>
+          )}
+        </div>
+        <div className="shell__account">
+          <div style={{ textAlign: 'right' }}>
+            <div className="shell__account-name">
+              {operator?.displayName ?? 'Operator'}
+            </div>
+            <div className="shell__account-role">{roleLabel}</div>
+          </div>
+          <button className="btn btn--outline" onClick={() => void signOut()}>
+            Sign out
+          </button>
+        </div>
+      </header>
+
+      <div className="shell__body">
+        <nav className="shell__nav" aria-label="Primary">
+          <NavItem icon="🛒" label="POS" active />
+          {canInventory && <NavItem icon="📦" label="Inventory" />}
+          {canReports && <NavItem icon="📊" label="Reports" />}
+        </nav>
+
+        <main className="shell__content">
+          <div className="shell__content-inner">{children}</div>
+        </main>
+      </div>
+    </div>
+  );
+}
+
+function NavItem({
+  icon,
+  label,
+  active = false,
+}: {
+  icon: string;
+  label: string;
+  active?: boolean;
+}) {
+  return (
+    <div
+      className={`shell__nav-item${active ? ' shell__nav-item--active' : ''}`}
+      aria-current={active ? 'page' : undefined}
+    >
+      <span className="shell__nav-icon" aria-hidden>
+        {icon}
+      </span>
+      <span>{label}</span>
+    </div>
+  );
+}

--- a/web-pos/src/hooks/useCurrency.ts
+++ b/web-pos/src/hooks/useCurrency.ts
@@ -1,0 +1,21 @@
+'use client';
+
+import { useCallback } from 'react';
+
+import { useSession } from '@/components/providers/SessionProvider';
+import { DEFAULT_CURRENCY, formatCurrency, formatKobo } from '@/lib/currency';
+
+// Currency helpers bound to the Operator's business currency (default_currency).
+// Every money display goes through these so nothing hard-codes ₦ (AC).
+export function useCurrency() {
+  const { operator } = useSession();
+  const code = operator?.currencyCode ?? DEFAULT_CURRENCY;
+
+  const money = useCallback((amount: number) => formatCurrency(amount, code), [
+    code,
+  ]);
+  const kobo = useCallback((amount: number | null | undefined) =>
+    formatKobo(amount, code), [code]);
+
+  return { code, money, kobo };
+}

--- a/web-pos/src/hooks/useCustomers.ts
+++ b/web-pos/src/hooks/useCustomers.ts
@@ -1,0 +1,42 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+import { useSession } from '@/components/providers/SessionProvider';
+import { loadCustomers } from '@/lib/customers';
+import type { CustomerWithBalance } from '@/lib/types';
+
+// Loads the registered-customer list (with derived wallet balances) once and
+// exposes a `refresh` to re-pull after a credit sale changes a balance. Live
+// Realtime is a later slice; here we refresh on demand like the catalogue.
+export function useCustomers(): {
+  customers: CustomerWithBalance[];
+  loading: boolean;
+  error: string | null;
+  refresh: () => Promise<void>;
+} {
+  const { supabase, operator } = useSession();
+  const businessId = operator?.businessId ?? null;
+
+  const [customers, setCustomers] = useState<CustomerWithBalance[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    setError(null);
+    try {
+      setCustomers(await loadCustomers(supabase));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load customers.');
+    } finally {
+      setLoading(false);
+    }
+  }, [supabase]);
+
+  useEffect(() => {
+    setLoading(true);
+    void refresh();
+  }, [refresh, businessId]);
+
+  return { customers, loading, error, refresh };
+}

--- a/web-pos/src/hooks/useIdleTimeout.ts
+++ b/web-pos/src/hooks/useIdleTimeout.ts
@@ -1,0 +1,47 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+
+// Fires `onIdle` after `timeoutMs` of no user interaction. Any of a small set of
+// activity events resets the timer. Used to re-lock the tab to the sign-in
+// screen after inactivity (AC: "Idle inactivity re-locks the tab to the sign-in
+// screen") on shared computers.
+const ACTIVITY_EVENTS: (keyof WindowEventMap)[] = [
+  'mousemove',
+  'mousedown',
+  'keydown',
+  'scroll',
+  'touchstart',
+  'click',
+];
+
+export function useIdleTimeout(
+  onIdle: () => void,
+  timeoutMs: number,
+  enabled: boolean,
+): void {
+  const onIdleRef = useRef(onIdle);
+  onIdleRef.current = onIdle;
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    let timer: ReturnType<typeof setTimeout>;
+    const reset = () => {
+      clearTimeout(timer);
+      timer = setTimeout(() => onIdleRef.current(), timeoutMs);
+    };
+
+    for (const evt of ACTIVITY_EVENTS) {
+      window.addEventListener(evt, reset, { passive: true });
+    }
+    reset();
+
+    return () => {
+      clearTimeout(timer);
+      for (const evt of ACTIVITY_EVENTS) {
+        window.removeEventListener(evt, reset);
+      }
+    };
+  }, [timeoutMs, enabled]);
+}

--- a/web-pos/src/lib/catalogue.ts
+++ b/web-pos/src/lib/catalogue.ts
@@ -8,6 +8,7 @@ import type { SupabaseClient } from '@supabase/supabase-js';
 import type {
   CategoryRow,
   InventoryRow,
+  ManufacturerRow,
   ProductRow,
   ProductWithStock,
 } from './types';
@@ -23,26 +24,33 @@ export interface Catalogue {
 export async function loadCatalogue(
   supabase: SupabaseClient,
 ): Promise<Catalogue> {
-  const [categoriesRes, productsRes, inventoryRes] = await Promise.all([
-    supabase
-      .from('categories')
-      .select('id, business_id, name, is_deleted')
-      .eq('is_deleted', false)
-      .order('name', { ascending: true })
-      .returns<CategoryRow[]>(),
-    supabase
-      .from('products')
-      .select(
-        'id, business_id, category_id, name, unit, size, retailer_price_kobo, wholesaler_price_kobo, buying_price_kobo, is_available, is_deleted, low_stock_threshold, image_path',
-      )
-      .eq('is_deleted', false)
-      .order('name', { ascending: true })
-      .returns<ProductRow[]>(),
-    supabase
-      .from('inventory')
-      .select('id, business_id, product_id, store_id, quantity')
-      .returns<InventoryRow[]>(),
-  ]);
+  const [categoriesRes, productsRes, inventoryRes, manufacturersRes] =
+    await Promise.all([
+      supabase
+        .from('categories')
+        .select('id, business_id, name, is_deleted')
+        .eq('is_deleted', false)
+        .order('name', { ascending: true })
+        .returns<CategoryRow[]>(),
+      supabase
+        .from('products')
+        .select(
+          'id, business_id, category_id, name, unit, size, retailer_price_kobo, wholesaler_price_kobo, buying_price_kobo, is_available, is_deleted, low_stock_threshold, image_path, track_empties, manufacturer_id',
+        )
+        .eq('is_deleted', false)
+        .order('name', { ascending: true })
+        .returns<ProductRow[]>(),
+      supabase
+        .from('inventory')
+        .select('id, business_id, product_id, store_id, quantity')
+        .returns<InventoryRow[]>(),
+      // Manufacturers carry the per-crate deposit rate (Slice 4). Small table;
+      // one read attaches each product's deposit rate for the empties surface.
+      supabase
+        .from('manufacturers')
+        .select('id, business_id, deposit_amount_kobo')
+        .returns<ManufacturerRow[]>(),
+    ]);
 
   const onHandByProduct = new Map<string, number>();
   for (const row of inventoryRes.data ?? []) {
@@ -52,9 +60,17 @@ export async function loadCatalogue(
     );
   }
 
+  const depositByManufacturer = new Map<string, number>();
+  for (const m of manufacturersRes.data ?? []) {
+    depositByManufacturer.set(m.id, m.deposit_amount_kobo ?? 0);
+  }
+
   const products: ProductWithStock[] = (productsRes.data ?? []).map((p) => ({
     ...p,
     onHand: onHandByProduct.get(p.id) ?? 0,
+    depositRateKobo: p.manufacturer_id
+      ? (depositByManufacturer.get(p.manufacturer_id) ?? 0)
+      : 0,
   }));
 
   const categories = (categoriesRes.data ?? []).map((c) => ({

--- a/web-pos/src/lib/catalogue.ts
+++ b/web-pos/src/lib/catalogue.ts
@@ -1,0 +1,66 @@
+// Live catalogue read for the POS grid (AC: "live product grid shows categories,
+// per-tier prices, and reflects the current stock"). All three reads are
+// RLS-scoped to the Operator's business; Slice 1 fetches over PostgREST on load
+// and on manual refresh — Realtime hardening is Slice 5 (#49), by decision.
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+import type {
+  CategoryRow,
+  InventoryRow,
+  ProductRow,
+  ProductWithStock,
+} from './types';
+
+export interface Catalogue {
+  categories: { id: string; name: string }[];
+  products: ProductWithStock[];
+}
+
+// Load categories, products, and on-hand stock, merging stock onto each product.
+// On-hand is summed across all of the business's stores (a single number per
+// product); per-store scoping is a later slice.
+export async function loadCatalogue(
+  supabase: SupabaseClient,
+): Promise<Catalogue> {
+  const [categoriesRes, productsRes, inventoryRes] = await Promise.all([
+    supabase
+      .from('categories')
+      .select('id, business_id, name, is_deleted')
+      .eq('is_deleted', false)
+      .order('name', { ascending: true })
+      .returns<CategoryRow[]>(),
+    supabase
+      .from('products')
+      .select(
+        'id, business_id, category_id, name, unit, size, retailer_price_kobo, wholesaler_price_kobo, buying_price_kobo, is_available, is_deleted, low_stock_threshold, image_path',
+      )
+      .eq('is_deleted', false)
+      .order('name', { ascending: true })
+      .returns<ProductRow[]>(),
+    supabase
+      .from('inventory')
+      .select('id, business_id, product_id, store_id, quantity')
+      .returns<InventoryRow[]>(),
+  ]);
+
+  const onHandByProduct = new Map<string, number>();
+  for (const row of inventoryRes.data ?? []) {
+    onHandByProduct.set(
+      row.product_id,
+      (onHandByProduct.get(row.product_id) ?? 0) + (row.quantity ?? 0),
+    );
+  }
+
+  const products: ProductWithStock[] = (productsRes.data ?? []).map((p) => ({
+    ...p,
+    onHand: onHandByProduct.get(p.id) ?? 0,
+  }));
+
+  const categories = (categoriesRes.data ?? []).map((c) => ({
+    id: c.id,
+    name: c.name ?? 'Uncategorised',
+  }));
+
+  return { categories, products };
+}

--- a/web-pos/src/lib/checkout.ts
+++ b/web-pos/src/lib/checkout.ts
@@ -1,0 +1,156 @@
+// The Web POS's only money-write for Slice 2: the server-authoritative
+// `checkout_order` RPC (migration 0135, ADR 0008). The web never writes order
+// rows through PostgREST — it hands the cart to the RPC, which does the whole
+// checkout atomically server-side (order + items + FIFO draw-down + COGS
+// snapshot + stock guard + server order number + revenue-at-checkout) and
+// returns the rows for the receipt. Amounts are `*_kobo` bigint end to end.
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+import type { ProductWithStock } from './types';
+
+// The retail tier is the primary line price (per-tier switching is a later
+// refinement); fall back to wholesaler, then 0.
+export function lineUnitPriceKobo(product: ProductWithStock): number {
+  return (
+    product.retailer_price_kobo ?? product.wholesaler_price_kobo ?? 0
+  );
+}
+
+export interface CheckoutLineInput {
+  productId: string;
+  quantity: number;
+  unitPriceKobo: number;
+  // Carried only for the receipt (the RPC doesn't echo product names).
+  name: string;
+}
+
+// The four checkout paths the server-authoritative RPC understands:
+//   'cash' | 'transfer' — fully-settled sale (walk-in or registered).
+//   'wallet'            — Pay-with-Credit: draw the whole sale from the customer's
+//                         existing wallet balance (no cash; amountPaidKobo = 0).
+//   'credit'            — Register-as-Credit-Sale: the customer owes the balance;
+//                         amountPaidKobo is any cash part-paid now (0..net).
+export type PaymentMethod = 'cash' | 'transfer' | 'wallet' | 'credit';
+
+export interface CheckoutArgs {
+  businessId: string;
+  storeId: string;
+  paymentMethod: PaymentMethod;
+  amountPaidKobo: number;
+  discountKobo: number;
+  lines: CheckoutLineInput[];
+  // A registered customer for the credit/wallet paths (and to post wallet legs
+  // on any registered sale). Null/undefined = walk-in.
+  customerId?: string | null;
+  // Carried only for the receipt (the RPC doesn't echo the customer name).
+  customerName?: string | null;
+}
+
+// The shape the receipt renders — the server-authoritative order plus the line
+// snapshot we sent (for names) and the tendered amount (for change).
+export interface CheckoutResult {
+  orderNumber: string;
+  totalAmountKobo: number;
+  discountKobo: number;
+  netAmountKobo: number;
+  amountPaidKobo: number;
+  paymentMethod: PaymentMethod;
+  lines: CheckoutLineInput[];
+  createdAt: string;
+  // Ephemeral, display-only (not stored server-side — the sale settles at net):
+  // the amount the operator tendered and the change to hand back.
+  tenderedKobo?: number;
+  changeKobo?: number;
+  // Registered-customer credit (Slice 3): the name for the receipt and the
+  // customer's derived balance AFTER the sale, straight from the RPC.
+  customerName?: string | null;
+  customerBalanceKobo?: number | null;
+  // Empty-crate summary for the receipt (Slice 4, #45): the returnable crates in
+  // this sale and their total deposit value. Present only when the business
+  // tracks crates; 0 crates ⇒ the receipt hides the empties line.
+  crateCount?: number;
+  crateDepositKobo?: number;
+}
+
+interface OrderRow {
+  order_number: string;
+  total_amount_kobo: number;
+  discount_kobo: number;
+  net_amount_kobo: number;
+  amount_paid_kobo: number;
+  created_at: string;
+}
+
+// Turn a raw RPC error into an operator-facing message.
+function friendlyError(message: string): string {
+  if (message.includes('insufficient_stock')) {
+    return 'Not enough stock to complete this sale — another till may have just sold the same item. Refresh and try again.';
+  }
+  if (message.includes('permission_denied')) {
+    return 'You do not have permission to ring up a sale.';
+  }
+  if (message.includes('debt_limit_exceeded')) {
+    return 'This sale would push the customer past their debt limit. Take a payment, lower the amount owed, or raise their limit.';
+  }
+  if (message.includes('customer_wallet_missing')) {
+    return 'This customer has no wallet set up yet. Add them again on the mobile app, then retry.';
+  }
+  if (message.includes('credit_requires_customer')) {
+    return 'Attach a registered customer before selling on credit.';
+  }
+  if (message.includes('amount_paid_below_net')) {
+    return 'The amount paid is less than the total. Enter the full amount, or use Pay with Credit / Register as Credit Sale.';
+  }
+  if (message.includes('tenant_mismatch') || message.includes('no_business_for_caller')) {
+    return 'Your session is not linked to this business. Sign out and back in.';
+  }
+  return message;
+}
+
+export async function checkoutOrder(
+  supabase: SupabaseClient,
+  args: CheckoutArgs,
+): Promise<CheckoutResult> {
+  const orderId =
+    typeof crypto !== 'undefined' && 'randomUUID' in crypto
+      ? crypto.randomUUID()
+      : `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+
+  const { data, error } = await supabase.rpc('checkout_order', {
+    p_business_id: args.businessId,
+    p_order_id: orderId,
+    p_store_id: args.storeId,
+    p_items: args.lines.map((l) => ({
+      product_id: l.productId,
+      quantity: l.quantity,
+      unit_price_kobo: l.unitPriceKobo,
+    })),
+    p_payment_method: args.paymentMethod,
+    p_amount_paid_kobo: args.amountPaidKobo,
+    p_discount_kobo: args.discountKobo,
+    p_customer_id: args.customerId ?? null,
+  });
+
+  if (error) {
+    throw new Error(friendlyError(error.message));
+  }
+
+  const payload = data as {
+    order: OrderRow;
+    customer_balance_kobo: number | null;
+  };
+  const order = payload.order;
+  return {
+    orderNumber: order.order_number,
+    totalAmountKobo: order.total_amount_kobo,
+    discountKobo: order.discount_kobo,
+    netAmountKobo: order.net_amount_kobo,
+    amountPaidKobo: order.amount_paid_kobo,
+    paymentMethod: args.paymentMethod,
+    lines: args.lines,
+    createdAt: order.created_at,
+    customerName: args.customerName ?? null,
+    customerBalanceKobo: payload.customer_balance_kobo ?? null,
+  };
+}

--- a/web-pos/src/lib/crate.ts
+++ b/web-pos/src/lib/crate.ts
@@ -1,0 +1,67 @@
+// Empty-crate (returnable-case) helpers for the Web POS (Slice 4, #45). Mirrors
+// the mobile crate model: crate features are visible only for crate-eligible
+// businesses that opt into empty tracking, and a sale of deposit-bearing product
+// carries returnable empties valued at a per-manufacturer deposit rate.
+//
+// The web posts the crate LEDGER server-side (checkout_order RPC, migration
+// 0137) for a registered customer at a crate-eligible business; this module is
+// the read/display side — the hide-don't-block surface and the empties summary
+// the cart + receipt show.
+
+import type { ProductWithStock } from './types';
+
+// Whether [type] is a business that uses empty-crate features — Bar or Beer/
+// Beverage distributor only. Byte-for-byte the mobile isCrateBusiness(type)
+// (lib/core/data/business_types.dart): case-insensitive + trimmed, so tenants
+// onboarded by older builds with non-canonical casings still match.
+export function isCrateBusiness(type: string | null | undefined): boolean {
+  const t = type?.trim().toLowerCase();
+  return t === 'bar' || t === 'beer distributor' || t === 'beverage distributor';
+}
+
+// Whether the business shows crate surfaces at all: crate-eligible type AND the
+// empty-crate tracking opt-in. This is the single gate for the web crate UI —
+// when false, no empties context is shown anywhere (mirrors the mobile hide).
+export function businessTracksCrates(
+  type: string | null | undefined,
+  tracksEmptyCrates: boolean,
+): boolean {
+  return isCrateBusiness(type) && tracksEmptyCrates;
+}
+
+// Whether a product carries a returnable crate deposit — a bottle with empties
+// tracking on and a manufacturer (whose deposit rate applies). Same basis as the
+// mobile sale-time crate dispatch (unit == 'bottle' && trackEmpties && a
+// manufacturer).
+export function crateEligible(product: ProductWithStock): boolean {
+  return (
+    product.unit?.toLowerCase() === 'bottle' &&
+    product.track_empties === true &&
+    product.manufacturer_id != null
+  );
+}
+
+export interface CrateSummary {
+  // Total deposit-bearing crates (empties) in the sale.
+  crates: number;
+  // Their total deposit value (sum of qty × the manufacturer's deposit rate).
+  depositValueKobo: number;
+}
+
+// The empties summary for a set of cart/receipt lines, counting only
+// crate-eligible bottles. Returns zero crates when the business doesn't track
+// crates, so callers can gate the surface on `crates > 0`.
+export function crateSummary(
+  lines: { product: ProductWithStock; quantity: number }[],
+  businessCrateEligible: boolean,
+): CrateSummary {
+  if (!businessCrateEligible) return { crates: 0, depositValueKobo: 0 };
+  let crates = 0;
+  let depositValueKobo = 0;
+  for (const l of lines) {
+    if (!crateEligible(l.product)) continue;
+    crates += l.quantity;
+    depositValueKobo += l.quantity * (l.product.depositRateKobo ?? 0);
+  }
+  return { crates, depositValueKobo };
+}

--- a/web-pos/src/lib/currency.ts
+++ b/web-pos/src/lib/currency.ts
@@ -1,0 +1,86 @@
+// Currency formatting for the Web POS — a faithful port of the mobile app's
+// number_format.dart + currencies.dart, so a money amount renders identically on
+// web and mobile. The business currency comes from the synced `default_currency`
+// setting; nothing hard-codes ₦ (AC: "Currency is formatted from the business
+// currency setting, never hard-coded").
+
+export const DEFAULT_CURRENCY = 'NGN';
+
+// ISO-4217 code → display symbol. Keep in lockstep with the mobile
+// kCurrencySymbols map (lib/core/data/currencies.dart).
+export const CURRENCY_SYMBOLS: Record<string, string> = {
+  NGN: '₦',
+  XOF: 'CFA',
+  XAF: 'FCFA',
+  CAD: 'CA$',
+  CNY: '¥',
+  EGP: 'E£',
+  EUR: '€',
+  GHS: 'GH₵',
+  INR: '₹',
+  KES: 'KSh',
+  LRD: 'L$',
+  MAD: 'DH',
+  RWF: 'FRw',
+  SLL: 'Le',
+  ZAR: 'R',
+  TZS: 'TSh',
+  UGX: 'USh',
+  AED: 'AED',
+  GBP: '£',
+  USD: '$',
+  ZMW: 'ZK',
+  ZWL: 'Z$',
+};
+
+const THREE_LETTERS = /[A-Za-z]{3}/g;
+const TRAILING_LETTER = /[A-Za-z]$/;
+
+// Normalise a stored currency value to a bare ISO-4217 code where possible.
+// Tolerant of legacy label-style values ("NGN (₦)" → "NGN", "Naira (NGN)" →
+// "NGN"), matching the mobile normalizeCurrencyCode.
+export function normalizeCurrencyCode(code: string | null | undefined): string {
+  if (!code || !code.trim()) return DEFAULT_CURRENCY;
+  const raw = code.trim().toUpperCase();
+  if (raw in CURRENCY_SYMBOLS) return raw;
+  const matches = raw.match(THREE_LETTERS);
+  if (matches) {
+    for (const m of matches) {
+      if (m in CURRENCY_SYMBOLS) return m;
+    }
+  }
+  return raw;
+}
+
+// Display symbol for a stored currency value — the glyph only (e.g. '₦', '$',
+// 'GH₵'), never the code or a "CODE (symbol)" label.
+export function currencySymbolForCode(code: string | null | undefined): string {
+  const norm = normalizeCurrencyCode(code);
+  return CURRENCY_SYMBOLS[norm] ?? norm;
+}
+
+// Format a whole-currency amount (NOT kobo) with the given currency's symbol.
+// A space follows letter-ending symbols ('KES' → 'KSh 5,000') but not glyphs
+// ('NGN' → '₦5,000'). Mirrors mobile formatCurrency.
+export function formatCurrency(
+  amount: number,
+  code: string | null | undefined = DEFAULT_CURRENCY,
+): string {
+  const isNegative = amount < 0;
+  const rounded = Math.round(Math.abs(amount));
+  const formatted = rounded.toLocaleString('en-US');
+  const sym = currencySymbolForCode(code);
+  const sep = TRAILING_LETTER.test(sym) ? ' ' : '';
+  return isNegative ? `-${sym}${sep}${formatted}` : `${sym}${sep}${formatted}`;
+}
+
+// Convenience: format a `*_kobo` bigint amount. Amounts are stored in kobo
+// (1/100 of the major unit) across the schema; the mobile app divides by 100 at
+// the display boundary. A null amount renders as an em dash.
+export function formatKobo(
+  kobo: number | null | undefined,
+  code: string | null | undefined = DEFAULT_CURRENCY,
+): string {
+  if (kobo === null || kobo === undefined) return '—';
+  return formatCurrency(kobo / 100, code);
+}

--- a/web-pos/src/lib/customers.ts
+++ b/web-pos/src/lib/customers.ts
@@ -1,0 +1,58 @@
+// Live customer read for the cart's attach-a-customer flow (Slice 3, #44). Both
+// reads are RLS-scoped to the Operator's business. Balances are DERIVED from the
+// append-only wallet ledger (invariant #3) — the same rule the mobile app and
+// the checkout_order RPC use: balance = SUM(signed_amount_kobo) over rows whose
+// reference_type is NOT a crate-deposit leg. We compute it client-side (like the
+// catalogue sums on-hand) rather than push a view, so Slice 3 stays read-only.
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+import type {
+  CustomerRow,
+  CustomerWithBalance,
+  WalletTransactionRow,
+} from './types';
+
+// The crate-deposit family is refundable money held for the customer — never
+// their spendable credit nor their debt (mirrors kCrateDepositReferenceTypes /
+// _customer_wallet_balance). Excluded from the balance sum.
+const CRATE_DEPOSIT_REFS = new Set([
+  'crate_deposit',
+  'crate_deposit_refunded',
+  'crate_deposit_forfeited',
+]);
+
+export async function loadCustomers(
+  supabase: SupabaseClient,
+): Promise<CustomerWithBalance[]> {
+  const [customersRes, ledgerRes] = await Promise.all([
+    supabase
+      .from('customers')
+      .select('id, business_id, name, phone, wallet_limit_kobo, is_deleted')
+      .eq('is_deleted', false)
+      .order('name', { ascending: true })
+      .returns<CustomerRow[]>(),
+    supabase
+      .from('wallet_transactions')
+      .select('customer_id, signed_amount_kobo, reference_type')
+      .returns<WalletTransactionRow[]>(),
+  ]);
+
+  const balanceByCustomer = new Map<string, number>();
+  for (const row of ledgerRes.data ?? []) {
+    if (CRATE_DEPOSIT_REFS.has(row.reference_type)) continue;
+    balanceByCustomer.set(
+      row.customer_id,
+      (balanceByCustomer.get(row.customer_id) ?? 0) +
+        (row.signed_amount_kobo ?? 0),
+    );
+  }
+
+  return (customersRes.data ?? []).map((c) => ({
+    id: c.id,
+    name: c.name,
+    phone: c.phone,
+    balanceKobo: balanceByCustomer.get(c.id) ?? 0,
+    debtLimitKobo: c.wallet_limit_kobo ?? 0,
+  }));
+}

--- a/web-pos/src/lib/operator.ts
+++ b/web-pos/src/lib/operator.ts
@@ -1,0 +1,182 @@
+// Loads the Operator context for the signed-in Supabase session (ADR 0011: the
+// per-user session IS the Operator). Business scope is resolved server-side from
+// profiles.business_id (the RLS anchor, current_user_business_ids()); the role
+// comes from the active user_businesses membership. Every read below is
+// RLS-scoped, so the Operator only ever sees their own business's rows (AC:
+// "shows only the caller's business data ... with no custom JWT claims").
+
+import type { SupabaseClient, User } from '@supabase/supabase-js';
+
+import {
+  resolveEffectivePermissions,
+  type EffectivePermissions,
+} from './permissions';
+import { DEFAULT_CURRENCY, normalizeCurrencyCode } from './currency';
+import { parsePaletteName, type PaletteName } from './theme/palettes';
+import type {
+  BusinessRow,
+  ProfileRow,
+  RolePermissionRow,
+  RoleRow,
+  SettingRow,
+  StoreRow,
+  UserBusinessRow,
+  UserPermissionOverrideRow,
+  UserRow,
+} from './types';
+
+const BUSINESS_DESIGN_SYSTEM_KEY = 'business_design_system';
+const DEFAULT_CURRENCY_KEY = 'default_currency';
+
+export interface Operator {
+  authUserId: string;
+  authEmail: string | null;
+  userId: string | null;
+  businessId: string | null;
+  displayName: string;
+  business: {
+    id: string;
+    name: string;
+    tracksEmptyCrates: boolean;
+  } | null;
+  role: { id: string; slug: string | null; name: string | null } | null;
+  permissions: EffectivePermissions;
+  currencyCode: string;
+  paletteName: PaletteName;
+  stores: { id: string; name: string }[];
+}
+
+const NO_PERMISSIONS: EffectivePermissions = {
+  isCeo: false,
+  keys: new Set<string>(),
+};
+
+// Resolve everything about the current Operator with RLS-scoped reads. Returns a
+// best-effort Operator even when some links are missing (e.g. a session not yet
+// bound to a users row) so the shell can still render and surface the state.
+export async function loadOperator(
+  supabase: SupabaseClient,
+  authUser: User,
+): Promise<Operator> {
+  const authUserId = authUser.id;
+
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('id, business_id, name')
+    .eq('id', authUserId)
+    .maybeSingle<ProfileRow>();
+
+  const businessId = profile?.business_id ?? null;
+
+  const { data: userRow } = await supabase
+    .from('users')
+    .select('id, business_id, auth_user_id, name, email')
+    .eq('auth_user_id', authUserId)
+    .maybeSingle<UserRow>();
+
+  const userId = userRow?.id ?? null;
+
+  // Role via the active membership for the bound business.
+  let role: Operator['role'] = null;
+  let permissions: EffectivePermissions = NO_PERMISSIONS;
+
+  if (userId) {
+    const { data: memberships } = await supabase
+      .from('user_businesses')
+      .select('id, business_id, user_id, role_id, status')
+      .eq('user_id', userId)
+      .returns<UserBusinessRow[]>();
+
+    const membership =
+      memberships?.find(
+        (m) => m.business_id === businessId && m.status === 'active',
+      ) ??
+      memberships?.find((m) => m.status === 'active') ??
+      memberships?.[0] ??
+      null;
+
+    if (membership?.role_id) {
+      const { data: roleRow } = await supabase
+        .from('roles')
+        .select('id, business_id, name, slug, is_deleted')
+        .eq('id', membership.role_id)
+        .maybeSingle<RoleRow>();
+
+      if (roleRow) {
+        role = { id: roleRow.id, slug: roleRow.slug, name: roleRow.name };
+
+        const [{ data: grants }, { data: overrides }] = await Promise.all([
+          supabase
+            .from('role_permissions')
+            .select('id, business_id, role_id, permission_key')
+            .eq('role_id', roleRow.id)
+            .returns<RolePermissionRow[]>(),
+          supabase
+            .from('user_permission_overrides')
+            .select('id, business_id, user_id, permission_key, is_granted')
+            .eq('user_id', userId)
+            .returns<UserPermissionOverrideRow[]>(),
+        ]);
+
+        permissions = resolveEffectivePermissions({
+          roleSlug: roleRow.slug,
+          roleGrants: grants ?? [],
+          userOverrides: overrides ?? [],
+        });
+      }
+    }
+  }
+
+  // Business + settings + stores.
+  const [businessRes, settingsRes, storesRes] = await Promise.all([
+    businessId
+      ? supabase
+          .from('businesses')
+          .select('id, name, type, tracks_empty_crates')
+          .eq('id', businessId)
+          .maybeSingle<BusinessRow>()
+      : Promise.resolve({ data: null }),
+    supabase
+      .from('settings')
+      .select('business_id, key, value')
+      .in('key', [BUSINESS_DESIGN_SYSTEM_KEY, DEFAULT_CURRENCY_KEY])
+      .returns<SettingRow[]>(),
+    supabase
+      .from('stores')
+      .select('id, business_id, name, is_deleted')
+      .eq('is_deleted', false)
+      .returns<StoreRow[]>(),
+  ]);
+
+  const businessRow = businessRes.data as BusinessRow | null;
+  const settings = settingsRes.data ?? [];
+  const stores = storesRes.data ?? [];
+
+  const designValue =
+    settings.find((s) => s.key === BUSINESS_DESIGN_SYSTEM_KEY)?.value ?? null;
+  const currencyValue =
+    settings.find((s) => s.key === DEFAULT_CURRENCY_KEY)?.value ?? null;
+
+  return {
+    authUserId,
+    authEmail: authUser.email ?? null,
+    userId,
+    businessId,
+    displayName:
+      userRow?.name ?? profile?.name ?? authUser.email ?? 'Operator',
+    business: businessRow
+      ? {
+          id: businessRow.id,
+          name: businessRow.name ?? 'Your business',
+          tracksEmptyCrates: businessRow.tracks_empty_crates ?? false,
+        }
+      : null,
+    role,
+    permissions,
+    currencyCode: currencyValue
+      ? normalizeCurrencyCode(currencyValue)
+      : DEFAULT_CURRENCY,
+    paletteName: parsePaletteName(designValue),
+    stores: stores.map((s) => ({ id: s.id, name: s.name ?? 'Store' })),
+  };
+}

--- a/web-pos/src/lib/operator.ts
+++ b/web-pos/src/lib/operator.ts
@@ -37,13 +37,30 @@ export interface Operator {
   business: {
     id: string;
     name: string;
+    // Business type + empties opt-in drive the crate surfaces (Slice 4, #45):
+    // crate context is shown only when isCrateBusiness(type) && tracksEmptyCrates.
+    type: string | null;
     tracksEmptyCrates: boolean;
   } | null;
   role: { id: string; slug: string | null; name: string | null } | null;
   permissions: EffectivePermissions;
+  // Max discount % this operator's role may apply on a sale (§12.6/§13.2). The
+  // web clamps the cart discount to this; the checkout_order RPC re-clamps
+  // server-side (defence in depth). CEO = 100.
+  maxDiscountPercent: number;
   currencyCode: string;
   paletteName: PaletteName;
   stores: { id: string; name: string }[];
+}
+
+const MAX_DISCOUNT_PERCENT_KEY = 'max_discount_percent';
+
+// Seed defaults matching the mobile currentUserMaxDiscountPercentProvider
+// (CEO 100, Manager 10, else 0) — used until a role_settings row is written.
+function seedDiscountPercent(slug: string | null | undefined): number {
+  if (slug === 'ceo') return 100;
+  if (slug === 'manager') return 10;
+  return 0;
 }
 
 const NO_PERMISSIONS: EffectivePermissions = {
@@ -79,6 +96,7 @@ export async function loadOperator(
   // Role via the active membership for the bound business.
   let role: Operator['role'] = null;
   let permissions: EffectivePermissions = NO_PERMISSIONS;
+  let maxDiscountPercent = 0;
 
   if (userId) {
     const { data: memberships } = await supabase
@@ -105,24 +123,39 @@ export async function loadOperator(
       if (roleRow) {
         role = { id: roleRow.id, slug: roleRow.slug, name: roleRow.name };
 
-        const [{ data: grants }, { data: overrides }] = await Promise.all([
-          supabase
-            .from('role_permissions')
-            .select('id, business_id, role_id, permission_key')
-            .eq('role_id', roleRow.id)
-            .returns<RolePermissionRow[]>(),
-          supabase
-            .from('user_permission_overrides')
-            .select('id, business_id, user_id, permission_key, is_granted')
-            .eq('user_id', userId)
-            .returns<UserPermissionOverrideRow[]>(),
-        ]);
+        const [{ data: grants }, { data: overrides }, { data: roleSettings }] =
+          await Promise.all([
+            supabase
+              .from('role_permissions')
+              .select('id, business_id, role_id, permission_key')
+              .eq('role_id', roleRow.id)
+              .returns<RolePermissionRow[]>(),
+            supabase
+              .from('user_permission_overrides')
+              .select('id, business_id, user_id, permission_key, is_granted')
+              .eq('user_id', userId)
+              .returns<UserPermissionOverrideRow[]>(),
+            supabase
+              .from('role_settings')
+              .select('setting_key, setting_value')
+              .eq('role_id', roleRow.id)
+              .returns<{ setting_key: string; setting_value: string | null }[]>(),
+          ]);
 
         permissions = resolveEffectivePermissions({
           roleSlug: roleRow.slug,
           roleGrants: grants ?? [],
           userOverrides: overrides ?? [],
         });
+
+        const storedDiscount = (roleSettings ?? []).find(
+          (s) => s.setting_key === MAX_DISCOUNT_PERCENT_KEY,
+        )?.setting_value;
+        const parsed =
+          storedDiscount != null ? Number.parseInt(storedDiscount, 10) : NaN;
+        maxDiscountPercent = Number.isFinite(parsed)
+          ? parsed
+          : seedDiscountPercent(roleRow.slug);
       }
     }
   }
@@ -168,11 +201,13 @@ export async function loadOperator(
       ? {
           id: businessRow.id,
           name: businessRow.name ?? 'Your business',
+          type: businessRow.type,
           tracksEmptyCrates: businessRow.tracks_empty_crates ?? false,
         }
       : null,
     role,
     permissions,
+    maxDiscountPercent,
     currencyCode: currencyValue
       ? normalizeCurrencyCode(currencyValue)
       : DEFAULT_CURRENCY,

--- a/web-pos/src/lib/permissions.ts
+++ b/web-pos/src/lib/permissions.ts
@@ -1,0 +1,77 @@
+// Permission-read layer for the Web POS (AC: "A permission-read utility exists
+// and hides actions the Operator's role lacks"). It mirrors the *decisions* of
+// the mobile Gate Registry (ADR 0002) — not its Dart code (ADR 0009): read the
+// same role_permissions / user_permission_overrides rows and apply
+// hide-don't-block, with the CEO always all-on.
+//
+// This is deliberately a plain data utility, reused by later slices. The web
+// only HIDES actions; every money-write RPC also re-checks the permission
+// server-side (defence in depth, PRD Implementation Decisions).
+
+import type {
+  RolePermissionRow,
+  UserPermissionOverrideRow,
+} from './types';
+
+// The permission keys this walking skeleton references. The full catalogue lives
+// in the cloud `permissions` table; later slices add their keys here as they
+// wire real actions. Keeping named constants (not string literals at call sites)
+// keeps the web's permission vocabulary auditable in one place.
+export const PermissionKeys = {
+  salesMake: 'sales.make',
+  productsAdd: 'products.add',
+  stockView: 'stock.view',
+  reportsView: 'reports.view',
+} as const;
+
+export type PermissionKey =
+  (typeof PermissionKeys)[keyof typeof PermissionKeys];
+
+// The resolved permission state for the current Operator.
+export interface EffectivePermissions {
+  isCeo: boolean;
+  keys: ReadonlySet<string>;
+}
+
+// Pure resolution of effective permissions, mirroring mobile
+// resolveEffectivePermissions + currentUserPermissionsProvider:
+//   - CEO (role slug 'ceo') is all-on and skips every override layer.
+//   - Otherwise start from the role's business grants, then apply the user's
+//     overrides (granted true = force-grant, false = force-revoke).
+// Store-scope overrides (§10.2.1 middle layer) are a later slice; the skeleton
+// resolves Business ± User, which is the common case for a single-store operator.
+export function resolveEffectivePermissions(params: {
+  roleSlug: string | null | undefined;
+  roleGrants: Pick<RolePermissionRow, 'permission_key'>[];
+  userOverrides: Pick<
+    UserPermissionOverrideRow,
+    'permission_key' | 'is_granted'
+  >[];
+}): EffectivePermissions {
+  const { roleSlug, roleGrants, userOverrides } = params;
+  const keys = new Set(roleGrants.map((g) => g.permission_key));
+
+  if (roleSlug === 'ceo') {
+    return { isCeo: true, keys };
+  }
+
+  for (const o of userOverrides) {
+    if (o.is_granted) {
+      keys.add(o.permission_key);
+    } else {
+      keys.delete(o.permission_key);
+    }
+  }
+  return { isCeo: false, keys };
+}
+
+// hide-don't-block predicate: does the Operator have this permission? The CEO
+// always passes.
+export function can(
+  perms: EffectivePermissions | null | undefined,
+  key: PermissionKey,
+): boolean {
+  if (!perms) return false;
+  if (perms.isCeo) return true;
+  return perms.keys.has(key);
+}

--- a/web-pos/src/lib/supabase/client.ts
+++ b/web-pos/src/lib/supabase/client.ts
@@ -1,0 +1,28 @@
+'use client';
+
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+
+import { supabaseAnonKey, supabaseUrl } from './config';
+
+// The Web POS is online-first (ADR 0007): a single browser Supabase client is
+// the whole data layer — RLS-scoped PostgREST reads and (later slices) rpc()
+// writes and Realtime channels. The signed-in Supabase session IS the Operator
+// for this browser tab (ADR 0011); it is persisted in localStorage and the
+// client detects the OAuth session in the return URL after a Google redirect.
+//
+// One module-level instance is reused across the app (a fresh client per render
+// would drop the auth listener and duplicate Realtime sockets).
+let browserClient: SupabaseClient | undefined;
+
+export function getSupabaseBrowserClient(): SupabaseClient {
+  if (browserClient) return browserClient;
+  browserClient = createClient(supabaseUrl, supabaseAnonKey, {
+    auth: {
+      persistSession: true,
+      autoRefreshToken: true,
+      detectSessionInUrl: true,
+      flowType: 'pkce',
+    },
+  });
+  return browserClient;
+}

--- a/web-pos/src/lib/supabase/config.ts
+++ b/web-pos/src/lib/supabase/config.ts
@@ -1,0 +1,17 @@
+// Public Supabase connection config for the Web POS.
+//
+// The URL and anon key are client-public, RLS-gated values — the same class of
+// value the Flutter app hardcodes in lib/main.dart by design (see the project's
+// "anon key is intentional" decision). Baking the defaults here means the app
+// builds and runs with zero env setup; NEXT_PUBLIC_* env vars override them when
+// pointing at a different Supabase project.
+
+const DEFAULT_SUPABASE_URL = 'https://ewwyofbvfjyqqirrcaou.supabase.co';
+const DEFAULT_SUPABASE_ANON_KEY =
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImV3d3lvZmJ2Zmp5cXFpcnJjYW91Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzM1NzM0MTgsImV4cCI6MjA4OTE0OTQxOH0.McPYfcKMT_h7j9cEE7GiutREcluXo0x2SxdLP0YsP5Q';
+
+export const supabaseUrl =
+  process.env.NEXT_PUBLIC_SUPABASE_URL ?? DEFAULT_SUPABASE_URL;
+
+export const supabaseAnonKey =
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? DEFAULT_SUPABASE_ANON_KEY;

--- a/web-pos/src/lib/theme/palettes.ts
+++ b/web-pos/src/lib/theme/palettes.ts
@@ -1,0 +1,246 @@
+// The five named business palettes, ported verbatim from the mobile app's
+// AppTheme / colors.dart so the web brand matches mobile exactly (AC: reproduce
+// blue / amber / purple / green / b&w, light + dark). The active palette is the
+// synced `business_design_system` value — the DesignSystem enum *name* the CEO
+// set — so these keys must equal the Flutter enum names.
+
+export type PaletteName = 'blue' | 'amber' | 'purple' | 'green' | 'bw';
+export type ThemeMode = 'light' | 'dark';
+
+export const PALETTE_NAMES: PaletteName[] = [
+  'blue',
+  'amber',
+  'purple',
+  'green',
+  'bw',
+];
+
+export const DEFAULT_PALETTE: PaletteName = 'blue';
+
+// The token set every theme surface reads. Each maps 1:1 to a CSS custom
+// property `--<token>` applied at the document root.
+export interface ThemeTokens {
+  bg: string;
+  surface: string;
+  surface2: string;
+  border: string;
+  text: string;
+  subtext: string;
+  primary: string;
+  primaryHover: string;
+  onPrimary: string;
+  secondary: string;
+  danger: string;
+  success: string;
+  warning: string;
+  info: string;
+}
+
+type PaletteSet = Record<ThemeMode, ThemeTokens>;
+
+// Shared status colours per design system (from AppTheme's _*Semantics + the
+// per-palette danger/success brand colours).
+const blue: PaletteSet = {
+  light: {
+    bg: '#F8FAFC',
+    surface: '#FFFFFF',
+    surface2: '#F1F5F9',
+    border: '#E2E8F0',
+    text: '#0F172A',
+    subtext: '#64748B',
+    primary: '#2563EB',
+    primaryHover: '#1D4ED8',
+    onPrimary: '#FFFFFF',
+    secondary: '#60A5FA',
+    danger: '#EF4444',
+    success: '#10B981',
+    warning: '#FFB020',
+    info: '#3B82F6',
+  },
+  dark: {
+    bg: '#090D14',
+    surface: '#111827',
+    surface2: '#1C2438',
+    border: 'rgba(255,255,255,0.12)',
+    text: '#F8FAFC',
+    subtext: '#A0AEC0',
+    primary: '#3B82F6',
+    primaryHover: '#2563EB',
+    onPrimary: '#FFFFFF',
+    secondary: '#60A5FA',
+    danger: '#EF4444',
+    success: '#10B981',
+    warning: '#FFB020',
+    info: '#3B82F6',
+  },
+};
+
+const amber: PaletteSet = {
+  light: {
+    bg: '#F4F6FA',
+    surface: '#FFFFFF',
+    surface2: '#EDF0F5',
+    border: 'rgba(0,0,0,0.07)',
+    text: '#0E1420',
+    subtext: '#4B5563',
+    primary: '#D97706', // contrastAmber — light-theme high-contrast amber
+    primaryHover: '#B45309',
+    onPrimary: '#000000',
+    secondary: '#FF7A00',
+    danger: '#FF3B30',
+    success: '#30D158',
+    warning: '#FFB020',
+    info: '#3B82F6',
+  },
+  dark: {
+    bg: '#080C12',
+    surface: '#0E1420',
+    surface2: '#141B28',
+    border: 'rgba(255,255,255,0.06)',
+    text: '#E8EEF6',
+    subtext: '#6B7A90',
+    primary: '#F5A623', // amberPrimary
+    primaryHover: '#D97706',
+    onPrimary: '#000000',
+    secondary: '#FF7A00',
+    danger: '#FF3B30',
+    success: '#30D158',
+    warning: '#FFB020',
+    info: '#3B82F6',
+  },
+};
+
+const purple: PaletteSet = {
+  light: {
+    bg: '#F7F8FA',
+    surface: '#FFFFFF',
+    surface2: '#EDF0F4',
+    border: 'rgba(0,0,0,0.07)',
+    text: '#111827',
+    subtext: '#6B7280',
+    primary: '#7C3AED', // purplePrimaryDark — light-theme primary
+    primaryHover: '#6D28D9',
+    onPrimary: '#FFFFFF',
+    secondary: '#6D28D9',
+    danger: '#FF3B30',
+    success: '#34D399',
+    warning: '#FBBF24',
+    info: '#8B5CF6',
+  },
+  dark: {
+    bg: '#0B0D10',
+    surface: '#15171B',
+    surface2: '#1E2127',
+    border: 'rgba(255,255,255,0.08)',
+    text: '#F3F4F6',
+    subtext: '#9CA3AF',
+    primary: '#8B5CF6', // purplePrimary
+    primaryHover: '#7C3AED',
+    onPrimary: '#FFFFFF',
+    secondary: '#6D28D9',
+    danger: '#FF3B30',
+    success: '#34D399',
+    warning: '#FBBF24',
+    info: '#8B5CF6',
+  },
+};
+
+const green: PaletteSet = {
+  light: {
+    bg: '#F7F8FA',
+    surface: '#FFFFFF',
+    surface2: '#EDF0F4',
+    border: 'rgba(0,0,0,0.07)',
+    text: '#111827',
+    subtext: '#6B7280',
+    primary: '#15803D', // greenContrast — light-theme deep forest primary
+    primaryHover: '#166534',
+    onPrimary: '#FFFFFF',
+    secondary: '#166534',
+    danger: '#FF3B30',
+    success: '#22C55E',
+    warning: '#FFB020',
+    info: '#3B82F6',
+  },
+  dark: {
+    bg: '#0B0D10',
+    surface: '#15171B',
+    surface2: '#1E2127',
+    border: 'rgba(255,255,255,0.08)',
+    text: '#F3F4F6',
+    subtext: '#9CA3AF',
+    primary: '#22C55E', // greenPrimary
+    primaryHover: '#15803D',
+    onPrimary: '#FFFFFF',
+    secondary: '#166534',
+    danger: '#FF3B30',
+    success: '#22C55E',
+    warning: '#FFB020',
+    info: '#3B82F6',
+  },
+};
+
+const bw: PaletteSet = {
+  light: {
+    bg: '#F4F4F5',
+    surface: '#FFFFFF',
+    surface2: '#E7E7E9',
+    border: 'rgba(0,0,0,0.08)',
+    text: '#09090B',
+    subtext: '#52525B',
+    primary: '#111111', // bwPrimaryLight — near-black
+    primaryHover: '#3F3F46',
+    onPrimary: '#FFFFFF',
+    secondary: '#3F3F46',
+    danger: '#FF3B30',
+    success: '#22C55E',
+    warning: '#FFB020',
+    info: '#3B82F6',
+  },
+  dark: {
+    bg: '#000000',
+    surface: '#121212',
+    surface2: '#1E1E1E',
+    border: 'rgba(255,255,255,0.12)',
+    text: '#FAFAFA',
+    subtext: '#A1A1AA',
+    primary: '#FAFAFA', // bwPrimaryDark — near-white
+    primaryHover: '#BDBDBD',
+    onPrimary: '#000000',
+    secondary: '#BDBDBD',
+    danger: '#FF3B30',
+    success: '#22C55E',
+    warning: '#FFB020',
+    info: '#3B82F6',
+  },
+};
+
+export const PALETTES: Record<PaletteName, PaletteSet> = {
+  blue,
+  amber,
+  purple,
+  green,
+  bw,
+};
+
+// Coerce an arbitrary stored `business_design_system` value to a known palette,
+// falling back to the blue default (matches the mobile _parseDesignSystem +
+// blue default when the key is unset/invalid).
+export function parsePaletteName(value: string | null | undefined): PaletteName {
+  if (value && (PALETTE_NAMES as string[]).includes(value)) {
+    return value as PaletteName;
+  }
+  return DEFAULT_PALETTE;
+}
+
+// The CSS custom properties for a palette+mode, as a plain object ready to apply
+// to an element's style (`el.style.setProperty('--bg', ...)`).
+export function tokensToCssVars(tokens: ThemeTokens): Record<string, string> {
+  const vars: Record<string, string> = {};
+  for (const [key, value] of Object.entries(tokens)) {
+    // camelCase token → kebab CSS var (`primaryHover` → `--primary-hover`).
+    const cssKey = key.replace(/[A-Z]/g, (m) => `-${m.toLowerCase()}`);
+    vars[`--${cssKey}`] = value;
+  }
+  return vars;
+}

--- a/web-pos/src/lib/types.ts
+++ b/web-pos/src/lib/types.ts
@@ -1,0 +1,109 @@
+// Row shapes for the cloud tables the Web POS reads directly over RLS-scoped
+// PostgREST. Only the columns Slice 1 (walking skeleton) uses are typed; later
+// slices widen these. Amounts are `*_kobo` bigints, returned by PostgREST as
+// JS numbers (safe below 2^53 — Naira kobo amounts stay well under that).
+//
+// Mirrors the cloud schema (snake_case) verified against the live project, not
+// the Flutter Drift models.
+
+export interface ProfileRow {
+  id: string; // = auth.uid()
+  business_id: string | null;
+  name: string | null;
+}
+
+export interface UserRow {
+  id: string;
+  business_id: string | null;
+  auth_user_id: string | null;
+  name: string | null;
+  email: string | null;
+}
+
+export interface UserBusinessRow {
+  id: string;
+  business_id: string;
+  user_id: string;
+  role_id: string | null;
+  status: string | null; // 'active' | 'suspended'
+}
+
+export interface RoleRow {
+  id: string;
+  business_id: string;
+  name: string | null;
+  slug: string | null; // 'ceo' | 'manager' | 'cashier' | 'stock_keeper'
+  is_deleted: boolean | null;
+}
+
+export interface RolePermissionRow {
+  id: string;
+  business_id: string;
+  role_id: string;
+  permission_key: string;
+}
+
+export interface UserPermissionOverrideRow {
+  id: string;
+  business_id: string;
+  user_id: string;
+  permission_key: string;
+  is_granted: boolean;
+}
+
+export interface BusinessRow {
+  id: string;
+  name: string | null;
+  type: string | null;
+  tracks_empty_crates: boolean | null;
+}
+
+export interface SettingRow {
+  business_id: string;
+  key: string;
+  value: string | null;
+}
+
+export interface StoreRow {
+  id: string;
+  business_id: string;
+  name: string | null;
+  is_deleted: boolean | null;
+}
+
+export interface CategoryRow {
+  id: string;
+  business_id: string;
+  name: string | null;
+  is_deleted: boolean | null;
+}
+
+export interface ProductRow {
+  id: string;
+  business_id: string;
+  category_id: string | null;
+  name: string;
+  unit: string | null;
+  size: string | null;
+  retailer_price_kobo: number | null;
+  wholesaler_price_kobo: number | null;
+  buying_price_kobo: number | null;
+  is_available: boolean | null;
+  is_deleted: boolean | null;
+  low_stock_threshold: number | null;
+  image_path: string | null;
+}
+
+export interface InventoryRow {
+  id: string;
+  business_id: string;
+  product_id: string;
+  store_id: string;
+  quantity: number;
+}
+
+// A product joined with its on-hand quantity (summed across stores, or scoped
+// to the active store) — the shape the POS grid renders.
+export interface ProductWithStock extends ProductRow {
+  onHand: number;
+}

--- a/web-pos/src/lib/types.ts
+++ b/web-pos/src/lib/types.ts
@@ -92,6 +92,19 @@ export interface ProductRow {
   is_deleted: boolean | null;
   low_stock_threshold: number | null;
   image_path: string | null;
+  // Empty-crate tracking (Slice 4, #45). A product is crate-eligible when it's a
+  // returnable bottle (unit 'bottle') with track_empties on AND a manufacturer
+  // (whose per-crate deposit rate applies) — see crateEligible() in crate.ts.
+  track_empties: boolean | null;
+  manufacturer_id: string | null;
+}
+
+// A manufacturer with its per-crate deposit rate (deposit_amount_kobo). The
+// deposit value of empties is per-manufacturer, shared across its products.
+export interface ManufacturerRow {
+  id: string;
+  business_id: string;
+  deposit_amount_kobo: number | null;
 }
 
 export interface InventoryRow {
@@ -103,7 +116,38 @@ export interface InventoryRow {
 }
 
 // A product joined with its on-hand quantity (summed across stores, or scoped
-// to the active store) — the shape the POS grid renders.
+// to the active store) — the shape the POS grid renders. [depositRateKobo] is
+// the product's manufacturer's per-crate deposit (0 when not crate-eligible).
 export interface ProductWithStock extends ProductRow {
   onHand: number;
+  depositRateKobo: number;
+}
+
+// A registered customer (Slice 3, #44). `wallet_limit_kobo` is the debt limit —
+// 0 means no credit is allowed at all (mirrors the mobile rule).
+export interface CustomerRow {
+  id: string;
+  business_id: string;
+  name: string;
+  phone: string | null;
+  wallet_limit_kobo: number | null;
+  is_deleted: boolean | null;
+}
+
+// One append-only wallet ledger row. The customer's spendable balance is
+// SUM(signed_amount_kobo) over rows whose reference_type is NOT a crate deposit.
+export interface WalletTransactionRow {
+  customer_id: string;
+  signed_amount_kobo: number;
+  reference_type: string;
+}
+
+// A customer joined with their derived spendable wallet balance (kobo). Positive
+// = credit we hold; negative = they owe us.
+export interface CustomerWithBalance {
+  id: string;
+  name: string;
+  phone: string | null;
+  balanceKobo: number;
+  debtLimitKobo: number;
 }

--- a/web-pos/tsconfig.json
+++ b/web-pos/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }],
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/web-pos/vercel.json
+++ b/web-pos/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "nextjs"
+}


### PR DESCRIPTION
Merges the full Web POS epic (Slices 1–4) as one stack. Originally opened as the
Slice 1 skeleton; expanded to carry the checkout keystone commits.

## What's in here

**Slice 1 — walking skeleton (#47)** · commit `ba2eb66`
Auth, live catalogue, responsive shell, theming for the new Next.js/TS +
supabase-js web client (`web-pos/`, online-first — no Drift/outbox).

**Slices 2–4 — checkout keystone (#43 #44 #45)** · commit `876f405`
- **Slice 2 (cash, #43)** — `checkout_order` RPC (`0135_checkout_order.sql`):
  header at status `pending` (revenue recognized at checkout), item/inventory/
  stock-guard/stock-ledger loop, FIFO draw-down + scalar `buying_price_kobo`
  re-point, `WEB-…` order number, order-level discount. Golden Scenario Suite
  (`test/golden/`) pins Dart-DAO ↔ SQL-RPC parity.
- **Slice 3 (credit & wallet, #44)** — `0136_checkout_order_credit.sql`:
  Pay-with-Credit / Register-as-Credit-Sale, §14.3 wallet ledger legs, debt-limit
  guard.
- **Slice 4 (crate, #45)** — `0137_checkout_order_crate.sql`: §13.4 empty-crate
  dispatch (crate-track only; `deposit_paid_kobo` = 0, money-track deferred), plus
  the checkout UI (`Cart`, `CheckoutDialog`, `Receipt`, `CustomerPicker`).

## Review status

Already reviewed on the branch (Standards + Spec). The findings were filed as
follow-ups **#53–#57** (SQL-helper de-duplication, order-number decision, missing
golden fixtures, money-track deposit, web UI cleanup) — all blocked on this merge,
none blocking it.

## Notes for whoever merges / deploys

- Merges cleanly into `main` (no conflicts).
- The 3 migrations are **not** auto-deployed by this merge — run
  `supabase db push` in deploy order (0135 → 0136 → 0137; each after 0132/0133)
  separately.

Closes #47. Advances #43 #44 #45.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded Web POS from browsing into a complete, permission-gated checkout flow with cart, discounts (capped by role), receipts, and print/share.
  * Added support for customer credit and wallet payments, including debt-limit enforcement and customer balance display.
  * Added empty-crate deposit visibility and checkout receipt details for eligible businesses.
* **Tests**
  * Introduced golden-scenario coverage to ensure checkout money-rule parity between implementations.
* **Documentation**
  * Updated Web POS architecture and phase scope, including the online-first model and golden-scenario testing approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->