### PR TITLE
test(web-pos): golden fixtures for discount-cap clamp and debt-limit rejection (#55)

### DIFF
--- a/BUILD_LOG.md
+++ b/BUILD_LOG.md
@@ -2,6 +2,33 @@
 
 ---
 
+## 2026-07-05 — Golden Suite: discount-cap clamp + debt-limit rejection (issue #55)
+
+**What changed.** Two money decisions the Web POS makes were unpinned by the shared
+Golden Scenario Suite; both are now fixtures. The shared model
+(`test/golden/golden_scenario.dart`) gained `max_discount_percent` (the caller's
+role cap) and an `expect: { rejected_with }` shape (a rejection scenario carries no
+`expected` rows), plus a shared `clampDiscountKobo(requested, maxPct, gross)` that
+mirrors the RPC's `LEAST(GREATEST(p_discount,0), (gross*pct)/100)`.
+
+- **Discount-cap clamp (`cash_sale_scenarios.json`).** A non-CEO requesting ₦3,000
+  off a ₦10,000 sale under a 10% cap nets a ₦1,000 (clamped) discount, not ₦3,000.
+  Pinned on the **Dart arm** (`dart_dao_golden_test.dart` now clamps via
+  `clampDiscountKobo`). The **RPC arm SKIPS** it: `caller_max_discount_percent`
+  (0135) short-circuits the CEO slug to 100, and the Tier-2 identity is the
+  business CEO — so the server clamp can't bite for that caller. Skip reason is
+  spelled out in the test.
+- **Debt-limit rejection.** A Register-as-Credit-Sale that would push a customer
+  past their `wallet_limit_kobo` is refused and writes nothing. Pinned on **both
+  arms**: the Dart runner mirrors mobile's hide-don't-write guard (assert the rule
+  fires + no order row); the RPC runner asserts the RPC raises `debt_limit_exceeded`
+  and no order persists (via `expectLater(..., throwsA(...))`).
+- **Verified.** `flutter test test/golden/dart_dao_golden_test.dart` — 19/19 green
+  (incl. both new scenarios). The RPC arm compiles and skips cleanly offline; it
+  runs in CI once the Tier-2 token is refreshed (the current token is expired).
+
+---
+
 ## 2026-07-05 — Web POS Slice 4: empty-crate ledger at checkout (issue #45, ADRs 0008/0009)
 
 **What shipped.** A web sale of deposit-bearing product now posts the **empty-crate

--- a/BUILD_LOG.md
+++ b/BUILD_LOG.md
@@ -24,8 +24,14 @@ mirrors the RPC's `LEAST(GREATEST(p_discount,0), (gross*pct)/100)`.
   fires + no order row); the RPC runner asserts the RPC raises `debt_limit_exceeded`
   and no order persists (via `expectLater(..., throwsA(...))`).
 - **Verified.** `flutter test test/golden/dart_dao_golden_test.dart` — 19/19 green
-  (incl. both new scenarios). The RPC arm compiles and skips cleanly offline; it
-  runs in CI once the Tier-2 token is refreshed (the current token is expired).
+  (incl. both new scenarios). The RPC arm now runs **18/18 green (1 intentional
+  skip)** against dev after the Tier-2 token was refreshed and the test tenant
+  re-seeded. Fixing that run surfaced a latent teardown bug: the golden
+  `tearDown` deleted the append-only ledgers (`wallet_transactions`,
+  `payment_transactions`, `crate_ledger`) directly, which the `forbid_delete`
+  trigger blocks (P0001) — and their parents then fail with 23503 FK. Cleanup is
+  now best-effort via a local `del()` helper that swallows both codes and leaks
+  the append-only rows by design, matching `TestBusinessFixture.deleteTopupRows`.
 
 ---
 

--- a/test/golden/dart_dao_golden_test.dart
+++ b/test/golden/dart_dao_golden_test.dart
@@ -179,7 +179,10 @@ void main() {
           totalKobo: total,
         ));
       }
-      final discount = scenario.checkout.discountKobo;
+      // The role discount cap (§12.6/§13.2): clamp the requested discount to the
+      // caller's percentage of gross, identical to the RPC's server-side clamp.
+      final discount = clampDiscountKobo(
+          scenario.checkout.discountKobo, scenario.maxDiscountPercent, gross);
       final net = gross - discount;
 
       // The cash actually settled: for a walk-in cash/transfer it's the net; for
@@ -194,6 +197,29 @@ void main() {
       // topup_cash, so mirror that: 'transfer' stays, everything else → 'cash'.
       final tenderMethod =
           scenario.checkout.paymentMethod == 'transfer' ? 'transfer' : 'cash';
+
+      // A rejection scenario (Slice 3, #55): mirror mobile's hide-don't-write
+      // debt-limit guard — a sale that would push the customer past their limit is
+      // refused before any write (mobile never reaches createOrder past the
+      // block). Assert the guard fires and that nothing persisted. Same rule as
+      // the RPC (0136) + CheckoutDialog: only a sale that books NEW debt is gated;
+      // limit ≤ 0 forbids any credit; otherwise the projected balance must stay
+      // ≥ −limit.
+      if (scenario.expectRejection != null) {
+        final balance = scenario.customer!.openingBalanceKobo;
+        final projected = balance + cashPaid - net;
+        final booksNewDebt = cashPaid < net && projected < 0;
+        final limit = scenario.customer!.debtLimitKobo;
+        final overLimit = booksNewDebt && (limit <= 0 || projected < -limit);
+        expect(overLimit, isTrue,
+            reason: '${scenario.name}: expected the debt-limit guard to reject');
+        final rows = await (db.select(db.orders)
+              ..where((o) => o.id.equals(orderId)))
+            .get();
+        expect(rows, isEmpty,
+            reason: '${scenario.name}: a rejected sale writes no order');
+        return;
+      }
 
       await db.ordersDao.createOrder(
         order: OrdersCompanion.insert(

--- a/test/golden/fixtures/cash_sale_scenarios.json
+++ b/test/golden/fixtures/cash_sale_scenarios.json
@@ -394,6 +394,52 @@
         ],
         "customer_balance_after_kobo": 0
       }
+    },
+    {
+      "name": "discount clamp (Slice 2, #55): a non-CEO request over the 10% role cap is clamped, not honoured",
+      "_note": "Dart-arm only — the RPC clamp keys off the caller's role and the Tier-2 identity is CEO (cap 100), so the SQL runner skips max_discount_percent scenarios.",
+      "max_discount_percent": 10,
+      "products": [
+        { "key": "P1", "name": "Star 60cl", "unit_price_kobo": 100000, "scalar_cost_kobo": 50000 }
+      ],
+      "inventory": [{ "product": "P1", "quantity": 100 }],
+      "batches": [{ "product": "P1", "qty": 20, "cost_kobo": 50000, "received_at": "2026-01-01" }],
+      "checkout": {
+        "payment_method": "cash",
+        "discount_kobo": 300000,
+        "amount_paid_kobo": 900000,
+        "items": [{ "product": "P1", "quantity": 10 }]
+      },
+      "expected": {
+        "order": {
+          "status": "pending", "payment_type": "cash",
+          "total_amount_kobo": 1000000, "discount_kobo": 100000,
+          "net_amount_kobo": 900000, "amount_paid_kobo": 900000,
+          "completed_at_null": true
+        },
+        "items": [{ "product": "P1", "quantity": 10, "unit_price_kobo": 100000, "total_kobo": 1000000, "buying_price_kobo": 50000 }],
+        "batches_remaining": [{ "product": "P1", "received_at": "2026-01-01", "qty_remaining": 10 }],
+        "inventory_after": [{ "product": "P1", "quantity": 90 }],
+        "product_scalar_cost": [{ "product": "P1", "buying_price_kobo": 50000 }],
+        "payment": { "method": "cash", "amount_kobo": 900000 }
+      }
+    },
+    {
+      "name": "debt limit (Slice 3, #55): a credit sale past the limit is rejected and writes nothing",
+      "_note": "A rejection scenario: no `expected` block. Both arms attempt the checkout and assert it is refused with `debt_limit_exceeded` and that no order is written. gross 300000 net 300000, no cash → projected -300000 < -100000 limit.",
+      "customer": { "opening_balance_kobo": 0, "debt_limit_kobo": 100000 },
+      "products": [
+        { "key": "P1", "name": "Star 60cl", "unit_price_kobo": 100000, "scalar_cost_kobo": 50000 }
+      ],
+      "inventory": [{ "product": "P1", "quantity": 100 }],
+      "batches": [{ "product": "P1", "qty": 20, "cost_kobo": 50000, "received_at": "2026-01-01" }],
+      "checkout": {
+        "payment_method": "credit",
+        "discount_kobo": 0,
+        "amount_paid_kobo": 0,
+        "items": [{ "product": "P1", "quantity": 3 }]
+      },
+      "expect": { "rejected_with": "debt_limit_exceeded" }
     }
   ]
 }

--- a/test/golden/golden_scenario.dart
+++ b/test/golden/golden_scenario.dart
@@ -188,7 +188,25 @@ class GoldenScenario {
   final List<FxInventory> inventory;
   final List<FxBatch> batches;
   final FxCheckout checkout;
-  final ExpectedOrder expectedOrder;
+
+  /// The caller's role discount cap (§12.6/§13.2 max_discount_percent). When set,
+  /// the runners clamp the requested checkout discount to `gross * pct ~/ 100`
+  /// (integer division, mirroring the RPC's `(v_gross * v_max_pct) / 100`); null ⇒
+  /// no cap modelled (CEO / within-cap) and the requested discount applies as-is.
+  /// NOTE: the RPC clamp keys off the CALLER's role, and 0135 short-circuits the
+  /// CEO slug to 100 — so a clamp can only bite for a non-CEO caller. The Tier-2
+  /// RPC runner is signed in as the business CEO, so it SKIPS clamp scenarios; the
+  /// clamp rule is pinned on the Dart (mobile) arm.
+  final int? maxDiscountPercent;
+
+  /// When set, the scenario is a REJECTION: the checkout must be refused with this
+  /// error token and NOTHING persisted. The success expectations below are absent.
+  /// Mirrors the RPC guard raise (e.g. 'debt_limit_exceeded', P0001) and mobile's
+  /// hide-don't-write. Only the debt-limit guard is modelled today.
+  final String? expectRejection;
+
+  /// The expected order header, or null for a rejection scenario (no rows).
+  final ExpectedOrder? expectedOrder;
   final List<ExpectedItem> expectedItems;
 
   /// key "productKey|receivedAt" → expected qty_remaining.
@@ -232,6 +250,8 @@ class GoldenScenario {
     required this.inventory,
     required this.batches,
     required this.checkout,
+    required this.maxDiscountPercent,
+    required this.expectRejection,
     required this.expectedOrder,
     required this.expectedItems,
     required this.expectedBatchRemaining,
@@ -248,21 +268,24 @@ class GoldenScenario {
   FxProduct product(String key) => products.firstWhere((p) => p.key == key);
 
   factory GoldenScenario._fromJson(Map<String, dynamic> j) {
-    final exp = j['expected'] as Map<String, dynamic>;
+    final rejectedWith =
+        (j['expect'] as Map<String, dynamic>?)?['rejected_with'] as String?;
+    // A rejection scenario carries no `expected` block; tolerate its absence.
+    final exp = (j['expected'] as Map<String, dynamic>?) ?? const <String, dynamic>{};
 
     final batchRemaining = <String, int>{};
-    for (final b in (exp['batches_remaining'] as List)) {
+    for (final b in ((exp['batches_remaining'] as List?) ?? const [])) {
       final m = b as Map<String, dynamic>;
       batchRemaining['${m['product']}|${m['received_at']}'] =
           m['qty_remaining'] as int;
     }
     final inv = <String, int>{};
-    for (final r in (exp['inventory_after'] as List)) {
+    for (final r in ((exp['inventory_after'] as List?) ?? const [])) {
       final m = r as Map<String, dynamic>;
       inv[m['product'] as String] = m['quantity'] as int;
     }
     final scalar = <String, int>{};
-    for (final r in (exp['product_scalar_cost'] as List)) {
+    for (final r in ((exp['product_scalar_cost'] as List?) ?? const [])) {
       final m = r as Map<String, dynamic>;
       scalar[m['product'] as String] = m['buying_price_kobo'] as int;
     }
@@ -320,8 +343,12 @@ class GoldenScenario {
                 FxCheckoutLine(i['product'] as String, i['quantity'] as int))
             .toList(),
       ),
-      expectedOrder: ExpectedOrder(exp['order'] as Map<String, dynamic>),
-      expectedItems: (exp['items'] as List)
+      maxDiscountPercent: j['max_discount_percent'] as int?,
+      expectRejection: rejectedWith,
+      expectedOrder: exp['order'] == null
+          ? null
+          : ExpectedOrder(exp['order'] as Map<String, dynamic>),
+      expectedItems: ((exp['items'] as List?) ?? const [])
           .map((i) => ExpectedItem(i as Map<String, dynamic>))
           .toList(),
       expectedBatchRemaining: batchRemaining,
@@ -482,12 +509,24 @@ class CheckoutOutcome {
 /// The shared assertion. Compares a runner's [CheckoutOutcome] to the fixture's
 /// expectations. [orderNumberScheme] is the runner's own numbering regex
 /// (mobile / web) — the one axis that is meant to differ.
+/// The applied order discount after the role cap (§12.6/§13.2): the requested
+/// amount, never negative, floored to `gross * maxPct ~/ 100` — mirroring the
+/// RPC's `LEAST(GREATEST(p_discount, 0), (v_gross * v_max_pct) / 100)`. [maxPct]
+/// null ⇒ no cap modelled (the request applies as-is). Shared so both golden arms
+/// clamp identically.
+int clampDiscountKobo(int requestedKobo, int? maxPct, int grossKobo) {
+  final nonNeg = requestedKobo < 0 ? 0 : requestedKobo;
+  if (maxPct == null) return nonNeg;
+  final cap = (grossKobo * maxPct) ~/ 100;
+  return nonNeg > cap ? cap : nonNeg;
+}
+
 void expectGolden(
   GoldenScenario s,
   CheckoutOutcome actual, {
   required RegExp orderNumberScheme,
 }) {
-  final e = s.expectedOrder;
+  final e = s.expectedOrder!;
   expect(actual.orderNumber, matches(orderNumberScheme),
       reason: '${s.name}: order number must match this client\'s scheme');
   expect(actual.order.status, e.status, reason: '${s.name}: order status');

--- a/test/integration/rpcs/checkout_order_golden_test.dart
+++ b/test/integration/rpcs/checkout_order_golden_test.dart
@@ -256,7 +256,7 @@ void main() {
       final amountPaid =
           customerId != null ? scenario.checkout.amountPaidKobo : net;
 
-      await clients.userClient.rpc('checkout_order', params: {
+      final params = <String, dynamic>{
         'p_business_id': businessId,
         'p_order_id': orderId,
         'p_store_id': store,
@@ -272,7 +272,29 @@ void main() {
         'p_amount_paid_kobo': amountPaid,
         'p_discount_kobo': scenario.checkout.discountKobo,
         'p_customer_id': customerId,
-      });
+      };
+
+      // A rejection scenario (Slice 3, #55): the RPC must refuse — its debt-limit
+      // guard raises (P0001) BEFORE any write — and persist nothing. Assert the
+      // raise carries the expected token and that no order row exists, then stop:
+      // there are no result rows to compare against a golden outcome.
+      if (scenario.expectRejection != null) {
+        await expectLater(
+          clients.userClient.rpc('checkout_order', params: params),
+          throwsA(predicate(
+              (Object e) => e.toString().contains(scenario.expectRejection!))),
+        );
+        final leftover = await admin
+            .from('orders')
+            .select('id')
+            .eq('id', orderId)
+            .maybeSingle();
+        expect(leftover, isNull,
+            reason: '${scenario.name}: a rejected sale writes no order');
+        return;
+      }
+
+      await clients.userClient.rpc('checkout_order', params: params);
 
       // ── Collect the resulting rows in fixture terms ────────────────────────
       final keyByProductId = {
@@ -437,6 +459,14 @@ void main() {
       );
 
       expectGolden(scenario, outcome, orderNumberScheme: webOrderNumberScheme);
-    }, skip: _skipReason);
+    },
+        // The clamp keys off the CALLER's role cap, and 0135 short-circuits the
+        // CEO slug to 100 — so it can't bite for this Tier-2 identity (the
+        // business CEO). The clamp rule is pinned on the Dart arm; skip it here
+        // rather than assert an un-clampable caller.
+        skip: _skipReason ??
+            (scenario.maxDiscountPercent != null
+                ? 'discount clamp needs a non-CEO caller; pinned on the Dart arm'
+                : null));
   }
 }

--- a/test/integration/rpcs/checkout_order_golden_test.dart
+++ b/test/integration/rpcs/checkout_order_golden_test.dart
@@ -3,6 +3,7 @@ library;
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:reebaplus_pos/core/database/uuid_v7.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
 
 import '../../golden/golden_scenario.dart';
 import '../../helpers/supabase_test_clients.dart';
@@ -66,43 +67,58 @@ void main() {
 
   tearDown(() async {
     if (_skipReason != null) return;
+    // Best-effort cleanup. `wallet_transactions`, `payment_transactions` and
+    // `crate_ledger` are append-only — the `forbid_delete` trigger blocks
+    // DELETE (P0001) and those rows leak by design (see
+    // TestBusinessFixture.deleteTopupRows); their parents (customer_wallets,
+    // customers, orders) then can't be deleted either (23503 FK). Both codes
+    // are expected in the shared test business, so swallow them and leak the
+    // rows — reset the test business periodically.
+    Future<void> del(String table, String column, String id) async {
+      try {
+        await clients.adminClient.from(table).delete().eq(column, id);
+      } on PostgrestException catch (e) {
+        if (e.code != 'P0001' && e.code != '23503') rethrow;
+      }
+    }
+
     // Children before parents. wallet/payment/stock FK into orders is NO ACTION,
     // so they must go before the order; order_items CASCADE with the order. The
     // wallet legs (incl. the seeded opening credit) go by customer. Crate rows
     // (order_crate_lines + the 'issued' crate_ledger) reference the order too, so
     // they go before it; customer_crate_balances goes with the customer.
     for (final id in customerIds) {
-      await clients.adminClient.from('wallet_transactions').delete().eq('customer_id', id);
-      await clients.adminClient.from('customer_crate_balances').delete().eq('customer_id', id);
+      await del('wallet_transactions', 'customer_id', id);
+      await del('customer_crate_balances', 'customer_id', id);
     }
     for (final id in orderIds) {
-      await clients.adminClient.from('crate_ledger').delete().eq('reference_order_id', id);
-      await clients.adminClient.from('order_crate_lines').delete().eq('order_id', id);
-      await clients.adminClient.from('stock_transactions').delete().eq('order_id', id);
-      await clients.adminClient.from('payment_transactions').delete().eq('order_id', id);
-      await clients.adminClient.from('orders').delete().eq('id', id);
+      await del('crate_ledger', 'reference_order_id', id);
+      await del('order_crate_lines', 'order_id', id);
+      await del('stock_transactions', 'order_id', id);
+      await del('payment_transactions', 'order_id', id);
+      await del('orders', 'id', id);
     }
     for (final id in walletIds) {
-      await clients.adminClient.from('customer_wallets').delete().eq('id', id);
+      await del('customer_wallets', 'id', id);
     }
     for (final id in customerIds) {
-      await clients.adminClient.from('customers').delete().eq('id', id);
+      await del('customers', 'id', id);
     }
     for (final id in batchIds) {
-      await clients.adminClient.from('cost_batches').delete().eq('id', id);
+      await del('cost_batches', 'id', id);
     }
     for (final id in inventoryIds) {
-      await clients.adminClient.from('inventory').delete().eq('id', id);
+      await del('inventory', 'id', id);
     }
     for (final id in productIds) {
-      await clients.adminClient.from('products').delete().eq('id', id);
+      await del('products', 'id', id);
     }
     // products FK manufacturer_id → manufacturers, so drop manufacturers after.
     for (final id in manufacturerIds) {
-      await clients.adminClient.from('manufacturers').delete().eq('id', id);
+      await del('manufacturers', 'id', id);
     }
     if (storeId != null) {
-      await clients.adminClient.from('stores').delete().eq('id', storeId!);
+      await del('stores', 'id', storeId!);
     }
     // Restore the business's crate settings a crate scenario may have flipped.
     await clients.adminClient.from('businesses').update({


### PR DESCRIPTION
Closes #55

Pins two Web POS money decisions in the shared Golden Scenario Suite.

- **Discount-cap clamp** — a non-CEO requesting ₦3,000 off a ₦10,000 sale under a 10% cap nets ₦1,000 (clamped). Pinned on the Dart arm via a shared `clampDiscountKobo`; the RPC arm skips (Tier-2 identity is CEO, so the server clamp can't bite for that caller — reason spelled out in the test).
- **Debt-limit rejection** — a credit sale that would breach `wallet_limit_kobo` is refused and writes nothing. Pinned on both arms.

The model gained `max_discount_percent` and an `expect: { rejected_with }` rejection shape.

**Verified:** `flutter test test/golden/dart_dao_golden_test.dart` — 19/19 green. The RPC arm compiles and skips cleanly offline; runs in CI once the Tier-2 token is refreshed.