### PR TITLE
feat(web-pos): UI redesign + collapsible sidebar, and checkout-UI de-duplication (#58, #57)

### DIFF
--- a/BUILD_LOG.md
+++ b/BUILD_LOG.md
@@ -2,6 +2,29 @@
 
 ---
 
+## 2026-07-05 — Web POS checkout-UI cleanup (issue #57)
+
+**What changed.** Quality-only de-duplication of the Slice 2–4 web checkout; no
+behavior change (typecheck + `next build` green).
+
+- **Shared `receiptRows()` (`web-pos/src/lib/receipt.ts`, new).** The receipt's
+  subtotal→empties summary was built twice — once in `Receipt.tsx`'s JSX and once
+  in its `plainText()` — and had already drifted (the empties line read
+  "— ₦X deposit" in plain text vs "· ₦X" on screen). Both renderings now derive
+  from one `receiptRows(result, format)` returning `{label, value, kind}[]`, so
+  they can't diverge; `receiptRowClass(kind)` maps a row to its CSS class. The
+  divergent empties wording is unified to "· ₦X deposit".
+- **`paymentMethodMeta` map (`web-pos/src/lib/checkout.ts`).** The `PaymentMethod`
+  labels + the hard-coded `['cash','transfer']` / `['wallet','credit']` selector
+  arrays collapsed into one `paymentMethodMeta` (label + group) with
+  `paymentMethodsInGroup('tender'|'credit')`. `CheckoutDialog` renders its
+  segmented control from these.
+- **`operatorTracksCrates(operator)` (`web-pos/src/lib/crate.ts`).** The verbatim
+  `businessTracksCrates(operator?.business?.type, …?.tracksEmptyCrates ?? false)`
+  duplicated in `Cart.tsx` and `CheckoutDialog.tsx` is now one bundled helper.
+
+---
+
 ## 2026-07-05 — Web POS Slice 4: empty-crate ledger at checkout (issue #45, ADRs 0008/0009)
 
 **What shipped.** A web sale of deposit-bearing product now posts the **empty-crate

--- a/docs/adr/0013-web-pos-visual-redesign.md
+++ b/docs/adr/0013-web-pos-visual-redesign.md
@@ -1,0 +1,26 @@
+# Web POS Visual Redesign, Stateful Theme Override, and Collapsible Sidebar
+
+The Web POS visual styling is upgraded to match the premium, custom-branded experience of the mobile client, while adding manual controls tailored for web users.
+
+## Context
+
+The initial Web POS skeleton featured simple CSS layouts with hardcoded color variables, default system fonts, and automatic light/dark colors matching the browser's system preference. Cashiers and administrative users requested a highly refined desktop-first user interface that looks modernized and exquisite, supports manual light/dark/system mode overrides in the app interface, uses high-quality typography, allows collapsing the sidebar navigation to reclaim horizontal space for product cards, and replicates the brand's exact signature gradients.
+
+## Decisions
+
+1. **Stateful Theme Provider & Context**: Implement a client-side theme provider context that governs the theme mode (`light | dark | system`) and resolves the theme dynamically. Store the setting in `localStorage` under `theme-mode`.
+2. **Flash of Unstyled Content (FOUC) Prevention**: Embed a synchronous blocking script inside the HTML `<head>` tag to retrieve the user's stored theme (or system fallback) and set the `data-theme` attribute and `colorScheme` property before React hydrates the page.
+3. **Plus Jakarta Sans Typography**: Load the premium sans-serif geometric font `Plus Jakarta Sans` via Next.js's optimized `next/font/google` loader.
+4. **Selective Glassmorphism**: Apply `backdrop-filter: blur(12px)` and translucent backgrounds (`color-mix` with `transparent`) strictly on fixed floating containers—including the top bar, navigation sidebar, overlay dialog backdrops, and menu panels—to convey depth without sacrificing content readability. Keep product cards and data tables opaque with refined borders and shadows.
+5. **Collapsible Navigation Rail**: Add an in-memory toggle state for the sidebar navigation. Clicking the hamburger button shrinks the sidebar from `240px` (desktop expanded) into a `76px` narrow rail (icons-only) or hides it on smaller screens, maximizing product grid space.
+6. **Mobile Gradient Replication**: Port the mobile app's signature gradients using standard CSS `color-mix()` functions to blend values directly from theme variables:
+   - Primary button/badge gradient: `linear-gradient` fading from `primary` with `80% opacity` to solid `primary`.
+   - Glassy page background gradient: `linear-gradient` blending `bg`, `bg + 5% primary`, and `bg + 12% primary`.
+   - AmberGlowLine style separator: `linear-gradient` transparent ➔ primary ➔ transparent.
+
+## Consequences
+
+- The web UI matches the exact branding and color configurations chosen by the CEO/business owner, keeping visual parity.
+- System preference-only theme switching is replaced by a manual dropdown control in the app shell, with preferences saved across visits.
+- Horizontal space forcashiers is highly adjustable on smaller laptop screens via the collapsible sidebar toggle.
+- The cart panel remains sticky and permanently visible on viewports >= 900px, ensuring checkout is always one click away on desktop screens.

--- a/docs/adr/0013-web-pos-visual-redesign.md
+++ b/docs/adr/0013-web-pos-visual-redesign.md
@@ -1,6 +1,6 @@
-# Web POS Visual Redesign, Stateful Theme Override, and Collapsible Sidebar
+# Web POS Visual Redesign, Stateful Theme Override, and Sidebar Navigation
 
-The Web POS visual styling is upgraded to match the premium, custom-branded experience of the mobile client, while adding manual controls tailored for web users.
+The Web POS visual styling is upgraded to match the premium, custom-branded experience of the mobile client, while adding manual controls and layout structures tailored for web users.
 
 ## Context
 
@@ -11,9 +11,12 @@ The initial Web POS skeleton featured simple CSS layouts with hardcoded color va
 1. **Stateful Theme Provider & Context**: Implement a client-side theme provider context that governs the theme mode (`light | dark | system`) and resolves the theme dynamically. Store the setting in `localStorage` under `theme-mode`.
 2. **Flash of Unstyled Content (FOUC) Prevention**: Embed a synchronous blocking script inside the HTML `<head>` tag to retrieve the user's stored theme (or system fallback) and set the `data-theme` attribute and `colorScheme` property before React hydrates the page.
 3. **Plus Jakarta Sans Typography**: Load the premium sans-serif geometric font `Plus Jakarta Sans` via Next.js's optimized `next/font/google` loader.
-4. **Selective Glassmorphism**: Apply `backdrop-filter: blur(12px)` and translucent backgrounds (`color-mix` with `transparent`) strictly on fixed floating containers—including the top bar, navigation sidebar, overlay dialog backdrops, and menu panels—to convey depth without sacrificing content readability. Keep product cards and data tables opaque with refined borders and shadows.
-5. **Collapsible Navigation Rail**: Add an in-memory toggle state for the sidebar navigation. Clicking the hamburger button shrinks the sidebar from `240px` (desktop expanded) into a `76px` narrow rail (icons-only) or hides it on smaller screens, maximizing product grid space.
-6. **Mobile Gradient Replication**: Port the mobile app's signature gradients using standard CSS `color-mix()` functions to blend values directly from theme variables:
+4. **Full-Height Left Navigation Grid**: Structure the layout using CSS grid-template-areas, positioning the navigation sidebar as a full-height column on the left edge, and the top-bar and content area side-by-side on the right.
+5. **Selective Glassmorphism & Mesh Background Glows**: Apply `backdrop-filter: blur(12px)` and translucent backgrounds (`color-mix` with `transparent`) strictly on fixed floating containers—including the top bar, navigation sidebar, overlay dialog backdrops, and menu panels—to convey depth without sacrificing content readability. Add pseudo-elements with radial gradients and large blurs on the shell background to create a colorful background mesh glow.
+6. **Product Card White Boxes**: Wrap product images inside a solid white rounded box container with `object-fit: contain` and centering padding, isolating the product shape from the background cards and improving product separation.
+7. **Outline SVG Icons**: Replace all system/unicode icons in the sidebar and headers with custom, lightweight inline SVGs.
+8. **Promoted Cart Provider & Search Integration**: Move the `<CartProvider>` wrapper to the root layout to allow the header search input to share its query value with the product card grid.
+9. **Mobile Gradient Replication**: Port the mobile app's signature gradients using standard CSS `color-mix()` functions to blend values directly from theme variables:
    - Primary button/badge gradient: `linear-gradient` fading from `primary` with `80% opacity` to solid `primary`.
    - Glassy page background gradient: `linear-gradient` blending `bg`, `bg + 5% primary`, and `bg + 12% primary`.
    - AmberGlowLine style separator: `linear-gradient` transparent ➔ primary ➔ transparent.
@@ -22,5 +25,6 @@ The initial Web POS skeleton featured simple CSS layouts with hardcoded color va
 
 - The web UI matches the exact branding and color configurations chosen by the CEO/business owner, keeping visual parity.
 - System preference-only theme switching is replaced by a manual dropdown control in the app shell, with preferences saved across visits.
-- Horizontal space forcashiers is highly adjustable on smaller laptop screens via the collapsible sidebar toggle.
+- Horizontal space for cashiers is highly adjustable on smaller laptop screens via the collapsible sidebar toggle, which collapses items into a stacked narrow rail (icons with labels below).
 - The cart panel remains sticky and permanently visible on viewports >= 900px, ensuring checkout is always one click away on desktop screens.
+- Global components (search, navigation rail, custom profiles) are highly modularized, utilizing dynamic `--bg`, `--surface`, `--text`, and `--primary` CSS variables, ensuring 100% reusability across future administrative pages.

--- a/docs/prd/web-pos-ui-redesign.md
+++ b/docs/prd/web-pos-ui-redesign.md
@@ -1,0 +1,53 @@
+# PRD — Web POS UI Visual Redesign & Collapsible Sidebar
+
+## Problem Statement
+
+The current Web POS UI has a basic flat aesthetic with system fonts, hardcoded color schemes, and no manual theme toggle. Cashiers and CEOs operating from desktop web browsers want a modern, premium, and visually stunning interface that matches top-tier POS designs, fits the brand aesthetic, supports manual light/dark theme selection, and provides a customizable view that maximizes the product grid space via collapsible navigation.
+
+## Solution
+
+A modernized, highly exquisite visual redesign of the Web POS client featuring:
+1. Stateful manual theme selection (Light / Dark / System) with `localStorage` persistence and FOUC (Flash of Un-themed Content) prevention.
+2. Plus Jakarta Sans typography integrated via Next.js Google Fonts.
+3. Spacious & Cinematic (Modern Premium) visual density, rich gradients, and micro-interactions.
+4. Collapsible sidebar navigation rail that toggles open/close to save space.
+5. Sticky, always-visible right-hand cart panel on desktop.
+6. Highly polished color palettes for `blue`, `amber`, `purple`, `green`, and `bw` that match the mobile app's colors exactly.
+7. CSS translations of signature mobile gradients (`primaryGradient`, `glassyBackground`, `AmberGlowLine`) using `color-mix()`.
+
+## User Stories
+
+1. As an Operator, I want to toggle the theme between Light, Dark, and System modes using a dropdown in the header, so that I can adjust the POS readability depending on my environment.
+2. As an Operator, I want my theme choice persisted in `localStorage`, so that when I reload the tab or sign back in, the theme preference is preserved.
+3. As an Operator, I want the page to load without a visual white flash (FOUC), so that the transition is seamless when using dark mode.
+4. As an Operator, I want a collapsible sidebar, so that I can collapse the navigation menu to a narrow icon-only rail (or hide it completely on mobile) to give maximum screen space to the product grid and cart.
+5. As an Operator, I want the sidebar collapse state persisted across reloads, so that I do not have to toggle it every time I open the app.
+6. As a cashier on a desktop browser, I want the cart panel to always stay visible and sticky on the right, so that I can see the items, totals, and checkout button while clicking products.
+7. As an Operator, I want the product cards to render with soft shadows, thin borders, and subtle lifting hover animations, so that the interface feels interactive and responsive.
+8. As a CEO, I want the five business palettes (`blue`, `amber`, `purple`, `green`, `bw`) to use the exact mobile color values, so that the branding looks premium and consistent across platforms in both light and dark modes.
+9. As an Operator, I want the UI text to render using the Plus Jakarta Sans font, so that the numbers, quantities, and labels look clean and professional.
+10. As an Operator, I want interactive form controls (like checked checkboxes and inputs) to use the active brand accent color, so that form interactions match the active business theme.
+11. As an Operator, I want the page background to feature a glassy gradient that blends the base background with a touch of the primary accent, matching the mobile app's signature page styling.
+
+## Implementation Decisions
+
+- **Stateful Theme Provider**: Architect a client-side `ThemeProvider` context that exposes `themeMode`, `resolvedTheme`, and `setThemeMode`. Store the preference under `theme-mode` in `localStorage`.
+- **FOUC Prevention Script**: Inject a small blocking script inside the HTML `<head>` (in `layout.tsx`) that reads `localStorage.getItem('theme-mode')` and applies `data-theme` and `style.colorScheme` immediately.
+- **Collapsible Sidebar**: Add a toggle button (e.g. ☰) next to the logo in the header. Manage the expanded/collapsed state locally and store in `localStorage`.
+- **Vanilla CSS Layout & Variables**: Update `globals.css` with clean CSS custom properties that inherit oklch color palettes dynamically. Apply `backdrop-filter: blur(12px)` selectively on the sticky header, collapsed/expanded sidebar, overlays, and dropdowns.
+- **Plus Jakarta Sans Typography**: Import `Plus_Jakarta_Sans` in Next.js `layout.tsx` and apply it root-wide.
+- **Mobile Gradient Replication**: Map the custom properties like `--primary`, `--bg`, `--surface`, etc. in `palettes.ts` and define gradients:
+  - `primaryGradient` using `linear-gradient(135deg, color-mix(in srgb, var(--primary) 80%, transparent) 0%, var(--primary) 100%)`.
+  - `glassyBackground` using `linear-gradient(135deg, var(--bg) 0%, color-mix(in srgb, var(--primary) 5%, var(--bg)) 50%, color-mix(in srgb, var(--primary) 12%, var(--bg)) 100%)`.
+  - `AmberGlowLine` using `linear-gradient(90deg, transparent 0%, var(--primary) 50%, transparent 100%)`.
+
+## Testing Decisions
+
+- Only test external behavior, not implementation details.
+- Verify typescript check compiles without errors: `npm run typecheck`.
+- Build the Next.js bundle successfully: `npm run build`.
+
+## Out of Scope
+
+- Offline-first capabilities for the Web POS (remains online-first as per ADR 0007).
+- Changing database schemas or Supabase RPC signatures.

--- a/web-pos/src/app/globals.css
+++ b/web-pos/src/app/globals.css
@@ -563,8 +563,8 @@ input {
 .product-card {
   display: flex;
   flex-direction: column;
-  gap: 10px;
-  padding: 18px;
+  gap: 8px;
+  padding: 12px;
   text-align: left;
   background: var(--surface);
   border: 1px solid var(--border);
@@ -590,31 +590,84 @@ input {
   transform: none !important;
   box-shadow: none !important;
 }
+
+/* Product Card Image container */
+.product-card__image-container {
+  width: 100%;
+  height: 110px;
+  border-radius: calc(var(--radius-lg) - 6px);
+  overflow: hidden;
+  position: relative;
+  background: color-mix(in srgb, var(--surface2) 80%, transparent);
+  border: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: border-color 0.2s ease;
+}
+.product-card:hover:not(:disabled) .product-card__image-container {
+  border-color: color-mix(in srgb, var(--primary) 30%, transparent);
+}
+.product-card__image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: transform 0.3s ease;
+}
+.product-card:hover:not(:disabled) .product-card__image {
+  transform: scale(1.05);
+}
+.product-card__placeholder {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--primary) 8%, transparent) 0%,
+    color-mix(in srgb, var(--primary) 2%, transparent) 100%
+  );
+}
+.product-card__placeholder-icon {
+  font-size: 36px;
+  filter: drop-shadow(0 4px 8px color-mix(in srgb, var(--primary) 15%, transparent));
+  transition: transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+.product-card:hover:not(:disabled) .product-card__placeholder-icon {
+  transform: scale(1.15) rotate(5deg);
+}
+
+.product-card__content {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
 .product-card__name {
   font-weight: 700;
-  font-size: 15px;
-  line-height: 1.4;
+  font-size: 14.5px;
+  line-height: 1.35;
   color: var(--text);
   display: -webkit-box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
   overflow: hidden;
-  height: 42px;
+  height: 38px;
 }
 .product-card__meta {
-  font-size: 12px;
+  font-size: 11.5px;
   color: var(--subtext);
-  font-weight: 500;
+  font-weight: 600;
 }
 .product-card__prices {
   display: flex;
   flex-direction: column;
   gap: 2px;
-  margin-top: auto;
+  margin-top: 2px;
 }
 .product-card__price {
   font-weight: 800;
-  font-size: 16px;
+  font-size: 15.5px;
   color: var(--text);
 }
 .product-card__price-tier {
@@ -624,7 +677,7 @@ input {
   letter-spacing: 0.02em;
 }
 .product-card__wholesale {
-  font-size: 12px;
+  font-size: 11.5px;
   color: var(--subtext);
   font-weight: 600;
 }
@@ -634,6 +687,7 @@ input {
   gap: 6px;
   font-size: 12px;
   font-weight: 700;
+  margin-top: auto;
 }
 .stock-dot {
   width: 8px;

--- a/web-pos/src/app/globals.css
+++ b/web-pos/src/app/globals.css
@@ -28,13 +28,19 @@
   --warning: #ffb020;
   --info: #3b82f6;
 
+  /* Fallback glassmorphism & background pattern tokens */
+  --glass-bg: rgba(255, 255, 255, 0.45);
+  --glass-border: rgba(255, 255, 255, 0.6);
+  --bg-pattern-color: rgba(37, 99, 235, 0.03);
+  --glow-opacity: 0.05;
+
   /* Layout and shapes spacing */
-  --radius: 14px;
-  --radius-lg: 20px;
+  --radius: 12px;
+  --radius-lg: 16px;
   --rail-width: 76px;
   --sidebar-width: 240px;
   --content-max: 1600px;
-  --card-min: 150px;
+  --card-min: 140px;
   --font-sans: var(--font-sans), system-ui, -apple-system, sans-serif;
 }
 
@@ -71,13 +77,17 @@ body {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   min-height: 100dvh;
-  /* Replicate mobile's glassyBackground signature top-left to bottom-right blend */
-  background-image: linear-gradient(
-    135deg,
-    var(--bg) 0%,
-    color-mix(in srgb, var(--primary) 5%, var(--bg)) 50%,
-    color-mix(in srgb, var(--primary) 12%, var(--bg)) 100%
-  );
+  /* Glassy background gradient + repeating grid pattern */
+  background-image: 
+    linear-gradient(to right, var(--bg-pattern-color) 1px, transparent 1px),
+    linear-gradient(to bottom, var(--bg-pattern-color) 1px, transparent 1px),
+    linear-gradient(
+      135deg,
+      var(--bg) 0%,
+      color-mix(in srgb, var(--primary) 5%, var(--bg)) 50%,
+      color-mix(in srgb, var(--primary) 12%, var(--bg)) 100%
+    );
+  background-size: 24px 24px, 24px 24px, 100% 100%;
   background-attachment: fixed;
 }
 
@@ -310,13 +320,14 @@ input {
   max-height: 500px;
   background: radial-gradient(
     circle,
-    color-mix(in srgb, var(--primary) 7%, transparent) 0%,
-    color-mix(in srgb, var(--secondary) 3%, transparent) 50%,
+    color-mix(in srgb, var(--primary) 50%, transparent) 0%,
+    color-mix(in srgb, var(--secondary) 25%, transparent) 50%,
     transparent 80%
   );
   filter: blur(80px);
   pointer-events: none;
   z-index: 0;
+  opacity: var(--glow-opacity);
 }
 .shell::after {
   content: '';
@@ -329,13 +340,14 @@ input {
   max-height: 600px;
   background: radial-gradient(
     circle,
-    color-mix(in srgb, var(--secondary) 6%, transparent) 0%,
-    color-mix(in srgb, var(--primary) 2%, transparent) 60%,
+    color-mix(in srgb, var(--secondary) 40%, transparent) 0%,
+    color-mix(in srgb, var(--primary) 15%, transparent) 60%,
     transparent 90%
   );
   filter: blur(100px);
   pointer-events: none;
   z-index: 0;
+  opacity: var(--glow-opacity);
 }
 
 .shell__topbar {
@@ -343,27 +355,27 @@ input {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 16px;
-  padding: 12px 24px;
-  height: 76px;
-  background: color-mix(in srgb, var(--bg) 60%, transparent);
+  gap: 12px;
+  padding: 6px 16px;
+  height: 58px;
+  background: var(--glass-bg);
   backdrop-filter: blur(16px);
   -webkit-backdrop-filter: blur(16px);
-  border-bottom: 1px solid var(--border);
+  border-bottom: 1px solid var(--glass-border);
   z-index: 45;
-  box-shadow: 0 4px 20px -8px color-mix(in srgb, var(--text) 8%, transparent);
+  box-shadow: 0 2px 12px -4px color-mix(in srgb, var(--text) 5%, transparent);
 }
 
 .shell__brand {
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 8px 0 24px;
-  border-bottom: 1px solid var(--border);
-  margin-bottom: 24px;
+  padding: 4px 0 12px;
+  border-bottom: 1px solid var(--glass-border);
+  margin-bottom: 12px;
 }
 .shell__brand-logo {
-  font-size: 26px;
+  font-size: 22px;
   font-weight: 900;
   color: var(--text);
   letter-spacing: -0.05em;
@@ -373,14 +385,14 @@ input {
 }
 .shell__brand-logo .plus-sign {
   color: var(--primary);
-  font-size: 24px;
+  font-size: 20px;
   font-weight: 700;
 }
 
 .shell__actions-group {
   display: flex;
   align-items: center;
-  gap: 14px;
+  gap: 10px;
 }
 
 /* Glassmorphic Navigation Rail/Sidebar */
@@ -388,34 +400,34 @@ input {
   grid-area: sidebar;
   display: flex;
   flex-direction: column;
-  background: color-mix(in srgb, var(--surface) 85%, transparent);
+  background: var(--glass-bg);
   backdrop-filter: blur(20px);
   -webkit-backdrop-filter: blur(20px);
-  border-right: 1px solid var(--border);
+  border-right: 1px solid var(--glass-border);
   width: var(--sidebar-width);
   height: 100vh;
   flex-shrink: 0;
   transition: width 0.25s cubic-bezier(0.4, 0, 0.2, 1);
   z-index: 50;
-  padding: 20px 14px;
+  padding: 12px 10px;
   position: relative;
 }
 
 .shell__nav-items {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 6px;
   flex: 1;
 }
 
 .shell__nav-item {
   display: flex;
   align-items: center;
-  gap: 14px;
-  padding: 12px 16px;
-  border-radius: 12px;
+  gap: 10px;
+  padding: 8px 12px;
+  border-radius: 10px;
   color: var(--subtext);
-  font-size: 14px;
+  font-size: 13.5px;
   font-weight: 700;
   cursor: pointer;
   transition: all 0.2s ease;
@@ -436,8 +448,8 @@ input {
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 24px;
-  height: 24px;
+  width: 20px;
+  height: 20px;
   flex-shrink: 0;
 }
 .shell__nav-label {
@@ -449,9 +461,9 @@ input {
 .shell__nav-footer {
   display: flex;
   flex-direction: column;
-  gap: 12px;
-  border-top: 1px solid var(--border);
-  padding-top: 16px;
+  gap: 10px;
+  border-top: 1px solid var(--glass-border);
+  padding-top: 12px;
   margin-top: auto;
 }
 .shell__sidebar-toggle-btn {
@@ -481,7 +493,7 @@ input {
 .shell__content {
   grid-area: main;
   overflow-y: auto;
-  padding: 24px;
+  padding: 16px;
   position: relative;
   z-index: 1;
 }
@@ -494,11 +506,12 @@ input {
 .shell__account-profile {
   display: flex;
   align-items: center;
-  gap: 12px;
-  padding: 4px 12px 4px 4px;
+  gap: 8px;
+  padding: 4px 10px 4px 4px;
   border-radius: 30px;
-  background: color-mix(in srgb, var(--surface2) 50%, transparent);
-  border: 1px solid var(--border);
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+  backdrop-filter: blur(8px);
 }
 .shell__avatar-container {
   position: relative;
@@ -548,16 +561,18 @@ input {
 /* Header Action Buttons */
 .shell__view-btn,
 .shell__signout-btn {
-  height: 40px;
-  border-radius: 12px;
-  padding: 0 16px;
-  font-size: 14px;
+  height: 34px;
+  border-radius: 10px;
+  padding: 0 12px;
+  font-size: 13px;
   font-weight: 700;
-  border-color: var(--border);
+  border: 1px solid var(--glass-border);
+  background: var(--glass-bg);
+  backdrop-filter: blur(8px);
 }
 .dropdown-arrow {
   font-size: 8px;
-  margin-left: 6px;
+  margin-left: 4px;
   opacity: 0.7;
 }
 
@@ -566,12 +581,13 @@ input {
   position: relative;
   display: flex;
   align-items: center;
-  background: color-mix(in srgb, var(--surface2) 80%, transparent);
-  border: 1px solid var(--border);
-  border-radius: 12px;
-  padding: 0 12px;
-  width: 240px;
-  height: 40px;
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+  backdrop-filter: blur(8px);
+  border-radius: 10px;
+  padding: 0 10px;
+  width: 220px;
+  height: 34px;
   transition: all 0.2s ease;
 }
 .search-bar:focus-within {
@@ -581,14 +597,15 @@ input {
 }
 .search-bar__icon {
   color: var(--subtext);
-  margin-right: 8px;
+  margin-right: 6px;
   flex-shrink: 0;
+  font-size: 13px;
 }
 .search-bar__input {
   background: transparent;
   border: none;
   color: var(--text);
-  font-size: 14px;
+  font-size: 13px;
   font-weight: 600;
   width: 100%;
   height: 100%;
@@ -601,11 +618,12 @@ input {
 
 /* Theme Dropdown Toggle */
 .theme-dropdown__icon-toggle {
-  width: 40px;
-  height: 40px;
+  width: 34px;
+  height: 34px;
   border-radius: 50%;
-  border: 1px solid var(--border);
-  background: color-mix(in srgb, var(--surface2) 80%, transparent);
+  border: 1px solid var(--glass-border);
+  background: var(--glass-bg);
+  backdrop-filter: blur(8px);
   color: var(--text);
   display: flex;
   align-items: center;
@@ -619,7 +637,7 @@ input {
   background: var(--surface);
 }
 .theme-dropdown__menu {
-  top: calc(100% + 8px);
+  top: calc(100% + 6px);
   right: 0;
   width: 130px;
 }
@@ -707,7 +725,7 @@ input {
 .pos {
   display: flex;
   flex-direction: column;
-  gap: 24px;
+  gap: 14px;
 }
 
 .pos__header {
@@ -715,10 +733,10 @@ input {
   flex-wrap: wrap;
   align-items: center;
   justify-content: space-between;
-  gap: 16px;
+  gap: 12px;
 }
 .pos__title {
-  font-size: 24px;
+  font-size: 20px;
   font-weight: 800;
   margin: 0;
   letter-spacing: -0.02em;
@@ -726,9 +744,9 @@ input {
 
 .category-bar {
   display: flex;
-  gap: 10px;
+  gap: 8px;
   overflow-x: auto;
-  padding-bottom: 8px;
+  padding-bottom: 6px;
   scrollbar-width: none;
 }
 .category-bar::-webkit-scrollbar {
@@ -736,17 +754,18 @@ input {
 }
 .chip {
   flex-shrink: 0;
-  padding: 10px 20px;
-  border-radius: 24px;
-  border: 1px solid var(--border);
-  background: color-mix(in srgb, var(--surface) 70%, transparent);
+  padding: 6px 14px;
+  border-radius: 20px;
+  border: 1px solid var(--glass-border);
+  background: var(--glass-bg);
   backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
   color: var(--text);
-  font-size: 13.5px;
+  font-size: 13px;
   font-weight: 700;
   white-space: nowrap;
   transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
-  box-shadow: 0 1px 3px color-mix(in srgb, var(--text) 4%, transparent);
+  box-shadow: 0 1px 2px color-mix(in srgb, var(--text) 2%, transparent);
 }
 .chip:hover {
   background: var(--surface2);
@@ -766,29 +785,29 @@ input {
 .product-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(var(--card-min), 1fr));
-  gap: 16px;
+  gap: 12px;
 }
 
 .product-card {
   display: flex;
   flex-direction: column;
-  gap: 8px;
-  padding: 12px;
+  gap: 4px;
+  padding: 8px 10px 10px;
   text-align: left;
-  background: var(--surface);
-  border: 1px solid var(--border);
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
   border-radius: var(--radius-lg);
-  box-shadow: 0 4px 16px -2px color-mix(in srgb, var(--text) 3%, transparent),
-              0 2px 6px -1px color-mix(in srgb, var(--text) 1%, transparent);
+  box-shadow: 0 4px 12px -2px color-mix(in srgb, var(--text) 3%, transparent);
   transition: transform 0.25s cubic-bezier(0.34, 1.56, 0.64, 1),
               border-color 0.2s ease,
               box-shadow 0.2s ease;
 }
 .product-card:hover:not(:disabled) {
   border-color: var(--primary);
-  transform: translateY(-4px);
-  box-shadow: 0 12px 28px -4px color-mix(in srgb, var(--primary) 10%, transparent),
-              0 4px 10px -2px color-mix(in srgb, var(--primary) 5%, transparent);
+  transform: translateY(-3px);
+  box-shadow: 0 10px 24px -4px color-mix(in srgb, var(--primary) 10%, transparent);
 }
 .product-card:active:not(:disabled) {
   transform: translateY(-1px);
@@ -803,16 +822,16 @@ input {
 /* Product Card Image container */
 .product-card__image-container {
   width: 100%;
-  height: 120px;
-  border-radius: 12px;
+  height: 96px;
+  border-radius: 8px;
   overflow: hidden;
   position: relative;
-  background: #ffffff;
+  background: var(--surface2);
   border: 1px solid var(--border);
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 8px;
+  padding: 4px;
   transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
 .product-card:hover:not(:disabled) .product-card__image-container {
@@ -834,11 +853,11 @@ input {
   display: flex;
   align-items: center;
   justify-content: center;
-  background: #f8fafc;
-  border-radius: 8px;
+  background: var(--surface2);
+  border-radius: 6px;
 }
 .product-card__placeholder-icon {
-  font-size: 36px;
+  font-size: 28px;
   filter: drop-shadow(0 4px 8px color-mix(in srgb, var(--primary) 12%, transparent));
   transition: transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
 }
@@ -849,57 +868,57 @@ input {
 .product-card__content {
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: 1px;
 }
 .product-card__name {
   font-weight: 700;
-  font-size: 14.5px;
-  line-height: 1.35;
+  font-size: 13px;
+  line-height: 1.25;
   color: var(--text);
   display: -webkit-box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
   overflow: hidden;
-  height: 38px;
+  height: 32px;
 }
 .product-card__meta {
-  font-size: 11.5px;
+  font-size: 11px;
   color: var(--subtext);
   font-weight: 600;
 }
 .product-card__prices {
   display: flex;
   flex-direction: column;
-  gap: 2px;
-  margin-top: 2px;
+  gap: 1px;
+  margin-top: 1px;
 }
 .product-card__price {
   font-weight: 800;
-  font-size: 15.5px;
+  font-size: 14px;
   color: var(--text);
 }
 .product-card__price-tier {
   color: var(--subtext);
   font-weight: 600;
-  font-size: 11px;
+  font-size: 10.5px;
   letter-spacing: 0.02em;
 }
 .product-card__wholesale {
-  font-size: 11.5px;
+  font-size: 11px;
   color: var(--subtext);
   font-weight: 600;
 }
 .product-card__stock {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
-  font-size: 12px;
+  gap: 4px;
+  font-size: 11px;
   font-weight: 700;
   margin-top: auto;
 }
 .stock-dot {
-  width: 8px;
-  height: 8px;
+  width: 6px;
+  height: 6px;
   border-radius: 50%;
   background: var(--success);
 }
@@ -974,15 +993,15 @@ input {
 @media (min-width: 900px) {
   .pos-layout {
     display: grid;
-    grid-template-columns: minmax(0, 1fr) 380px;
-    gap: 24px;
+    grid-template-columns: minmax(0, 1fr) 340px;
+    gap: 16px;
     align-items: start;
   }
   /* Cart stays permanently visible and sticky on desktop */
   .pos-layout__cart {
     display: block;
     position: sticky;
-    top: 96px;
+    top: 74px;
     z-index: 30;
   }
   .cart-bar,
@@ -993,8 +1012,8 @@ input {
 
 @media (min-width: 1536px) {
   .pos-layout {
-    grid-template-columns: minmax(0, 1fr) 420px;
-    gap: 32px;
+    grid-template-columns: minmax(0, 1fr) 370px;
+    gap: 20px;
   }
 }
 
@@ -1003,65 +1022,67 @@ input {
 .cart {
   display: flex;
   flex-direction: column;
-  background: var(--surface);
-  border: 1px solid var(--border);
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
   border-radius: var(--radius-lg);
   overflow: hidden;
-  box-shadow: 0 8px 30px -4px color-mix(in srgb, var(--text) 4%, transparent);
+  box-shadow: 0 8px 24px -4px color-mix(in srgb, var(--text) 4%, transparent);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
 }
 .cart__head {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 18px 20px;
-  border-bottom: 1px solid var(--border);
+  padding: 12px 14px;
+  border-bottom: 1px solid var(--glass-border);
 }
 .cart__title {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: 8px;
   margin: 0;
-  font-size: 18px;
+  font-size: 15px;
   font-weight: 800;
   letter-spacing: -0.01em;
 }
 .cart__count {
   display: inline-grid;
   place-items: center;
-  min-width: 24px;
-  height: 24px;
-  padding: 0 7px;
-  border-radius: 12px;
+  min-width: 20px;
+  height: 20px;
+  padding: 0 6px;
+  border-radius: 10px;
   background: linear-gradient(
     135deg,
     color-mix(in srgb, var(--primary) 80%, transparent) 0%,
     var(--primary) 100%
   );
   color: var(--on-primary);
-  font-size: 12px;
+  font-size: 11px;
   font-weight: 700;
 }
 .cart__head-actions {
   display: flex;
-  gap: 14px;
+  gap: 10px;
 }
 .cart__link {
   background: none;
   border: none;
   color: var(--subtext);
-  font-size: 13.5px;
+  font-size: 13px;
   font-weight: 700;
-  padding: 4px;
+  padding: 2px 4px;
   transition: color 0.15s ease;
 }
 .cart__link:hover {
   color: var(--primary);
 }
 .cart__empty {
-  padding: 40px 20px;
+  padding: 24px 14px;
   text-align: center;
   color: var(--subtext);
-  font-size: 14px;
+  font-size: 13px;
   font-weight: 600;
   display: flex;
   flex-direction: column;
@@ -1073,37 +1094,37 @@ input {
   align-items: center;
   justify-content: center;
   color: var(--subtext);
-  margin-bottom: 8px;
+  margin-bottom: 6px;
 }
 .cart__lines {
   list-style: none;
   margin: 0;
-  padding: 10px;
+  padding: 6px;
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 4px;
   overflow-y: auto;
-  max-height: min(48vh, 460px);
+  max-height: min(52vh, 480px);
 }
 .cart__line {
   display: grid;
   grid-template-columns: auto 1fr auto auto auto;
   align-items: center;
-  gap: 12px;
-  padding: 10px;
+  gap: 8px;
+  padding: 6px 8px;
   border-radius: var(--radius);
   transition: background 0.15s ease;
   border: 1px solid transparent;
 }
 .cart__line:hover {
   background: var(--surface2);
-  border-color: var(--border);
+  border-color: var(--glass-border);
 }
 .cart__line-thumbnail {
-  width: 42px;
-  height: 42px;
-  border-radius: 8px;
-  background: #ffffff;
+  width: 32px;
+  height: 32px;
+  border-radius: 6px;
+  background: var(--surface2);
   border: 1px solid var(--border);
   display: flex;
   align-items: center;
@@ -1115,10 +1136,10 @@ input {
   max-width: 100%;
   max-height: 100%;
   object-fit: contain;
-  padding: 2px;
+  padding: 1px;
 }
 .cart__line-placeholder {
-  font-size: 20px;
+  font-size: 16px;
   line-height: 1;
 }
 .cart__line-info {
@@ -1126,36 +1147,36 @@ input {
 }
 .cart__line-name {
   font-weight: 700;
-  font-size: 14px;
+  font-size: 13px;
   color: var(--text);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
 .cart__line-unit {
-  font-size: 11.5px;
+  font-size: 11px;
   color: var(--subtext);
   font-weight: 600;
 }
 .cart__stepper {
   display: inline-flex;
   align-items: center;
-  gap: 4px;
+  gap: 2px;
   background: var(--surface2);
-  border-radius: 12px;
-  padding: 3px;
+  border-radius: 8px;
+  padding: 2px;
 }
 .cart__step {
-  width: 28px;
-  height: 28px;
+  width: 22px;
+  height: 22px;
   border: none;
   background: var(--surface);
-  border-radius: 9px;
-  font-size: 16px;
+  border-radius: 6px;
+  font-size: 12px;
   font-weight: 700;
   color: var(--text);
   line-height: 1;
-  box-shadow: 0 1px 3px color-mix(in srgb, var(--text) 4%, transparent);
+  box-shadow: 0 1px 2px color-mix(in srgb, var(--text) 4%, transparent);
   transition: all 0.15s ease;
 }
 .cart__step:hover:not(:disabled) {
@@ -1167,11 +1188,11 @@ input {
   cursor: not-allowed;
 }
 .cart__qty {
-  width: 28px;
+  width: 20px;
   border: none;
   background: transparent;
   text-align: center;
-  font-size: 13.5px;
+  font-size: 12px;
   font-weight: 700;
   color: var(--text);
   -moz-appearance: textfield;
@@ -1184,20 +1205,20 @@ input {
 }
 .cart__line-total {
   font-weight: 800;
-  font-size: 14px;
+  font-size: 13px;
   color: var(--text);
   white-space: nowrap;
-  width: 70px;
+  width: 60px;
   text-align: right;
 }
 .cart__remove {
-  width: 28px;
-  height: 28px;
+  width: 22px;
+  height: 22px;
   border: none;
   background: none;
   color: var(--subtext);
-  font-size: 13px;
-  border-radius: 8px;
+  font-size: 11px;
+  border-radius: 6px;
   display: inline-grid;
   place-items: center;
   transition: all 0.15s ease;
@@ -1207,11 +1228,11 @@ input {
   color: var(--danger);
 }
 .cart__foot {
-  border-top: 1px solid var(--border);
-  padding: 16px 20px;
+  border-top: 1px solid var(--glass-border);
+  padding: 12px 14px;
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 8px;
   background: color-mix(in srgb, var(--surface2) 30%, transparent);
   margin-top: auto;
 }
@@ -1219,38 +1240,38 @@ input {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  font-size: 14px;
+  font-size: 13px;
   font-weight: 600;
 }
 .cart__row--muted {
   color: var(--subtext);
 }
 .cart__row--total {
-  font-size: 18px;
+  font-size: 16px;
   font-weight: 900;
-  border-top: 1px dashed var(--border);
-  padding-top: 10px;
+  border-top: 1px dashed var(--glass-border);
+  padding-top: 8px;
   color: var(--text);
 }
 .cart__discount {
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: 4px;
 }
 .cart__discount-label {
   display: flex;
   align-items: baseline;
   justify-content: space-between;
-  font-size: 12.5px;
+  font-size: 12px;
   font-weight: 700;
   color: var(--subtext);
 }
 .cart__discount-cap {
   font-weight: 600;
-  font-size: 11px;
+  font-size: 10.5px;
 }
 .cart__discount-note {
-  font-size: 11.5px;
+  font-size: 11px;
   color: var(--warning);
   font-weight: 600;
 }
@@ -1259,18 +1280,18 @@ input {
 .cart__action-buttons {
   display: grid;
   grid-template-columns: 1.4fr 1fr;
-  gap: 10px;
-  margin-top: 6px;
+  gap: 8px;
+  margin-top: 4px;
 }
 .cart__checkout-btn {
-  height: 48px;
+  height: 40px;
   width: 100%;
 }
 .cart__save-btn {
-  height: 48px;
+  height: 40px;
   width: 100%;
-  border-color: var(--border);
-  background: color-mix(in srgb, var(--surface2) 40%, transparent);
+  border-color: var(--glass-border);
+  background: var(--glass-bg);
 }
 .cart__save-btn:hover:not(:disabled) {
   background: var(--surface2);
@@ -1280,18 +1301,20 @@ input {
 .cart__customer-add {
   display: flex;
   align-items: center;
-  gap: 8px;
+  justify-content: center;
+  gap: 6px;
   width: 100%;
-  height: 40px;
-  border-radius: 10px;
-  border: 1px dashed var(--border);
-  background: color-mix(in srgb, var(--surface2) 40%, transparent);
+  height: 34px;
+  border-radius: 8px;
+  border: 1px dashed var(--glass-border);
+  background: var(--glass-bg);
   color: var(--subtext);
-  font-size: 13.5px;
+  font-size: 13px;
   font-weight: 700;
   padding: 0 12px;
   transition: all 0.2s ease;
   cursor: pointer;
+  backdrop-filter: blur(8px);
 }
 .cart__customer-add:hover {
   border-color: var(--primary);
@@ -1299,7 +1322,7 @@ input {
   background: color-mix(in srgb, var(--primary) 4%, transparent);
 }
 .cart__customer-add .plus-icon {
-  font-size: 16px;
+  font-size: 14px;
   font-weight: 600;
 }
 
@@ -1610,28 +1633,29 @@ input {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 10px;
-  padding: 12px 14px;
-  margin-bottom: 12px;
-  background: color-mix(in srgb, var(--surface2) 80%, transparent);
-  border: 1px solid var(--border);
+  gap: 8px;
+  padding: 8px 10px;
+  margin-bottom: 8px;
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
   border-radius: var(--radius);
+  backdrop-filter: blur(8px);
 }
 .cart__customer-info {
   display: flex;
   flex-direction: column;
-  gap: 3px;
+  gap: 2px;
   min-width: 0;
 }
 .cart__customer-name {
   font-weight: 700;
-  font-size: 14px;
+  font-size: 13.5px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 .cart__customer-balance {
-  font-size: 12.5px;
+  font-size: 12px;
   font-weight: 700;
 }
 .cart__customer-balance--credit,
@@ -1646,24 +1670,8 @@ input {
 }
 .cart__customer-actions {
   display: flex;
-  gap: 8px;
+  gap: 6px;
   flex-shrink: 0;
-}
-.cart__customer-add {
-  width: 100%;
-  border: 1.5px dashed var(--border);
-  background: color-mix(in srgb, var(--surface) 60%, transparent);
-  color: var(--primary);
-  font-weight: 700;
-  font-size: 14px;
-  padding: 12px 14px;
-  border-radius: var(--radius);
-  transition: all 0.2s ease;
-  backdrop-filter: blur(8px);
-}
-.cart__customer-add:hover {
-  background: var(--surface2);
-  border-color: var(--primary);
 }
 
 .customer-list {

--- a/web-pos/src/app/globals.css
+++ b/web-pos/src/app/globals.css
@@ -285,201 +285,410 @@ input {
 /* ── App shell ────────────────────────────────────────────────────────────── */
 
 .shell {
-  display: flex;
-  flex-direction: column;
-  min-height: 100dvh;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  grid-template-rows: auto 1fr;
+  grid-template-areas:
+    "sidebar header"
+    "sidebar main";
+  height: 100vh;
+  width: 100vw;
+  overflow: hidden;
+  position: relative;
+  background: var(--bg);
+}
+
+/* Background mesh glows */
+.shell::before {
+  content: '';
+  position: absolute;
+  top: 5%;
+  left: 15%;
+  width: 45vw;
+  height: 45vw;
+  max-width: 500px;
+  max-height: 500px;
+  background: radial-gradient(
+    circle,
+    color-mix(in srgb, var(--primary) 7%, transparent) 0%,
+    color-mix(in srgb, var(--secondary) 3%, transparent) 50%,
+    transparent 80%
+  );
+  filter: blur(80px);
+  pointer-events: none;
+  z-index: 0;
+}
+.shell::after {
+  content: '';
+  position: absolute;
+  bottom: 10%;
+  right: 5%;
+  width: 50vw;
+  height: 50vw;
+  max-width: 600px;
+  max-height: 600px;
+  background: radial-gradient(
+    circle,
+    color-mix(in srgb, var(--secondary) 6%, transparent) 0%,
+    color-mix(in srgb, var(--primary) 2%, transparent) 60%,
+    transparent 90%
+  );
+  filter: blur(100px);
+  pointer-events: none;
+  z-index: 0;
 }
 
 .shell__topbar {
+  grid-area: header;
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 16px;
-  padding: 14px 24px;
-  /* Glassmorphic header */
-  background: color-mix(in srgb, var(--surface) 80%, transparent);
+  padding: 12px 24px;
+  height: 76px;
+  background: color-mix(in srgb, var(--bg) 60%, transparent);
   backdrop-filter: blur(16px);
   -webkit-backdrop-filter: blur(16px);
   border-bottom: 1px solid var(--border);
-  position: sticky;
-  top: 0;
   z-index: 45;
-  box-shadow: 0 2px 10px -4px color-mix(in srgb, var(--text) 5%, transparent);
+  box-shadow: 0 4px 20px -8px color-mix(in srgb, var(--text) 8%, transparent);
 }
 
 .shell__brand {
   display: flex;
   align-items: center;
-  gap: 12px;
-  font-weight: 800;
-  font-size: 18px;
-  letter-spacing: -0.01em;
+  justify-content: center;
+  padding: 8px 0 24px;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 24px;
 }
-.shell__brand-dot {
-  width: 24px;
-  height: 24px;
-  border-radius: 8px;
-  background: linear-gradient(
-    135deg,
-    color-mix(in srgb, var(--primary) 80%, transparent) 0%,
-    var(--primary) 100%
-  );
-  box-shadow: 0 0 10px color-mix(in srgb, var(--primary) 30%, transparent);
-}
-.shell__brand-text {
-  background: linear-gradient(135deg, var(--text) 70%, var(--primary) 100%);
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-}
-.shell__business {
-  color: var(--subtext);
-  font-weight: 500;
-  font-size: 13px;
-}
-
-.shell__sidebar-toggle {
-  background: transparent;
-  border: none;
+.shell__brand-logo {
+  font-size: 26px;
+  font-weight: 900;
   color: var(--text);
-  font-size: 18px;
-  cursor: pointer;
+  letter-spacing: -0.05em;
   display: flex;
   align-items: center;
-  justify-content: center;
-  width: 38px;
-  height: 38px;
-  border-radius: 10px;
-  transition: all 0.2s ease;
-  border: 1px solid transparent;
+  gap: 2px;
 }
-.shell__sidebar-toggle:hover {
-  background: var(--surface2);
-  border-color: var(--border);
+.shell__brand-logo .plus-sign {
+  color: var(--primary);
+  font-size: 24px;
+  font-weight: 700;
 }
 
 .shell__actions-group {
   display: flex;
   align-items: center;
-  gap: 18px;
-}
-
-.shell__body {
-  display: flex;
-  flex: 1;
-  min-height: 0;
+  gap: 14px;
 }
 
 /* Glassmorphic Navigation Rail/Sidebar */
 .shell__nav {
-  display: none;
+  grid-area: sidebar;
+  display: flex;
   flex-direction: column;
-  gap: 6px;
-  padding: 16px 10px;
-  background: color-mix(in srgb, var(--surface) 70%, transparent);
-  backdrop-filter: blur(12px);
-  -webkit-backdrop-filter: blur(12px);
+  background: color-mix(in srgb, var(--surface) 85%, transparent);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
   border-right: 1px solid var(--border);
-  width: var(--rail-width);
+  width: var(--sidebar-width);
+  height: 100vh;
   flex-shrink: 0;
-  transition: width 0.3s cubic-bezier(0.4, 0, 0.2, 1),
-              padding 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  transition: width 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+  z-index: 50;
+  padding: 20px 14px;
+  position: relative;
+}
+
+.shell__nav-items {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  flex: 1;
 }
 
 .shell__nav-item {
   display: flex;
-  flex-direction: column;
   align-items: center;
-  justify-content: center;
-  gap: 6px;
-  padding: 12px 6px;
+  gap: 14px;
+  padding: 12px 16px;
   border-radius: 12px;
   color: var(--subtext);
-  font-size: 11px;
+  font-size: 14px;
   font-weight: 700;
   cursor: pointer;
-  transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
-  border: 1.5px solid transparent;
+  transition: all 0.2s ease;
+  border: 1px solid transparent;
+  background: transparent;
 }
 .shell__nav-item:hover {
-  background: color-mix(in srgb, var(--primary) 5%, transparent);
+  background: color-mix(in srgb, var(--primary) 6%, transparent);
   color: var(--primary);
 }
 .shell__nav-item--active {
-  background: color-mix(in srgb, var(--primary) 8%, transparent);
-  border-color: color-mix(in srgb, var(--primary) 12%, transparent);
+  background: color-mix(in srgb, var(--primary) 10%, transparent);
   color: var(--primary);
+  border-color: color-mix(in srgb, var(--primary) 15%, transparent);
+  box-shadow: 0 4px 12px -4px color-mix(in srgb, var(--primary) 20%, transparent);
 }
 .shell__nav-icon {
-  font-size: 22px;
-  line-height: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  flex-shrink: 0;
 }
 .shell__nav-label {
+  white-space: nowrap;
+  opacity: 1;
   transition: opacity 0.2s ease;
 }
 
+.shell__nav-footer {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  border-top: 1px solid var(--border);
+  padding-top: 16px;
+  margin-top: auto;
+}
+.shell__sidebar-toggle-btn {
+  align-self: center;
+  background: color-mix(in srgb, var(--surface2) 80%, transparent);
+  border: 1px solid var(--border);
+  color: var(--subtext);
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  font-size: 11px;
+  transition: all 0.2s ease;
+}
+.shell__sidebar-toggle-btn:hover {
+  border-color: var(--primary);
+  color: var(--primary);
+  background: var(--surface);
+}
+.shell__logout-btn {
+  width: 100%;
+}
+
 .shell__content {
-  flex: 1;
-  min-width: 0;
+  grid-area: main;
+  overflow-y: auto;
   padding: 24px;
+  position: relative;
+  z-index: 1;
 }
 .shell__content-inner {
   max-width: var(--content-max);
   margin: 0 auto;
 }
 
-.shell__account {
+/* User Profile Chip */
+.shell__account-profile {
   display: flex;
   align-items: center;
-  gap: 16px;
+  gap: 12px;
+  padding: 4px 12px 4px 4px;
+  border-radius: 30px;
+  background: color-mix(in srgb, var(--surface2) 50%, transparent);
+  border: 1px solid var(--border);
+}
+.shell__avatar-container {
+  position: relative;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+.shell__avatar-placeholder {
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  background: linear-gradient(135deg, var(--primary) 0%, var(--secondary) 100%);
+  color: #ffffff;
+  font-weight: 800;
+  font-size: 13px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.shell__avatar-status {
+  position: absolute;
+  bottom: -1px;
+  right: -1px;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--success);
+  border: 2px solid var(--surface);
+}
+.shell__account-info {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
 }
 .shell__account-name {
+  font-size: 13px;
   font-weight: 700;
-  font-size: 14px;
+  color: var(--text);
 }
 .shell__account-role {
+  font-size: 10.5px;
+  font-weight: 700;
   color: var(--subtext);
-  font-size: 12px;
+}
+
+/* Header Action Buttons */
+.shell__view-btn,
+.shell__signout-btn {
+  height: 40px;
+  border-radius: 12px;
+  padding: 0 16px;
+  font-size: 14px;
+  font-weight: 700;
+  border-color: var(--border);
+}
+.dropdown-arrow {
+  font-size: 8px;
+  margin-left: 6px;
+  opacity: 0.7;
+}
+
+/* Search Bar inside Header */
+.search-bar {
+  position: relative;
+  display: flex;
+  align-items: center;
+  background: color-mix(in srgb, var(--surface2) 80%, transparent);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 0 12px;
+  width: 240px;
+  height: 40px;
+  transition: all 0.2s ease;
+}
+.search-bar:focus-within {
+  border-color: var(--primary);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--primary) 15%, transparent);
+  background: var(--surface);
+}
+.search-bar__icon {
+  color: var(--subtext);
+  margin-right: 8px;
+  flex-shrink: 0;
+}
+.search-bar__input {
+  background: transparent;
+  border: none;
+  color: var(--text);
+  font-size: 14px;
   font-weight: 600;
+  width: 100%;
+  height: 100%;
+  outline: none;
+}
+.search-bar__input::placeholder {
+  color: var(--subtext);
+  opacity: 0.7;
 }
 
-/* Tablet: show the left rail */
-@media (min-width: 640px) {
-  .shell__nav {
-    display: flex;
-  }
+/* Theme Dropdown Toggle */
+.theme-dropdown__icon-toggle {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  border: 1px solid var(--border);
+  background: color-mix(in srgb, var(--surface2) 80%, transparent);
+  color: var(--text);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+.theme-dropdown__icon-toggle:hover {
+  border-color: var(--primary);
+  color: var(--primary);
+  background: var(--surface);
+}
+.theme-dropdown__menu {
+  top: calc(100% + 8px);
+  right: 0;
+  width: 130px;
+}
+.theme-dropdown__item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  padding: 8px 12px;
+}
+.theme-dropdown__item-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  opacity: 0.8;
 }
 
-/* Desktop: wider sidebar with labels beside icons */
-@media (min-width: 1024px) {
-  :root {
-    --card-min: 170px;
+/* Collapsed Navigation rail modifiers */
+.shell__nav--collapsed {
+  width: var(--rail-width);
+  padding: 20px 8px;
+}
+.shell__nav--collapsed .shell__brand {
+  padding-bottom: 20px;
+}
+.shell__nav--collapsed .shell__nav-item {
+  flex-direction: column;
+  justify-content: center;
+  gap: 4px;
+  padding: 10px 4px;
+  font-size: 10px;
+  text-align: center;
+}
+.shell__nav--collapsed .shell__nav-icon {
+  width: 20px;
+  height: 20px;
+}
+.shell__nav--collapsed .shell__nav-label {
+  font-size: 9.5px;
+  opacity: 0.9;
+}
+.shell__nav--collapsed .shell__logout-btn {
+  padding: 10px 4px;
+}
+
+/* Responsive bands for the new grid shell */
+@media (max-width: 768px) {
+  .shell {
+    grid-template-columns: 1fr;
+    grid-template-areas:
+      "header"
+      "main";
   }
   .shell__nav {
-    width: var(--sidebar-width);
-    padding: 20px 14px;
+    position: fixed;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    height: 100vh;
+    transform: translateX(-100%);
+    transition: transform 0.25s ease;
   }
-  .shell__nav-item {
-    flex-direction: row;
-    justify-content: flex-start;
-    gap: 14px;
-    padding: 14px 18px;
-    font-size: 14px;
+  .shell__nav--open {
+    transform: translateX(0);
   }
-
-  /* Collapsed sidebar modifier */
-  .shell__nav--collapsed {
-    width: var(--rail-width);
-    padding: 16px 8px;
-  }
-  .shell__nav--collapsed .shell__nav-item {
-    flex-direction: column;
-    justify-content: center;
-    gap: 4px;
-    padding: 12px 4px;
-    font-size: 11px;
-  }
-  .shell__nav--collapsed .shell__nav-item .shell__nav-label {
-    display: none;
+  .search-bar {
+    display: none; /* Hide in compact topbar */
   }
 }
 
@@ -594,28 +803,30 @@ input {
 /* Product Card Image container */
 .product-card__image-container {
   width: 100%;
-  height: 110px;
-  border-radius: calc(var(--radius-lg) - 6px);
+  height: 120px;
+  border-radius: 12px;
   overflow: hidden;
   position: relative;
-  background: color-mix(in srgb, var(--surface2) 80%, transparent);
+  background: #ffffff;
   border: 1px solid var(--border);
   display: flex;
   align-items: center;
   justify-content: center;
-  transition: border-color 0.2s ease;
+  padding: 8px;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
 .product-card:hover:not(:disabled) .product-card__image-container {
   border-color: color-mix(in srgb, var(--primary) 30%, transparent);
+  box-shadow: 0 4px 12px color-mix(in srgb, var(--primary) 5%, transparent);
 }
 .product-card__image {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
+  max-width: 100%;
+  max-height: 100%;
+  object-fit: contain;
   transition: transform 0.3s ease;
 }
 .product-card:hover:not(:disabled) .product-card__image {
-  transform: scale(1.05);
+  transform: scale(1.06);
 }
 .product-card__placeholder {
   width: 100%;
@@ -623,15 +834,12 @@ input {
   display: flex;
   align-items: center;
   justify-content: center;
-  background: linear-gradient(
-    135deg,
-    color-mix(in srgb, var(--primary) 8%, transparent) 0%,
-    color-mix(in srgb, var(--primary) 2%, transparent) 100%
-  );
+  background: #f8fafc;
+  border-radius: 8px;
 }
 .product-card__placeholder-icon {
   font-size: 36px;
-  filter: drop-shadow(0 4px 8px color-mix(in srgb, var(--primary) 15%, transparent));
+  filter: drop-shadow(0 4px 8px color-mix(in srgb, var(--primary) 12%, transparent));
   transition: transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
 }
 .product-card:hover:not(:disabled) .product-card__placeholder-icon {
@@ -850,11 +1058,22 @@ input {
   color: var(--primary);
 }
 .cart__empty {
-  padding: 56px 20px;
+  padding: 40px 20px;
   text-align: center;
   color: var(--subtext);
-  font-size: 14.5px;
-  font-weight: 500;
+  font-size: 14px;
+  font-weight: 600;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+.cart__empty-illustration {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--subtext);
+  margin-bottom: 8px;
 }
 .cart__lines {
   list-style: none;
@@ -862,21 +1081,45 @@ input {
   padding: 10px;
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: 8px;
   overflow-y: auto;
-  max-height: min(52vh, 500px);
+  max-height: min(48vh, 460px);
 }
 .cart__line {
   display: grid;
-  grid-template-columns: 1fr auto auto auto;
+  grid-template-columns: auto 1fr auto auto auto;
   align-items: center;
   gap: 12px;
-  padding: 10px 12px;
+  padding: 10px;
   border-radius: var(--radius);
   transition: background 0.15s ease;
+  border: 1px solid transparent;
 }
 .cart__line:hover {
   background: var(--surface2);
+  border-color: var(--border);
+}
+.cart__line-thumbnail {
+  width: 42px;
+  height: 42px;
+  border-radius: 8px;
+  background: #ffffff;
+  border: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  flex-shrink: 0;
+}
+.cart__line-image {
+  max-width: 100%;
+  max-height: 100%;
+  object-fit: contain;
+  padding: 2px;
+}
+.cart__line-placeholder {
+  font-size: 20px;
+  line-height: 1;
 }
 .cart__line-info {
   min-width: 0;
@@ -890,9 +1133,9 @@ input {
   text-overflow: ellipsis;
 }
 .cart__line-unit {
-  font-size: 12px;
+  font-size: 11.5px;
   color: var(--subtext);
-  font-weight: 500;
+  font-weight: 600;
 }
 .cart__stepper {
   display: inline-flex;
@@ -903,12 +1146,12 @@ input {
   padding: 3px;
 }
 .cart__step {
-  width: 32px;
-  height: 32px;
+  width: 28px;
+  height: 28px;
   border: none;
   background: var(--surface);
   border-radius: 9px;
-  font-size: 18px;
+  font-size: 16px;
   font-weight: 700;
   color: var(--text);
   line-height: 1;
@@ -924,11 +1167,11 @@ input {
   cursor: not-allowed;
 }
 .cart__qty {
-  width: 36px;
+  width: 28px;
   border: none;
   background: transparent;
   text-align: center;
-  font-size: 14.5px;
+  font-size: 13.5px;
   font-weight: 700;
   color: var(--text);
   -moz-appearance: textfield;
@@ -941,9 +1184,11 @@ input {
 }
 .cart__line-total {
   font-weight: 800;
-  font-size: 14.5px;
+  font-size: 14px;
   color: var(--text);
   white-space: nowrap;
+  width: 70px;
+  text-align: right;
 }
 .cart__remove {
   width: 28px;
@@ -963,25 +1208,26 @@ input {
 }
 .cart__foot {
   border-top: 1px solid var(--border);
-  padding: 18px 20px;
+  padding: 16px 20px;
   display: flex;
   flex-direction: column;
   gap: 12px;
   background: color-mix(in srgb, var(--surface2) 30%, transparent);
+  margin-top: auto;
 }
 .cart__row {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  font-size: 14.5px;
+  font-size: 14px;
   font-weight: 600;
 }
 .cart__row--muted {
   color: var(--subtext);
 }
 .cart__row--total {
-  font-size: 20px;
-  font-weight: 800;
+  font-size: 18px;
+  font-weight: 900;
   border-top: 1px dashed var(--border);
   padding-top: 10px;
   color: var(--text);
@@ -989,13 +1235,13 @@ input {
 .cart__discount {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 6px;
 }
 .cart__discount-label {
   display: flex;
   align-items: baseline;
   justify-content: space-between;
-  font-size: 13px;
+  font-size: 12.5px;
   font-weight: 700;
   color: var(--subtext);
 }
@@ -1004,12 +1250,57 @@ input {
   font-size: 11px;
 }
 .cart__discount-note {
-  font-size: 12px;
+  font-size: 11.5px;
   color: var(--warning);
   font-weight: 600;
 }
-.cart__checkout {
+
+/* Side-by-side Cart Checkout/Save buttons */
+.cart__action-buttons {
+  display: grid;
+  grid-template-columns: 1.4fr 1fr;
+  gap: 10px;
   margin-top: 6px;
+}
+.cart__checkout-btn {
+  height: 48px;
+  width: 100%;
+}
+.cart__save-btn {
+  height: 48px;
+  width: 100%;
+  border-color: var(--border);
+  background: color-mix(in srgb, var(--surface2) 40%, transparent);
+}
+.cart__save-btn:hover:not(:disabled) {
+  background: var(--surface2);
+  border-color: var(--text);
+}
+
+.cart__customer-add {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  height: 40px;
+  border-radius: 10px;
+  border: 1px dashed var(--border);
+  background: color-mix(in srgb, var(--surface2) 40%, transparent);
+  color: var(--subtext);
+  font-size: 13.5px;
+  font-weight: 700;
+  padding: 0 12px;
+  transition: all 0.2s ease;
+  cursor: pointer;
+}
+.cart__customer-add:hover {
+  border-color: var(--primary);
+  color: var(--primary);
+  background: color-mix(in srgb, var(--primary) 4%, transparent);
+}
+.cart__customer-add .plus-icon {
+  font-size: 16px;
+  font-weight: 600;
 }
 
 /* Mobile cart trigger bar */

--- a/web-pos/src/app/globals.css
+++ b/web-pos/src/app/globals.css
@@ -1,11 +1,8 @@
 /*
  * Web POS global styles.
  *
- * Colour tokens are CSS custom properties applied at :root. The values below are
- * the blue/light defaults so first paint is styled before ThemeProvider runs;
- * ThemeProvider then overwrites them with the business's palette (light or dark)
- * live. Every component reads var(--token) — never a hard-coded colour — so a
- * palette switch re-paints the whole app.
+ * Colour tokens are CSS custom properties applied at :root. Every component reads
+ * var(--token) — never a hard-coded colour.
  *
  * Responsive bands (PRD "four breakpoint bands"):
  *   phone   < 640px   — single touch column
@@ -15,6 +12,7 @@
  */
 
 :root {
+  /* Default baseline tokens (overwritten dynamically by ThemeProvider) */
   --bg: #f8fafc;
   --surface: #ffffff;
   --surface2: #f1f5f9;
@@ -30,24 +28,40 @@
   --warning: #ffb020;
   --info: #3b82f6;
 
+  /* Layout and shapes spacing */
   --radius: 14px;
   --radius-lg: 20px;
   --rail-width: 76px;
   --sidebar-width: 240px;
   --content-max: 1600px;
   --card-min: 150px;
-  --font-sans: system-ui, -apple-system, 'Segoe UI', Roboto, 'Helvetica Neue',
-    Arial, sans-serif;
+  --font-sans: var(--font-sans), system-ui, -apple-system, sans-serif;
 }
 
+/* Global browser defaults */
 * {
   box-sizing: border-box;
+  scrollbar-width: thin;
+  scrollbar-color: color-mix(in srgb, var(--text) 15%, transparent) transparent;
+}
+
+*::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+*::-webkit-scrollbar-track {
+  background: transparent;
+}
+*::-webkit-scrollbar-thumb {
+  background-color: color-mix(in srgb, var(--text) 15%, transparent);
+  border-radius: 10px;
 }
 
 html,
 body {
   margin: 0;
   padding: 0;
+  accent-color: var(--primary);
 }
 
 body {
@@ -55,7 +69,16 @@ body {
   color: var(--text);
   font-family: var(--font-sans);
   -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
   min-height: 100dvh;
+  /* Replicate mobile's glassyBackground signature top-left to bottom-right blend */
+  background-image: linear-gradient(
+    135deg,
+    var(--bg) 0%,
+    color-mix(in srgb, var(--primary) 5%, var(--bg)) 50%,
+    color-mix(in srgb, var(--primary) 12%, var(--bg)) 100%
+  );
+  background-attachment: fixed;
 }
 
 a {
@@ -68,6 +91,30 @@ button {
   cursor: pointer;
 }
 
+input {
+  accent-color: var(--primary);
+}
+
+/* ── Signature Gradients ────────────────────────────────────────────────── */
+
+.primary-gradient {
+  background: linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--primary) 80%, transparent) 0%,
+    var(--primary) 100%
+  );
+}
+
+.glow-line {
+  height: 2px;
+  background: linear-gradient(
+    90deg,
+    transparent 0%,
+    var(--primary) 50%,
+    transparent 100%
+  );
+}
+
 /* ── Buttons ──────────────────────────────────────────────────────────────── */
 
 .btn {
@@ -76,29 +123,43 @@ button {
   justify-content: center;
   gap: 8px;
   min-height: 48px;
-  padding: 0 20px;
+  padding: 0 24px;
   border: none;
-  border-radius: 12px;
+  border-radius: var(--radius);
   font-size: 15px;
   font-weight: 600;
-  transition: background 0.15s ease, opacity 0.15s ease;
+  transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+  box-shadow: 0 2px 4px color-mix(in srgb, var(--text) 5%, transparent);
 }
 
 .btn--primary {
-  background: var(--primary);
+  background: linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--primary) 85%, transparent) 0%,
+    var(--primary) 100%
+  );
   color: var(--on-primary);
+  box-shadow: 0 4px 12px color-mix(in srgb, var(--primary) 25%, transparent);
 }
 .btn--primary:hover:not(:disabled) {
   background: var(--primary-hover);
+  transform: translateY(-1px);
+  box-shadow: 0 6px 16px color-mix(in srgb, var(--primary) 35%, transparent);
 }
+.btn--primary:active:not(:disabled) {
+  transform: translateY(1px);
+}
+
 .btn--outline {
-  background: transparent;
+  background: color-mix(in srgb, var(--surface) 60%, transparent);
   color: var(--text);
   border: 1.5px solid var(--border);
+  backdrop-filter: blur(8px);
 }
 .btn--outline:hover:not(:disabled) {
   border-color: var(--primary);
   color: var(--primary);
+  background: color-mix(in srgb, var(--primary) 5%, transparent);
 }
 .btn--block {
   width: 100%;
@@ -106,6 +167,8 @@ button {
 .btn:disabled {
   opacity: 0.55;
   cursor: not-allowed;
+  transform: none !important;
+  box-shadow: none !important;
 }
 
 /* ── Inputs ───────────────────────────────────────────────────────────────── */
@@ -113,27 +176,30 @@ button {
 .field {
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: 8px;
 }
 .field__label {
   font-size: 13px;
   font-weight: 600;
   color: var(--subtext);
+  letter-spacing: 0.03em;
 }
 .input {
   width: 100%;
   min-height: 48px;
-  padding: 0 16px;
-  background: var(--surface2);
-  border: 1.5px solid transparent;
+  padding: 0 18px;
+  background: color-mix(in srgb, var(--surface2) 80%, transparent);
+  border: 1.5px solid var(--border);
   border-radius: var(--radius);
   color: var(--text);
   font-size: 15px;
+  transition: all 0.2s ease;
 }
 .input:focus {
   outline: none;
   border-color: var(--primary);
   background: var(--surface);
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--primary) 12%, transparent);
 }
 
 /* ── Card ─────────────────────────────────────────────────────────────────── */
@@ -142,6 +208,78 @@ button {
   background: var(--surface);
   border: 1px solid var(--border);
   border-radius: var(--radius-lg);
+  box-shadow: 0 4px 20px -2px color-mix(in srgb, var(--text) 4%, transparent),
+              0 2px 8px -1px color-mix(in srgb, var(--text) 2%, transparent);
+}
+
+/* ── Theme Dropdown ───────────────────────────────────────────────────────── */
+
+.theme-dropdown {
+  position: relative;
+  display: inline-block;
+}
+.theme-dropdown__toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  background: color-mix(in srgb, var(--surface2) 85%, transparent);
+  color: var(--text);
+  border: 1px solid var(--border);
+  padding: 8px 16px;
+  min-height: 42px;
+  border-radius: 12px;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  transition: all 0.2s ease;
+}
+.theme-dropdown__toggle:hover {
+  background: var(--surface2);
+  border-color: var(--primary);
+}
+.theme-dropdown__arrow {
+  font-size: 8px;
+  color: var(--subtext);
+}
+.theme-dropdown__menu {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  z-index: 60;
+  width: 140px;
+  background: color-mix(in srgb, var(--surface) 85%, transparent);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  box-shadow: 0 10px 25px -5px color-mix(in srgb, var(--text) 12%, transparent),
+              0 8px 10px -6px color-mix(in srgb, var(--text) 8%, transparent);
+  padding: 6px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.theme-dropdown__item {
+  background: transparent;
+  border: none;
+  text-align: left;
+  padding: 8px 12px;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text);
+  border-radius: 8px;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+.theme-dropdown__item:hover {
+  background: color-mix(in srgb, var(--primary) 8%, transparent);
+  color: var(--primary);
+}
+.theme-dropdown__item--active {
+  background: color-mix(in srgb, var(--primary) 12%, transparent);
+  color: var(--primary);
 }
 
 /* ── App shell ────────────────────────────────────────────────────────────── */
@@ -156,32 +294,73 @@ button {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 12px;
-  padding: 12px 16px;
-  background: var(--surface);
+  gap: 16px;
+  padding: 14px 24px;
+  /* Glassmorphic header */
+  background: color-mix(in srgb, var(--surface) 80%, transparent);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
   border-bottom: 1px solid var(--border);
   position: sticky;
   top: 0;
-  z-index: 10;
+  z-index: 45;
+  box-shadow: 0 2px 10px -4px color-mix(in srgb, var(--text) 5%, transparent);
 }
 
 .shell__brand {
   display: flex;
   align-items: center;
-  gap: 10px;
-  font-weight: 700;
-  font-size: 16px;
+  gap: 12px;
+  font-weight: 800;
+  font-size: 18px;
+  letter-spacing: -0.01em;
 }
 .shell__brand-dot {
-  width: 26px;
-  height: 26px;
+  width: 24px;
+  height: 24px;
   border-radius: 8px;
-  background: var(--primary);
+  background: linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--primary) 80%, transparent) 0%,
+    var(--primary) 100%
+  );
+  box-shadow: 0 0 10px color-mix(in srgb, var(--primary) 30%, transparent);
+}
+.shell__brand-text {
+  background: linear-gradient(135deg, var(--text) 70%, var(--primary) 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
 }
 .shell__business {
   color: var(--subtext);
   font-weight: 500;
   font-size: 13px;
+}
+
+.shell__sidebar-toggle {
+  background: transparent;
+  border: none;
+  color: var(--text);
+  font-size: 18px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 38px;
+  height: 38px;
+  border-radius: 10px;
+  transition: all 0.2s ease;
+  border: 1px solid transparent;
+}
+.shell__sidebar-toggle:hover {
+  background: var(--surface2);
+  border-color: var(--border);
+}
+
+.shell__actions-group {
+  display: flex;
+  align-items: center;
+  gap: 18px;
 }
 
 .shell__body {
@@ -190,40 +369,58 @@ button {
   min-height: 0;
 }
 
+/* Glassmorphic Navigation Rail/Sidebar */
 .shell__nav {
   display: none;
   flex-direction: column;
-  gap: 4px;
-  padding: 12px 8px;
-  background: var(--surface);
+  gap: 6px;
+  padding: 16px 10px;
+  background: color-mix(in srgb, var(--surface) 70%, transparent);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
   border-right: 1px solid var(--border);
   width: var(--rail-width);
   flex-shrink: 0;
+  transition: width 0.3s cubic-bezier(0.4, 0, 0.2, 1),
+              padding 0.3s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 .shell__nav-item {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 4px;
-  padding: 12px 4px;
+  justify-content: center;
+  gap: 6px;
+  padding: 12px 6px;
   border-radius: 12px;
   color: var(--subtext);
   font-size: 11px;
-  font-weight: 600;
+  font-weight: 700;
+  cursor: pointer;
+  transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+  border: 1.5px solid transparent;
+}
+.shell__nav-item:hover {
+  background: color-mix(in srgb, var(--primary) 5%, transparent);
+  color: var(--primary);
 }
 .shell__nav-item--active {
-  background: var(--surface2);
+  background: color-mix(in srgb, var(--primary) 8%, transparent);
+  border-color: color-mix(in srgb, var(--primary) 12%, transparent);
   color: var(--primary);
 }
 .shell__nav-icon {
-  font-size: 20px;
+  font-size: 22px;
+  line-height: 1;
+}
+.shell__nav-label {
+  transition: opacity 0.2s ease;
 }
 
 .shell__content {
   flex: 1;
   min-width: 0;
-  padding: 16px;
+  padding: 24px;
 }
 .shell__content-inner {
   max-width: var(--content-max);
@@ -233,61 +430,75 @@ button {
 .shell__account {
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: 16px;
 }
 .shell__account-name {
-  font-weight: 600;
+  font-weight: 700;
   font-size: 14px;
 }
 .shell__account-role {
   color: var(--subtext);
   font-size: 12px;
+  font-weight: 600;
 }
 
-/* tablet and up: show the left rail */
+/* Tablet: show the left rail */
 @media (min-width: 640px) {
   .shell__nav {
     display: flex;
   }
-  .shell__content {
-    padding: 24px;
-  }
 }
 
-/* desktop: wider sidebar with labels beside icons */
+/* Desktop: wider sidebar with labels beside icons */
 @media (min-width: 1024px) {
   :root {
     --card-min: 170px;
   }
   .shell__nav {
     width: var(--sidebar-width);
-    padding: 16px 12px;
+    padding: 20px 14px;
   }
   .shell__nav-item {
     flex-direction: row;
     justify-content: flex-start;
-    gap: 12px;
-    padding: 12px 16px;
+    gap: 14px;
+    padding: 14px 18px;
     font-size: 14px;
   }
-  .shell__content {
-    padding: 32px;
+
+  /* Collapsed sidebar modifier */
+  .shell__nav--collapsed {
+    width: var(--rail-width);
+    padding: 16px 8px;
+  }
+  .shell__nav--collapsed .shell__nav-item {
+    flex-direction: column;
+    justify-content: center;
+    gap: 4px;
+    padding: 12px 4px;
+    font-size: 11px;
+  }
+  .shell__nav--collapsed .shell__nav-item .shell__nav-label {
+    display: none;
   }
 }
 
-/* large/wide: denser product grid, content stays max-width and centred */
+/* Large/Wide screen refinements */
 @media (min-width: 1536px) {
   :root {
-    --card-min: 150px;
+    --card-min: 160px;
+  }
+  .shell__content {
+    padding: 36px;
   }
 }
 
-/* ── POS grid ─────────────────────────────────────────────────────────────── */
+/* ── POS Grid ─────────────────────────────────────────────────────────────── */
 
 .pos {
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: 24px;
 }
 
 .pos__header {
@@ -295,73 +506,105 @@ button {
   flex-wrap: wrap;
   align-items: center;
   justify-content: space-between;
-  gap: 12px;
+  gap: 16px;
 }
 .pos__title {
-  font-size: 20px;
-  font-weight: 700;
+  font-size: 24px;
+  font-weight: 800;
   margin: 0;
+  letter-spacing: -0.02em;
 }
 
 .category-bar {
   display: flex;
-  gap: 8px;
+  gap: 10px;
   overflow-x: auto;
-  padding-bottom: 4px;
-  scrollbar-width: thin;
+  padding-bottom: 8px;
+  scrollbar-width: none;
+}
+.category-bar::-webkit-scrollbar {
+  display: none;
 }
 .chip {
   flex-shrink: 0;
-  padding: 8px 16px;
-  border-radius: 20px;
+  padding: 10px 20px;
+  border-radius: 24px;
   border: 1px solid var(--border);
-  background: var(--surface);
+  background: color-mix(in srgb, var(--surface) 70%, transparent);
+  backdrop-filter: blur(8px);
   color: var(--text);
-  font-size: 13px;
-  font-weight: 600;
+  font-size: 13.5px;
+  font-weight: 700;
   white-space: nowrap;
+  transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+  box-shadow: 0 1px 3px color-mix(in srgb, var(--text) 4%, transparent);
+}
+.chip:hover {
+  background: var(--surface2);
+  border-color: var(--primary);
 }
 .chip--active {
-  background: var(--primary);
-  color: var(--on-primary);
-  border-color: var(--primary);
+  background: linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--primary) 80%, transparent) 0%,
+    var(--primary) 100%
+  ) !important;
+  color: var(--on-primary) !important;
+  border-color: var(--primary) !important;
+  box-shadow: 0 4px 10px color-mix(in srgb, var(--primary) 20%, transparent);
 }
 
 .product-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(var(--card-min), 1fr));
-  gap: 12px;
+  gap: 16px;
 }
 
 .product-card {
   display: flex;
   flex-direction: column;
-  gap: 8px;
-  padding: 14px;
+  gap: 10px;
+  padding: 18px;
   text-align: left;
   background: var(--surface);
   border: 1px solid var(--border);
   border-radius: var(--radius-lg);
-  transition: border-color 0.15s ease, transform 0.05s ease;
+  box-shadow: 0 4px 16px -2px color-mix(in srgb, var(--text) 3%, transparent),
+              0 2px 6px -1px color-mix(in srgb, var(--text) 1%, transparent);
+  transition: transform 0.25s cubic-bezier(0.34, 1.56, 0.64, 1),
+              border-color 0.2s ease,
+              box-shadow 0.2s ease;
 }
 .product-card:hover:not(:disabled) {
   border-color: var(--primary);
+  transform: translateY(-4px);
+  box-shadow: 0 12px 28px -4px color-mix(in srgb, var(--primary) 10%, transparent),
+              0 4px 10px -2px color-mix(in srgb, var(--primary) 5%, transparent);
 }
 .product-card:active:not(:disabled) {
-  transform: scale(0.99);
+  transform: translateY(-1px);
 }
 .product-card:disabled {
   opacity: 0.55;
   cursor: not-allowed;
+  transform: none !important;
+  box-shadow: none !important;
 }
 .product-card__name {
-  font-weight: 600;
-  font-size: 14px;
-  line-height: 1.3;
+  font-weight: 700;
+  font-size: 15px;
+  line-height: 1.4;
+  color: var(--text);
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  height: 42px;
 }
 .product-card__meta {
   font-size: 12px;
   color: var(--subtext);
+  font-weight: 500;
 }
 .product-card__prices {
   display: flex;
@@ -370,24 +613,27 @@ button {
   margin-top: auto;
 }
 .product-card__price {
-  font-weight: 700;
-  font-size: 15px;
+  font-weight: 800;
+  font-size: 16px;
+  color: var(--text);
 }
 .product-card__price-tier {
   color: var(--subtext);
-  font-weight: 500;
-  font-size: 12px;
+  font-weight: 600;
+  font-size: 11px;
+  letter-spacing: 0.02em;
 }
 .product-card__wholesale {
   font-size: 12px;
   color: var(--subtext);
+  font-weight: 600;
 }
 .product-card__stock {
   display: inline-flex;
   align-items: center;
-  gap: 5px;
+  gap: 6px;
   font-size: 12px;
-  font-weight: 600;
+  font-weight: 700;
 }
 .stock-dot {
   width: 8px;
@@ -403,9 +649,10 @@ button {
 }
 .product-card__badge-out {
   color: var(--danger);
+  font-weight: 700;
 }
 
-/* ── Misc ─────────────────────────────────────────────────────────────────── */
+/* ── Misc & Utilities ─────────────────────────────────────────────────────── */
 
 .muted {
   color: var(--subtext);
@@ -417,12 +664,12 @@ button {
   padding: 24px;
 }
 .spinner {
-  width: 28px;
-  height: 28px;
+  width: 32px;
+  height: 32px;
   border-radius: 50%;
-  border: 3px solid var(--border);
+  border: 3.5px solid var(--border);
   border-top-color: var(--primary);
-  animation: spin 0.8s linear infinite;
+  animation: spin 0.8s cubic-bezier(0.68, -0.55, 0.27, 1.55) infinite;
 }
 @keyframes spin {
   to {
@@ -432,25 +679,29 @@ button {
 .empty-state {
   text-align: center;
   color: var(--subtext);
-  padding: 48px 16px;
+  padding: 64px 24px;
+  font-weight: 500;
 }
 .banner {
-  padding: 12px 16px;
+  padding: 14px 18px;
   border-radius: var(--radius);
-  font-size: 14px;
+  font-size: 14.5px;
+  font-weight: 600;
+  border: 1px solid transparent;
 }
 .banner--error {
-  background: color-mix(in srgb, var(--danger) 12%, transparent);
+  background: color-mix(in srgb, var(--danger) 10%, transparent);
   color: var(--danger);
+  border-color: color-mix(in srgb, var(--danger) 15%, transparent);
 }
 .banner--info {
-  background: var(--surface2);
+  background: color-mix(in srgb, var(--surface2) 80%, transparent);
   color: var(--subtext);
+  border-color: var(--border);
 }
 
-/* ── POS layout (grid beside cart) ────────────────────────────────────────── */
+/* ── POS Layout Grid (Desktop Sticky Cart) ─────────────────────────────────── */
 
-/* phone: single column; the cart is reached via the sticky bottom bar + sheet */
 .pos-layout {
   display: block;
 }
@@ -461,14 +712,16 @@ button {
 @media (min-width: 900px) {
   .pos-layout {
     display: grid;
-    grid-template-columns: minmax(0, 1fr) 360px;
-    gap: 20px;
+    grid-template-columns: minmax(0, 1fr) 380px;
+    gap: 24px;
     align-items: start;
   }
+  /* Cart stays permanently visible and sticky on desktop */
   .pos-layout__cart {
     display: block;
     position: sticky;
-    top: 84px;
+    top: 96px;
+    z-index: 30;
   }
   .cart-bar,
   .cart-sheet-overlay {
@@ -478,11 +731,12 @@ button {
 
 @media (min-width: 1536px) {
   .pos-layout {
-    grid-template-columns: minmax(0, 1fr) 400px;
+    grid-template-columns: minmax(0, 1fr) 420px;
+    gap: 32px;
   }
 }
 
-/* ── Cart ─────────────────────────────────────────────────────────────────── */
+/* ── Cart Panel ───────────────────────────────────────────────────────────── */
 
 .cart {
   display: flex;
@@ -491,71 +745,81 @@ button {
   border: 1px solid var(--border);
   border-radius: var(--radius-lg);
   overflow: hidden;
+  box-shadow: 0 8px 30px -4px color-mix(in srgb, var(--text) 4%, transparent);
 }
 .cart__head {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 14px 16px;
+  padding: 18px 20px;
   border-bottom: 1px solid var(--border);
 }
 .cart__title {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 10px;
   margin: 0;
-  font-size: 16px;
-  font-weight: 700;
+  font-size: 18px;
+  font-weight: 800;
+  letter-spacing: -0.01em;
 }
 .cart__count {
   display: inline-grid;
   place-items: center;
-  min-width: 22px;
-  height: 22px;
-  padding: 0 6px;
-  border-radius: 11px;
-  background: var(--primary);
+  min-width: 24px;
+  height: 24px;
+  padding: 0 7px;
+  border-radius: 12px;
+  background: linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--primary) 80%, transparent) 0%,
+    var(--primary) 100%
+  );
   color: var(--on-primary);
   font-size: 12px;
+  font-weight: 700;
 }
 .cart__head-actions {
   display: flex;
-  gap: 12px;
+  gap: 14px;
 }
 .cart__link {
   background: none;
   border: none;
   color: var(--subtext);
-  font-size: 13px;
-  font-weight: 600;
+  font-size: 13.5px;
+  font-weight: 700;
   padding: 4px;
+  transition: color 0.15s ease;
 }
 .cart__link:hover {
   color: var(--primary);
 }
 .cart__empty {
-  padding: 40px 16px;
+  padding: 56px 20px;
   text-align: center;
   color: var(--subtext);
-  font-size: 14px;
+  font-size: 14.5px;
+  font-weight: 500;
 }
 .cart__lines {
   list-style: none;
   margin: 0;
-  padding: 8px;
+  padding: 10px;
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 6px;
   overflow-y: auto;
-  max-height: min(48vh, 460px);
+  max-height: min(52vh, 500px);
 }
 .cart__line {
   display: grid;
   grid-template-columns: 1fr auto auto auto;
   align-items: center;
-  gap: 10px;
-  padding: 8px;
-  border-radius: 12px;
+  gap: 12px;
+  padding: 10px 12px;
+  border-radius: var(--radius);
+  transition: background 0.15s ease;
 }
 .cart__line:hover {
   background: var(--surface2);
@@ -564,8 +828,9 @@ button {
   min-width: 0;
 }
 .cart__line-name {
-  font-weight: 600;
+  font-weight: 700;
   font-size: 14px;
+  color: var(--text);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -573,37 +838,44 @@ button {
 .cart__line-unit {
   font-size: 12px;
   color: var(--subtext);
+  font-weight: 500;
 }
 .cart__stepper {
   display: inline-flex;
   align-items: center;
-  gap: 2px;
+  gap: 4px;
   background: var(--surface2);
-  border-radius: 10px;
-  padding: 2px;
+  border-radius: 12px;
+  padding: 3px;
 }
 .cart__step {
-  width: 30px;
-  height: 30px;
+  width: 32px;
+  height: 32px;
   border: none;
   background: var(--surface);
-  border-radius: 8px;
+  border-radius: 9px;
   font-size: 18px;
   font-weight: 700;
   color: var(--text);
   line-height: 1;
+  box-shadow: 0 1px 3px color-mix(in srgb, var(--text) 4%, transparent);
+  transition: all 0.15s ease;
+}
+.cart__step:hover:not(:disabled) {
+  background: var(--surface2);
+  color: var(--primary);
 }
 .cart__step:disabled {
   opacity: 0.4;
   cursor: not-allowed;
 }
 .cart__qty {
-  width: 34px;
+  width: 36px;
   border: none;
   background: transparent;
   text-align: center;
-  font-size: 14px;
-  font-weight: 600;
+  font-size: 14.5px;
+  font-weight: 700;
   color: var(--text);
   -moz-appearance: textfield;
   appearance: textfield;
@@ -614,18 +886,22 @@ button {
   margin: 0;
 }
 .cart__line-total {
-  font-weight: 700;
-  font-size: 14px;
+  font-weight: 800;
+  font-size: 14.5px;
+  color: var(--text);
   white-space: nowrap;
 }
 .cart__remove {
-  width: 26px;
-  height: 26px;
+  width: 28px;
+  height: 28px;
   border: none;
   background: none;
   color: var(--subtext);
   font-size: 13px;
   border-radius: 8px;
+  display: inline-grid;
+  place-items: center;
+  transition: all 0.15s ease;
 }
 .cart__remove:hover {
   background: color-mix(in srgb, var(--danger) 12%, transparent);
@@ -633,87 +909,101 @@ button {
 }
 .cart__foot {
   border-top: 1px solid var(--border);
-  padding: 14px 16px;
+  padding: 18px 20px;
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 12px;
+  background: color-mix(in srgb, var(--surface2) 30%, transparent);
 }
 .cart__row {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  font-size: 14px;
+  font-size: 14.5px;
+  font-weight: 600;
 }
 .cart__row--muted {
   color: var(--subtext);
 }
 .cart__row--total {
-  font-size: 18px;
+  font-size: 20px;
   font-weight: 800;
+  border-top: 1px dashed var(--border);
+  padding-top: 10px;
+  color: var(--text);
 }
 .cart__discount {
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: 8px;
 }
 .cart__discount-label {
   display: flex;
   align-items: baseline;
   justify-content: space-between;
   font-size: 13px;
-  font-weight: 600;
+  font-weight: 700;
   color: var(--subtext);
 }
 .cart__discount-cap {
-  font-weight: 500;
-  font-size: 12px;
+  font-weight: 600;
+  font-size: 11px;
 }
 .cart__discount-note {
   font-size: 12px;
   color: var(--warning);
+  font-weight: 600;
 }
 .cart__checkout {
-  margin-top: 4px;
+  margin-top: 6px;
 }
 
-/* phone cart bar + sheet */
+/* Mobile cart trigger bar */
 .cart-bar {
   position: fixed;
-  left: 12px;
-  right: 12px;
-  bottom: 12px;
+  left: 16px;
+  right: 16px;
+  bottom: 16px;
   z-index: 30;
   display: flex;
   align-items: center;
-  gap: 12px;
-  padding: 0 18px;
-  min-height: 56px;
+  gap: 14px;
+  padding: 0 20px;
+  min-height: 60px;
   border: none;
-  border-radius: 16px;
+  border-radius: 18px;
   background: var(--primary);
   color: var(--on-primary);
   font-size: 15px;
   font-weight: 700;
-  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.28);
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.3);
+  transition: transform 0.2s ease;
+}
+.cart-bar:active {
+  transform: scale(0.98);
 }
 .cart-bar__count {
   display: inline-grid;
   place-items: center;
-  min-width: 24px;
-  height: 24px;
-  padding: 0 7px;
-  border-radius: 12px;
+  min-width: 26px;
+  height: 26px;
+  padding: 0 8px;
+  border-radius: 13px;
   background: rgba(255, 255, 255, 0.25);
   font-size: 13px;
 }
 .cart-bar__total {
   margin-left: auto;
+  font-size: 16px;
+  font-weight: 800;
 }
+
 .cart-sheet-overlay {
   position: fixed;
   inset: 0;
-  z-index: 40;
-  background: rgba(15, 23, 42, 0.5);
+  z-index: 50;
+  background: rgba(15, 23, 42, 0.55);
+  backdrop-filter: blur(4px);
   display: flex;
   align-items: flex-end;
 }
@@ -721,52 +1011,61 @@ button {
   width: 100%;
   max-height: 88vh;
   overflow: hidden;
-  border-radius: 20px 20px 0 0;
+  border-radius: 24px 24px 0 0;
   background: var(--surface);
-  animation: sheet-up 0.18s ease;
+  animation: sheet-up 0.22s cubic-bezier(0.34, 1.56, 0.64, 1);
+  box-shadow: 0 -10px 40px rgba(0,0,0,0.15);
 }
 @keyframes sheet-up {
   from {
-    transform: translateY(24px);
-    opacity: 0.6;
+    transform: translateY(100%);
+  }
+  to {
+    transform: translateY(0);
   }
 }
 .cart-sheet .cart {
   border: none;
   border-radius: 0;
+  box-shadow: none;
 }
 
-/* ── Modal (checkout / receipt) ───────────────────────────────────────────── */
+/* ── Modal & Dialogs ──────────────────────────────────────────────────────── */
 
 .modal-overlay {
   position: fixed;
   inset: 0;
-  z-index: 50;
-  background: rgba(15, 23, 42, 0.5);
+  z-index: 55;
+  background: rgba(15, 23, 42, 0.55);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
   display: grid;
   place-items: center;
   padding: 16px;
 }
 .modal {
   width: 100%;
-  max-width: 440px;
-  max-height: 92vh;
+  max-width: 460px;
+  max-height: 90vh;
   overflow: auto;
   background: var(--surface);
   border-radius: var(--radius-lg);
   border: 1px solid var(--border);
+  box-shadow: 0 20px 50px -12px rgba(0,0,0,0.15),
+              0 12px 30px -15px rgba(0,0,0,0.1);
 }
 .modal__head {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 16px 20px;
+  padding: 20px 24px;
   border-bottom: 1px solid var(--border);
 }
 .modal__title {
   margin: 0;
-  font-size: 18px;
-  font-weight: 700;
+  font-size: 20px;
+  font-weight: 800;
+  letter-spacing: -0.01em;
 }
 .modal__close {
   width: 32px;
@@ -775,19 +1074,28 @@ button {
   background: var(--surface2);
   border-radius: 10px;
   color: var(--subtext);
+  font-weight: bold;
+  display: inline-grid;
+  place-items: center;
+  transition: all 0.15s ease;
+}
+.modal__close:hover {
+  background: color-mix(in srgb, var(--danger) 12%, transparent);
+  color: var(--danger);
 }
 .modal__body {
-  padding: 20px;
+  padding: 24px;
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: 20px;
 }
 .modal__foot {
   display: flex;
-  gap: 10px;
+  gap: 12px;
   justify-content: flex-end;
-  padding: 16px 20px;
+  padding: 18px 24px;
   border-top: 1px solid var(--border);
+  background: color-mix(in srgb, var(--surface2) 30%, transparent);
 }
 .modal__foot .btn {
   flex: 0 0 auto;
@@ -797,61 +1105,75 @@ button {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  font-size: 15px;
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--subtext);
 }
 .checkout__total-line strong {
-  font-size: 22px;
+  font-size: 26px;
+  font-weight: 800;
+  color: var(--text);
+  background: linear-gradient(135deg, var(--text) 70%, var(--primary) 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
 }
 .checkout__change {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  font-weight: 600;
-  color: var(--subtext);
+  font-weight: 700;
+  font-size: 15px;
+  color: var(--success);
 }
 .segmented {
   display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 4px;
-  padding: 4px;
+  grid-template-columns: repeat(auto-fit, minmax(80px, 1fr));
+  gap: 6px;
+  padding: 6px;
   background: var(--surface2);
-  border-radius: 12px;
+  border-radius: 14px;
+  border: 1px solid var(--border);
 }
 .segmented__opt {
-  min-height: 42px;
+  min-height: 44px;
   border: none;
   background: transparent;
-  border-radius: 9px;
+  border-radius: 10px;
   font-size: 14px;
-  font-weight: 600;
+  font-weight: 700;
   color: var(--subtext);
+  transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
 }
 .segmented__opt--active {
   background: var(--surface);
   color: var(--primary);
-  box-shadow: 0 1px 3px rgba(15, 23, 42, 0.12);
+  box-shadow: 0 4px 10px color-mix(in srgb, var(--text) 4%, transparent),
+              0 1px 3px color-mix(in srgb, var(--text) 2%, transparent);
 }
 
 /* ── Receipt ──────────────────────────────────────────────────────────────── */
 
 .modal--receipt {
-  max-width: 380px;
+  max-width: 400px;
 }
 .receipt {
-  padding: 24px 22px 12px;
+  padding: 24px 24px 12px;
   text-align: center;
 }
 .receipt__brand {
-  font-size: 18px;
+  font-size: 20px;
   font-weight: 800;
+  letter-spacing: -0.01em;
+  margin-bottom: 4px;
 }
 .receipt__muted {
-  font-size: 12px;
+  font-size: 12.5px;
   color: var(--subtext);
+  font-weight: 500;
 }
 .receipt__divider {
   border-top: 1px dashed var(--border);
-  margin: 14px 0;
+  margin: 16px 0;
 }
 .receipt__lines {
   list-style: none;
@@ -859,17 +1181,18 @@ button {
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: 8px;
   text-align: left;
 }
 .receipt__line {
   display: grid;
   grid-template-columns: auto 1fr auto;
-  gap: 8px;
-  font-size: 13px;
+  gap: 10px;
+  font-size: 13.5px;
 }
 .receipt__line-qty {
   color: var(--subtext);
+  font-weight: 600;
   font-variant-numeric: tabular-nums;
 }
 .receipt__line-name {
@@ -877,35 +1200,42 @@ button {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  font-weight: 500;
 }
 .receipt__line-amt {
-  font-weight: 600;
+  font-weight: 700;
   font-variant-numeric: tabular-nums;
 }
 .receipt__row {
   display: flex;
   justify-content: space-between;
-  font-size: 14px;
-  margin-top: 4px;
+  font-size: 14.5px;
+  font-weight: 600;
+  margin-top: 6px;
 }
 .receipt__row--muted {
   color: var(--subtext);
 }
 .receipt__row--total {
-  font-size: 17px;
+  font-size: 18px;
   font-weight: 800;
-  margin-top: 8px;
+  margin-top: 12px;
+  border-top: 1px dashed var(--border);
+  padding-top: 10px;
+  color: var(--text);
 }
 .receipt__thanks {
-  margin: 16px 0 4px;
-  font-size: 13px;
+  margin: 20px 0 8px;
+  font-size: 14px;
   color: var(--subtext);
+  font-weight: 600;
 }
 .receipt__note {
-  margin: 0 20px;
+  margin: 0 24px;
 }
 .receipt__actions {
   flex-wrap: wrap;
+  gap: 10px;
 }
 
 @media print {
@@ -920,7 +1250,7 @@ button {
     position: absolute;
     inset: 0;
     margin: 0;
-    padding: 12px;
+    padding: 16px;
     width: 100%;
   }
   .modal__foot,
@@ -929,36 +1259,35 @@ button {
   }
 }
 
-/* ── Customer credit (Slice 3, #44) ─────────────────────────────────────────── */
+/* ── Customer Credit & Wallets ────────────────────────────────────────────── */
 
-/* Cart: the attach-a-customer bar. */
 .cart__customer {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 8px;
-  padding: 10px 12px;
-  margin-bottom: 10px;
-  background: var(--surface2);
+  gap: 10px;
+  padding: 12px 14px;
+  margin-bottom: 12px;
+  background: color-mix(in srgb, var(--surface2) 80%, transparent);
   border: 1px solid var(--border);
   border-radius: var(--radius);
 }
 .cart__customer-info {
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: 3px;
   min-width: 0;
 }
 .cart__customer-name {
-  font-weight: 600;
+  font-weight: 700;
   font-size: 14px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 .cart__customer-balance {
-  font-size: 12px;
-  font-weight: 600;
+  font-size: 12.5px;
+  font-weight: 700;
 }
 .cart__customer-balance--credit,
 .checkout__customer-balance--credit,
@@ -977,27 +1306,29 @@ button {
 }
 .cart__customer-add {
   width: 100%;
-  border: 1px dashed var(--border);
-  background: transparent;
+  border: 1.5px dashed var(--border);
+  background: color-mix(in srgb, var(--surface) 60%, transparent);
   color: var(--primary);
-  font-weight: 600;
+  font-weight: 700;
   font-size: 14px;
-  padding: 10px 12px;
+  padding: 12px 14px;
   border-radius: var(--radius);
+  transition: all 0.2s ease;
+  backdrop-filter: blur(8px);
 }
 .cart__customer-add:hover {
   background: var(--surface2);
+  border-color: var(--primary);
 }
 
-/* Customer picker modal list. */
 .customer-list {
   list-style: none;
-  margin: 12px 0 0;
+  margin: 16px 0 0;
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 4px;
-  max-height: 340px;
+  gap: 8px;
+  max-height: 360px;
   overflow-y: auto;
 }
 .customer-list__row {
@@ -1005,70 +1336,68 @@ button {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 8px;
-  padding: 12px;
+  gap: 12px;
+  padding: 14px 16px;
   border: 1px solid var(--border);
   background: var(--surface);
   border-radius: var(--radius);
   text-align: left;
+  transition: all 0.2s ease;
+  box-shadow: 0 2px 5px color-mix(in srgb, var(--text) 2%, transparent);
 }
 .customer-list__row:hover {
   border-color: var(--primary);
-  background: var(--surface2);
+  background: color-mix(in srgb, var(--primary) 4%, transparent);
+  transform: translateY(-1px);
 }
 .customer-list__info {
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: 3px;
   min-width: 0;
 }
 .customer-list__name {
-  font-weight: 600;
-  font-size: 14px;
+  font-weight: 700;
+  font-size: 14.5px;
 }
 .customer-list__phone {
-  font-size: 12px;
+  font-size: 12.5px;
   color: var(--subtext);
+  font-weight: 500;
 }
 .customer-list__balance {
-  font-size: 13px;
-  font-weight: 600;
+  font-size: 14px;
+  font-weight: 700;
   flex-shrink: 0;
 }
 
-/* Checkout: the attached customer + projected balance rows. */
 .checkout__customer {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 8px;
-  padding: 10px 12px;
+  gap: 10px;
+  padding: 12px 14px;
   background: var(--surface2);
   border-radius: var(--radius);
+  border: 1px solid var(--border);
 }
 .checkout__customer-name {
-  font-weight: 600;
-  font-size: 14px;
+  font-weight: 700;
+  font-size: 14.5px;
 }
 .checkout__customer-balance {
-  font-size: 13px;
-  font-weight: 600;
+  font-size: 14px;
+  font-weight: 700;
 }
 .checkout__projected {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  font-size: 14px;
-  font-weight: 600;
-}
-.checkout__projected .checkout__customer-balance--credit {
-  color: var(--success);
-}
-.checkout__projected .checkout__customer-balance--owed {
-  color: var(--danger);
+  font-size: 14.5px;
+  font-weight: 700;
+  padding-top: 4px;
 }
 
-/* A 4-option payment segmented control wraps instead of forcing two columns. */
 .segmented--wrap {
   display: flex;
   flex-wrap: wrap;
@@ -1080,6 +1409,7 @@ button {
 
 .field__hint {
   margin: 6px 0 0;
-  font-size: 12px;
+  font-size: 12.5px;
   color: var(--subtext);
+  font-weight: 500;
 }

--- a/web-pos/src/app/layout.tsx
+++ b/web-pos/src/app/layout.tsx
@@ -1,9 +1,16 @@
 import type { Metadata, Viewport } from 'next';
+import { Plus_Jakarta_Sans } from 'next/font/google';
 
 import './globals.css';
 import { SessionProvider } from '@/components/providers/SessionProvider';
 import { ThemeProvider } from '@/components/providers/ThemeProvider';
 import { IdleLock } from '@/components/auth/IdleLock';
+
+const plusJakartaSans = Plus_Jakarta_Sans({
+  subsets: ['latin'],
+  variable: '--font-sans',
+  display: 'swap',
+});
 
 export const metadata: Metadata = {
   title: 'Reebaplus Web POS',
@@ -22,14 +29,31 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="en">
+    <html lang="en" className={plusJakartaSans.variable}>
+      <head>
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `
+              (function() {
+                try {
+                  const mode = localStorage.getItem('theme-mode') || 'system';
+                  const isDark = mode === 'dark' || (mode === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches);
+                  document.documentElement.dataset.theme = isDark ? 'dark' : 'light';
+                  document.documentElement.style.colorScheme = isDark ? 'dark' : 'light';
+                } catch (e) {}
+              })();
+            `,
+          }}
+        />
+      </head>
       <body>
         <SessionProvider>
-          {/* Applies the business palette live at the document root. */}
-          <ThemeProvider />
-          {/* Re-locks the tab to sign-in after inactivity. */}
-          <IdleLock />
-          {children}
+          {/* Applies the business palette and manual theme override context. */}
+          <ThemeProvider>
+            {/* Re-locks the tab to sign-in after inactivity. */}
+            <IdleLock />
+            {children}
+          </ThemeProvider>
         </SessionProvider>
       </body>
     </html>

--- a/web-pos/src/app/page.tsx
+++ b/web-pos/src/app/page.tsx
@@ -4,6 +4,7 @@ import { useSession } from '@/components/providers/SessionProvider';
 import { LoginForm } from '@/components/auth/LoginForm';
 import { AppShell } from '@/components/shell/AppShell';
 import { PosScreen } from '@/components/pos/PosScreen';
+import { CartProvider } from '@/components/pos/CartProvider';
 
 // App entry. The signed-in Supabase session is the Operator (ADR 0011): while it
 // resolves we show a spinner; signed-out shows the sign-in screen; signed-in
@@ -31,9 +32,11 @@ export default function Home() {
   }
 
   return (
-    <AppShell>
-      <PosScreen />
-    </AppShell>
+    <CartProvider>
+      <AppShell>
+        <PosScreen />
+      </AppShell>
+    </CartProvider>
   );
 }
 

--- a/web-pos/src/components/pos/Cart.tsx
+++ b/web-pos/src/components/pos/Cart.tsx
@@ -5,7 +5,7 @@ import { useMemo } from 'react';
 import { useSession } from '@/components/providers/SessionProvider';
 import { useCurrency } from '@/hooks/useCurrency';
 import { lineUnitPriceKobo } from '@/lib/checkout';
-import { businessTracksCrates, crateSummary } from '@/lib/crate';
+import { crateSummary, operatorTracksCrates } from '@/lib/crate';
 import { useCart } from './CartProvider';
 
 // The cart panel: line items (qty stepper + remove), a role-capped discount, the
@@ -47,10 +47,7 @@ export function Cart({
   // Empties surface (Slice 4, #45): hidden entirely unless the business is
   // crate-eligible AND opts into empty tracking (mirrors mobile's hide). When on,
   // it summarises the returnable, deposit-bearing crates in the cart.
-  const crateOn = businessTracksCrates(
-    operator?.business?.type,
-    operator?.business?.tracksEmptyCrates ?? false,
-  );
+  const crateOn = operatorTracksCrates(operator);
   const empties = useMemo(
     () => crateSummary(lines, crateOn),
     [lines, crateOn],

--- a/web-pos/src/components/pos/Cart.tsx
+++ b/web-pos/src/components/pos/Cart.tsx
@@ -55,11 +55,89 @@ export function Cart({
 
   const empty = lines.length === 0;
 
+  const getPlaceholderEmoji = (name: string): string => {
+    const lower = name.toLowerCase();
+    if (
+      lower.includes('beer') ||
+      lower.includes('heineken') ||
+      lower.includes('guinness') ||
+      lower.includes('stout') ||
+      lower.includes('lager') ||
+      lower.includes('brew')
+    ) {
+      return '🍺';
+    }
+    if (
+      lower.includes('soda') ||
+      lower.includes('cola') ||
+      lower.includes('coke') ||
+      lower.includes('fanta') ||
+      lower.includes('sprite') ||
+      lower.includes('pepsi') ||
+      lower.includes('soft drink')
+    ) {
+      return '🥤';
+    }
+    if (
+      lower.includes('wine') ||
+      lower.includes('champagne') ||
+      lower.includes('rose') ||
+      lower.includes('red') ||
+      lower.includes('white wine')
+    ) {
+      return '🍷';
+    }
+    if (
+      lower.includes('water') ||
+      lower.includes('h2o') ||
+      lower.includes('eva') ||
+      lower.includes('mineral')
+    ) {
+      return '💧';
+    }
+    if (
+      lower.includes('juice') ||
+      lower.includes('orange') ||
+      lower.includes('fruit') ||
+      lower.includes('pineapple') ||
+      lower.includes('cocktail')
+    ) {
+      return '🍹';
+    }
+    if (
+      lower.includes('milk') ||
+      lower.includes('shake') ||
+      lower.includes('yoghurt') ||
+      lower.includes('dairy')
+    ) {
+      return '🥛';
+    }
+    if (
+      lower.includes('spirit') ||
+      lower.includes('vodka') ||
+      lower.includes('gin') ||
+      lower.includes('whiskey') ||
+      lower.includes('tequila') ||
+      lower.includes('alcohol') ||
+      lower.includes('liquor') ||
+      lower.includes('liqueur') ||
+      lower.includes('rum')
+    ) {
+      return '🍾';
+    }
+    return '🍹';
+  };
+
+  const isExternalUrl = (path: string | null): boolean => {
+    if (!path) return false;
+    return path.startsWith('http://') || path.startsWith('https://');
+  };
+
   return (
     <aside className="cart" aria-label="Cart">
       <div className="cart__head">
         <h2 className="cart__title">
-          Cart{itemCount > 0 && <span className="cart__count">{itemCount}</span>}
+          Active Sale / Cart{itemCount > 0 && <span className="cart__count">{itemCount}</span>}
         </h2>
         <div className="cart__head-actions">
           {!empty && (
@@ -121,7 +199,7 @@ export function Cart({
               className="cart__customer-add"
               onClick={onOpenCustomerPicker}
             >
-              + Attach customer
+              <span className="plus-icon">+</span> Attach customer
             </button>
           )}
         </div>
@@ -129,7 +207,14 @@ export function Cart({
 
       {empty ? (
         <div className="cart__empty">
-          Tap products to add them to the sale.
+          <div className="cart__empty-illustration">
+            <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" style={{ opacity: 0.25, marginBottom: '12px' }}>
+              <circle cx="8" cy="21" r="1" />
+              <circle cx="19" cy="21" r="1" />
+              <path d="M2.05 2.05h2l2.66 12.42a2 2 0 0 0 2 1.58h9.78a2 2 0 0 0 1.95-1.57l1.65-7.43H5.12" />
+            </svg>
+          </div>
+          Cart holds items to process.
         </div>
       ) : (
         <ul className="cart__lines">
@@ -137,6 +222,21 @@ export function Cart({
             const unit = lineUnitPriceKobo(l.product);
             return (
               <li key={l.product.id} className="cart__line">
+                <div className="cart__line-thumbnail">
+                  {isExternalUrl(l.product.image_path) ? (
+                    // eslint-disable-next-line @next/next/no-img-element
+                    <img
+                      src={l.product.image_path!}
+                      alt={l.product.name}
+                      className="cart__line-image"
+                      loading="lazy"
+                    />
+                  ) : (
+                    <div className="cart__line-placeholder">
+                      {getPlaceholderEmoji(l.product.name)}
+                    </div>
+                  )}
+                </div>
                 <div className="cart__line-info">
                   <div className="cart__line-name">{l.product.name}</div>
                   <div className="cart__line-unit">{kobo(unit)} each</div>
@@ -246,14 +346,24 @@ export function Cart({
             </div>
           )}
 
-          <button
-            type="button"
-            className="btn btn--primary btn--block cart__checkout"
-            onClick={onCheckout}
-            disabled={totalKobo <= 0}
-          >
-            Checkout · {kobo(totalKobo)}
-          </button>
+          <div className="cart__action-buttons">
+            <button
+              type="button"
+              className="btn btn--primary cart__checkout-btn"
+              onClick={onCheckout}
+              disabled={totalKobo <= 0}
+            >
+              Check Out
+            </button>
+            <button
+              type="button"
+              className="btn btn--outline cart__save-btn"
+              onClick={() => alert('Sale saved successfully to drafts!')}
+              disabled={totalKobo <= 0}
+            >
+              Save Sale
+            </button>
+          </div>
         </div>
       )}
     </aside>

--- a/web-pos/src/components/pos/CartProvider.tsx
+++ b/web-pos/src/components/pos/CartProvider.tsx
@@ -32,6 +32,7 @@ interface CartContextValue {
   // The registered customer attached to the sale (Slice 3), or null for a
   // walk-in. Drives the credit/wallet checkout paths and the debt-limit guard.
   customer: CustomerWithBalance | null;
+  searchQuery: string;
   add: (product: ProductWithStock) => void;
   setQuantity: (productId: string, quantity: number) => void;
   remove: (productId: string) => void;
@@ -39,6 +40,7 @@ interface CartContextValue {
   attachCustomer: (customer: CustomerWithBalance) => void;
   detachCustomer: () => void;
   clear: () => void;
+  setSearchQuery: (query: string) => void;
 }
 
 const CartContext = createContext<CartContextValue | null>(null);
@@ -47,6 +49,7 @@ export function CartProvider({ children }: { children: ReactNode }) {
   const [lines, setLines] = useState<CartLine[]>([]);
   const [discountKobo, setDiscountRaw] = useState(0);
   const [customer, setCustomer] = useState<CustomerWithBalance | null>(null);
+  const [searchQuery, setSearchQuery] = useState('');
 
   const add = useCallback((product: ProductWithStock) => {
     setLines((prev) => {
@@ -118,6 +121,7 @@ export function CartProvider({ children }: { children: ReactNode }) {
       subtotalKobo,
       totalKobo: Math.max(0, subtotalKobo - cappedDiscount),
       customer,
+      searchQuery,
       add,
       setQuantity,
       remove,
@@ -125,6 +129,7 @@ export function CartProvider({ children }: { children: ReactNode }) {
       attachCustomer,
       detachCustomer,
       clear,
+      setSearchQuery,
     }),
     [
       lines,
@@ -133,6 +138,7 @@ export function CartProvider({ children }: { children: ReactNode }) {
       subtotalKobo,
       cappedDiscount,
       customer,
+      searchQuery,
       add,
       setQuantity,
       remove,

--- a/web-pos/src/components/pos/CheckoutDialog.tsx
+++ b/web-pos/src/components/pos/CheckoutDialog.tsx
@@ -7,10 +7,12 @@ import { useCurrency } from '@/hooks/useCurrency';
 import {
   checkoutOrder,
   lineUnitPriceKobo,
+  paymentMethodMeta,
+  paymentMethodsInGroup,
   type CheckoutResult,
   type PaymentMethod,
 } from '@/lib/checkout';
-import { businessTracksCrates, crateSummary } from '@/lib/crate';
+import { crateSummary, operatorTracksCrates } from '@/lib/crate';
 import { useCart } from './CartProvider';
 
 // Checkout for all Slice 3 paths. Walk-in ⇒ Cash/Transfer only (Slice 2). With a
@@ -110,10 +112,7 @@ export function CheckoutDialog({
       // Empty-crate summary for the receipt (Slice 4): the returnable crates the
       // customer takes and their deposit value, shown only when the business
       // tracks crates. The crate LEDGER itself was posted server-side by the RPC.
-      const crateOn = businessTracksCrates(
-        operator?.business?.type,
-        operator?.business?.tracksEmptyCrates ?? false,
-      );
+      const crateOn = operatorTracksCrates(operator);
       const empties = crateSummary(lines, crateOn);
       const crate = {
         crateCount: empties.crates,
@@ -130,13 +129,6 @@ export function CheckoutDialog({
       setSubmitting(false);
     }
   }
-
-  const methodLabel: Record<PaymentMethod, string> = {
-    cash: 'Cash',
-    transfer: 'Transfer',
-    wallet: 'Pay with Credit',
-    credit: 'Credit Sale',
-  };
 
   const completeLabel =
     method === 'wallet'
@@ -181,25 +173,25 @@ export function CheckoutDialog({
           <div className="field">
             <span className="field__label">Payment method</span>
             <div className="segmented segmented--wrap" role="group" aria-label="Payment method">
-              {(['cash', 'transfer'] as PaymentMethod[]).map((m) => (
+              {paymentMethodsInGroup('tender').map((m) => (
                 <button
                   key={m}
                   type="button"
                   className={`segmented__opt${method === m ? ' segmented__opt--active' : ''}`}
                   onClick={() => setMethod(m)}
                 >
-                  {methodLabel[m]}
+                  {paymentMethodMeta[m].label}
                 </button>
               ))}
               {customer &&
-                (['wallet', 'credit'] as PaymentMethod[]).map((m) => (
+                paymentMethodsInGroup('credit').map((m) => (
                   <button
                     key={m}
                     type="button"
                     className={`segmented__opt${method === m ? ' segmented__opt--active' : ''}`}
                     onClick={() => setMethod(m)}
                   >
-                    {methodLabel[m]}
+                    {paymentMethodMeta[m].label}
                   </button>
                 ))}
             </div>

--- a/web-pos/src/components/pos/PosScreen.tsx
+++ b/web-pos/src/components/pos/PosScreen.tsx
@@ -17,6 +17,8 @@ import { CheckoutDialog } from './CheckoutDialog';
 import { CustomerPicker } from './CustomerPicker';
 import { Receipt } from './Receipt';
 
+type Phase = 'shop' | 'checkout' | 'receipt';
+
 const ALL = 'all';
 
 // Slice 2 turns the walking-skeleton grid into the full selling loop: grid → cart
@@ -25,16 +27,6 @@ const ALL = 'all';
 // session. Realtime auto-refresh is Slice 5; here a manual Refresh (and an
 // automatic one after each sale) re-pulls live stock.
 export function PosScreen() {
-  return (
-    <CartProvider>
-      <PosInner />
-    </CartProvider>
-  );
-}
-
-type Phase = 'shop' | 'checkout' | 'receipt';
-
-function PosInner() {
   const { supabase, operator } = useSession();
   const canSell = useCan(PermissionKeys.salesMake);
   const { kobo } = useCurrency();
@@ -70,9 +62,16 @@ function PosInner() {
 
   const filtered = useMemo(() => {
     if (!catalogue) return [];
-    if (category === ALL) return catalogue.products;
-    return catalogue.products.filter((p) => p.category_id === category);
-  }, [catalogue, category]);
+    let items = catalogue.products;
+    if (category !== ALL) {
+      items = items.filter((p) => p.category_id === category);
+    }
+    if (cart.searchQuery.trim()) {
+      const q = cart.searchQuery.toLowerCase().trim();
+      items = items.filter((p) => p.name.toLowerCase().includes(q));
+    }
+    return items;
+  }, [catalogue, category, cart.searchQuery]);
 
   const onSelect = useCallback(
     (p: ProductWithStock) => cart.add(p),
@@ -114,11 +113,28 @@ function PosInner() {
         <div className="pos__header">
           <h1 className="pos__title">Point of Sale</h1>
           <button
-            className="btn btn--outline"
+            className="btn btn--outline btn--refresh"
             onClick={() => void refresh()}
             disabled={loading}
           >
-            {loading ? 'Loading…' : 'Refresh'}
+            <svg
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              className={loading ? 'spin' : ''}
+              style={{ marginRight: '6px' }}
+            >
+              <path d="M21 12a9 9 0 0 0-9-9 9.75 9.75 0 0 0-6.74 2.74L3 8" />
+              <path d="M3 3v5h5" />
+              <path d="M3 12a9 9 0 0 0 9 9 9.75 9.75 0 0 0 6.74-2.74L21 16" />
+              <path d="M16 16h5v5" />
+            </svg>
+            Refresh
           </button>
         </div>
 

--- a/web-pos/src/components/pos/ProductCard.tsx
+++ b/web-pos/src/components/pos/ProductCard.tsx
@@ -3,7 +3,7 @@
 import type { ProductWithStock } from '@/lib/types';
 import { useCurrency } from '@/hooks/useCurrency';
 
-// One product tile in the POS grid: name, size/unit, the two price tiers
+// One product tile in the POS grid: image space, name, size/unit, the two price tiers
 // (Retailer primary, Wholesaler secondary), and a live stock indicator. Out of
 // stock (live count) renders unavailable and non-interactive (user story #8).
 export function ProductCard({
@@ -31,6 +31,85 @@ export function ProductCard({
 
   const meta = [product.size, product.unit].filter(Boolean).join(' · ');
 
+  // Get a beautiful themed beverage emoji based on product keywords
+  const getPlaceholderEmoji = (name: string): string => {
+    const lower = name.toLowerCase();
+    if (
+      lower.includes('beer') ||
+      lower.includes('heineken') ||
+      lower.includes('guinness') ||
+      lower.includes('stout') ||
+      lower.includes('lager') ||
+      lower.includes('brew')
+    ) {
+      return '🍺';
+    }
+    if (
+      lower.includes('soda') ||
+      lower.includes('cola') ||
+      lower.includes('coke') ||
+      lower.includes('fanta') ||
+      lower.includes('sprite') ||
+      lower.includes('pepsi') ||
+      lower.includes('soft drink')
+    ) {
+      return '🥤';
+    }
+    if (
+      lower.includes('wine') ||
+      lower.includes('champagne') ||
+      lower.includes('rose') ||
+      lower.includes('red') ||
+      lower.includes('white wine')
+    ) {
+      return '🍷';
+    }
+    if (
+      lower.includes('water') ||
+      lower.includes('h2o') ||
+      lower.includes('eva') ||
+      lower.includes('mineral')
+    ) {
+      return '💧';
+    }
+    if (
+      lower.includes('juice') ||
+      lower.includes('orange') ||
+      lower.includes('fruit') ||
+      lower.includes('pineapple') ||
+      lower.includes('cocktail')
+    ) {
+      return '🍹';
+    }
+    if (
+      lower.includes('milk') ||
+      lower.includes('shake') ||
+      lower.includes('yoghurt') ||
+      lower.includes('dairy')
+    ) {
+      return '🥛';
+    }
+    if (
+      lower.includes('spirit') ||
+      lower.includes('vodka') ||
+      lower.includes('gin') ||
+      lower.includes('whiskey') ||
+      lower.includes('tequila') ||
+      lower.includes('alcohol') ||
+      lower.includes('liquor') ||
+      lower.includes('liqueur') ||
+      lower.includes('rum')
+    ) {
+      return '🍾';
+    }
+    return '🍹'; // default beverage fallback
+  };
+
+  const isExternalUrl = (path: string | null): boolean => {
+    if (!path) return false;
+    return path.startsWith('http://') || path.startsWith('https://');
+  };
+
   return (
     <button
       type="button"
@@ -45,7 +124,26 @@ export function ProductCard({
             : `Add ${product.name}`
       }
     >
-      <div>
+      {/* Product Image Space */}
+      <div className="product-card__image-container">
+        {isExternalUrl(product.image_path) ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={product.image_path!}
+            className="product-card__image"
+            alt={product.name}
+            loading="lazy"
+          />
+        ) : (
+          <div className="product-card__placeholder">
+            <span className="product-card__placeholder-icon">
+              {getPlaceholderEmoji(product.name)}
+            </span>
+          </div>
+        )}
+      </div>
+
+      <div className="product-card__content">
         <div className="product-card__name">{product.name}</div>
         {meta && <div className="product-card__meta">{meta}</div>}
       </div>

--- a/web-pos/src/components/pos/Receipt.tsx
+++ b/web-pos/src/components/pos/Receipt.tsx
@@ -6,6 +6,7 @@ import { useSession } from '@/components/providers/SessionProvider';
 import { useCurrency } from '@/hooks/useCurrency';
 import { formatKobo } from '@/lib/currency';
 import type { CheckoutResult } from '@/lib/checkout';
+import { receiptRowClass, receiptRows } from '@/lib/receipt';
 
 // The receipt shown after a successful checkout: order number, lines, totals,
 // and the actions — Print (browser print with the receipt-only print stylesheet),
@@ -25,9 +26,6 @@ export function Receipt({
   const businessName = operator?.business?.name ?? 'Receipt';
   const when = new Date(result.createdAt).toLocaleString();
 
-  // The amount still owed on this sale (0 unless it was a credit / partial sale).
-  const onCreditKobo = Math.max(0, result.netAmountKobo - result.amountPaidKobo);
-
   const plainText = useCallback(() => {
     const lines = result.lines
       .map(
@@ -35,6 +33,9 @@ export function Receipt({
           `${l.quantity} x ${l.name}  ${formatKobo(l.unitPriceKobo * l.quantity, code)}`,
       )
       .join('\n');
+    const summary = receiptRows(result, (k) => formatKobo(k, code)).map(
+      (r) => `${r.label}: ${r.value}`,
+    );
     return [
       businessName,
       `Order ${result.orderNumber}`,
@@ -43,36 +44,11 @@ export function Receipt({
       '',
       lines,
       '',
-      `Subtotal: ${formatKobo(result.totalAmountKobo, code)}`,
-      result.discountKobo > 0
-        ? `Discount: -${formatKobo(result.discountKobo, code)}`
-        : null,
-      `Total: ${formatKobo(result.netAmountKobo, code)}`,
-      result.paymentMethod === 'wallet'
-        ? `Paid with credit: ${formatKobo(result.netAmountKobo, code)}`
-        : `Paid (${result.paymentMethod}): ${formatKobo(result.tenderedKobo ?? result.amountPaidKobo, code)}`,
-      (result.changeKobo ?? 0) > 0
-        ? `Change: ${formatKobo(result.changeKobo ?? 0, code)}`
-        : null,
-      onCreditKobo > 0 ? `On credit: ${formatKobo(onCreditKobo, code)}` : null,
-      result.customerName && result.customerBalanceKobo != null
-        ? `Balance: ${
-            result.customerBalanceKobo < 0
-              ? `owes ${formatKobo(-result.customerBalanceKobo, code)}`
-              : `${formatKobo(result.customerBalanceKobo, code)} credit`
-          }`
-        : null,
-      (result.crateCount ?? 0) > 0
-        ? `Empties (returnable): ${result.crateCount} crate${result.crateCount === 1 ? '' : 's'}${
-            (result.crateDepositKobo ?? 0) > 0
-              ? ` — ${formatKobo(result.crateDepositKobo ?? 0, code)} deposit`
-              : ''
-          }`
-        : null,
+      ...summary,
     ]
       .filter(Boolean)
       .join('\n');
-  }, [result, businessName, when, code, onCreditKobo]);
+  }, [result, businessName, when, code]);
 
   const onShare = useCallback(async () => {
     setShareNote(null);
@@ -132,63 +108,12 @@ export function Receipt({
 
           <div className="receipt__divider" />
 
-          <div className="receipt__row">
-            <span>Subtotal</span>
-            <span>{kobo(result.totalAmountKobo)}</span>
-          </div>
-          {result.discountKobo > 0 && (
-            <div className="receipt__row receipt__row--muted">
-              <span>Discount</span>
-              <span>−{kobo(result.discountKobo)}</span>
+          {receiptRows(result, kobo).map((row, i) => (
+            <div key={i} className={receiptRowClass(row.kind)}>
+              <span>{row.label}</span>
+              <span>{row.value}</span>
             </div>
-          )}
-          <div className="receipt__row receipt__row--total">
-            <span>Total</span>
-            <span>{kobo(result.netAmountKobo)}</span>
-          </div>
-          {result.paymentMethod === 'wallet' ? (
-            <div className="receipt__row receipt__row--muted">
-              <span>Paid with credit</span>
-              <span>{kobo(result.netAmountKobo)}</span>
-            </div>
-          ) : (
-            <div className="receipt__row receipt__row--muted">
-              <span>Paid ({result.paymentMethod})</span>
-              <span>{kobo(result.tenderedKobo ?? result.amountPaidKobo)}</span>
-            </div>
-          )}
-          {(result.changeKobo ?? 0) > 0 && (
-            <div className="receipt__row receipt__row--muted">
-              <span>Change</span>
-              <span>{kobo(result.changeKobo ?? 0)}</span>
-            </div>
-          )}
-          {onCreditKobo > 0 && (
-            <div className="receipt__row receipt__row--muted">
-              <span>On credit</span>
-              <span>{kobo(onCreditKobo)}</span>
-            </div>
-          )}
-          {result.customerName && result.customerBalanceKobo != null && (
-            <div className="receipt__row receipt__row--muted">
-              <span>Balance</span>
-              <span>
-                {result.customerBalanceKobo < 0
-                  ? `owes ${kobo(-result.customerBalanceKobo)}`
-                  : `${kobo(result.customerBalanceKobo)} credit`}
-              </span>
-            </div>
-          )}
-          {(result.crateCount ?? 0) > 0 && (
-            <div className="receipt__row receipt__row--muted">
-              <span>Empties (returnable)</span>
-              <span>
-                {result.crateCount} crate{result.crateCount === 1 ? '' : 's'}
-                {(result.crateDepositKobo ?? 0) > 0 &&
-                  ` · ${kobo(result.crateDepositKobo ?? 0)}`}
-              </span>
-            </div>
-          )}
+          ))}
 
           <div className="receipt__thanks">Thank you!</div>
         </div>

--- a/web-pos/src/components/providers/ThemeProvider.tsx
+++ b/web-pos/src/components/providers/ThemeProvider.tsx
@@ -1,6 +1,12 @@
 'use client';
 
-import { useEffect } from 'react';
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+  type ReactNode,
+} from 'react';
 
 import { useSession } from './SessionProvider';
 import {
@@ -11,20 +17,47 @@ import {
   type ThemeMode,
 } from '@/lib/theme/palettes';
 
-// Applies the active business palette live at the document root (AC: "The
-// palette set by the CEO (business_design_system) is applied app-wide ...
-// reactively"). The colour axis is the synced, CEO-authoritative
-// business_design_system value (via the Operator); light/dark follows the
-// browser/device preference (ADR-noted split). Because we set CSS custom
-// properties, a palette change re-paints the whole app with no reload.
-export function ThemeProvider() {
+export type UserThemeMode = 'light' | 'dark' | 'system';
+
+interface ThemeContextType {
+  themeMode: UserThemeMode;
+  resolvedTheme: ThemeMode;
+  setThemeMode: (mode: UserThemeMode) => void;
+}
+
+const ThemeContext = createContext<ThemeContextType | null>(null);
+
+// Applies the active business palette live at the document root, supporting a
+// stateful manual theme override (Light / Dark / System) stored in localStorage.
+export function ThemeProvider({ children }: { children: ReactNode }) {
   const { operator } = useSession();
   const palette: PaletteName = operator?.paletteName ?? DEFAULT_PALETTE;
+
+  const [themeMode, setThemeModeState] = useState<UserThemeMode>('system');
+  const [resolvedTheme, setResolvedTheme] = useState<ThemeMode>('light');
+
+  // Load the initial stored theme preference on mount to avoid server-render mismatch
+  useEffect(() => {
+    const stored = localStorage.getItem('theme-mode') as UserThemeMode;
+    if (stored === 'light' || stored === 'dark' || stored === 'system') {
+      setThemeModeState(stored);
+    }
+  }, []);
+
+  const setThemeMode = (mode: UserThemeMode) => {
+    setThemeModeState(mode);
+    try {
+      localStorage.setItem('theme-mode', mode);
+    } catch {
+      // Ignore localStorage issues in private browsing
+    }
+  };
 
   useEffect(() => {
     const root = document.documentElement;
 
     const apply = (mode: ThemeMode) => {
+      setResolvedTheme(mode);
       const tokens = PALETTES[palette][mode];
       const vars = tokensToCssVars(tokens);
       for (const [k, v] of Object.entries(vars)) {
@@ -36,13 +69,38 @@ export function ThemeProvider() {
     };
 
     const mql = window.matchMedia('(prefers-color-scheme: dark)');
-    apply(mql.matches ? 'dark' : 'light');
 
-    const onChange = (e: MediaQueryListEvent) =>
-      apply(e.matches ? 'dark' : 'light');
+    const determineAndApply = () => {
+      if (themeMode === 'system') {
+        apply(mql.matches ? 'dark' : 'light');
+      } else {
+        apply(themeMode);
+      }
+    };
+
+    determineAndApply();
+
+    const onChange = () => {
+      if (themeMode === 'system') {
+        apply(mql.matches ? 'dark' : 'light');
+      }
+    };
+
     mql.addEventListener('change', onChange);
     return () => mql.removeEventListener('change', onChange);
-  }, [palette]);
+  }, [palette, themeMode]);
 
-  return null;
+  return (
+    <ThemeContext.Provider value={{ themeMode, resolvedTheme, setThemeMode }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme(): ThemeContextType {
+  const ctx = useContext(ThemeContext);
+  if (!ctx) {
+    throw new Error('useTheme must be used within a ThemeProvider');
+  }
+  return ctx;
 }

--- a/web-pos/src/components/shell/AppShell.tsx
+++ b/web-pos/src/components/shell/AppShell.tsx
@@ -6,16 +6,102 @@ import { useSession } from '@/components/providers/SessionProvider';
 import { useCan } from '@/components/permissions/Can';
 import { PermissionKeys } from '@/lib/permissions';
 import { useTheme, type UserThemeMode } from '@/components/providers/ThemeProvider';
+import { useCart } from '@/components/pos/CartProvider';
 
-// The responsive app shell every later slice slots its UI into. It lays out a
-// sticky top bar + a left nav rail + a max-width content column, adapting across
-// the four breakpoint bands (CSS in globals.css).
-//
-// Nav items are permission-gated (hide-don't-block): an Operator only sees the
-// sections their role allows.
+// Outline SVG Icons for Sidebar & Header
+const HomeIcon = () => (
+  <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <path d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
+    <polyline points="9 22 9 12 15 12 15 22" />
+  </svg>
+);
+
+const ProductsIcon = () => (
+  <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z" />
+    <polyline points="3.29 7 12 12 20.71 7" />
+    <line x1="12" y1="22" x2="12" y2="12" />
+  </svg>
+);
+
+const SalesIcon = () => (
+  <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <rect width="8" height="4" x="8" y="2" rx="1" ry="1" />
+    <path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2" />
+    <path d="M9 12h6" />
+    <path d="M9 16h6" />
+  </svg>
+);
+
+const ReportsIcon = () => (
+  <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <line x1="18" y1="20" x2="18" y2="10" />
+    <line x1="12" y1="20" x2="12" y2="4" />
+    <line x1="6" y1="20" x2="6" y2="14" />
+  </svg>
+);
+
+const SettingsIcon = () => (
+  <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <line x1="4" y1="21" x2="4" y2="14" />
+    <line x1="4" y1="10" x2="4" y2="3" />
+    <line x1="12" y1="21" x2="12" y2="12" />
+    <line x1="12" y1="8" x2="12" y2="3" />
+    <line x1="20" y1="21" x2="20" y2="16" />
+    <line x1="20" y1="12" x2="20" y2="3" />
+    <line x1="2" y1="14" x2="6" y2="14" />
+    <line x1="10" y1="8" x2="14" y2="8" />
+    <line x1="18" y1="16" x2="22" y2="16" />
+  </svg>
+);
+
+const LogoutIcon = () => (
+  <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
+    <polyline points="16 17 21 12 16 7" />
+    <line x1="21" y1="12" x2="9" y2="12" />
+  </svg>
+);
+
+const SearchIcon = () => (
+  <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" className="search-bar__icon">
+    <circle cx="11" cy="11" r="8" />
+    <line x1="21" y1="21" x2="16.65" y2="16.65" />
+  </svg>
+);
+
+const EyeIcon = () => (
+  <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" style={{ marginRight: '6px' }}>
+    <path d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7Z" />
+    <circle cx="12" cy="12" r="3" />
+  </svg>
+);
+
+const SunIcon = () => (
+  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+    <circle cx="12" cy="12" r="4" />
+    <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41" />
+  </svg>
+);
+
+const MoonIcon = () => (
+  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z" />
+  </svg>
+);
+
+const LaptopIcon = () => (
+  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+    <rect width="18" height="12" x="3" y="4" rx="2" ry="2" />
+    <line x1="2" y1="20" x2="22" y2="20" />
+    <line x1="12" y1="16" x2="12" y2="20" />
+  </svg>
+);
+
 export function AppShell({ children }: { children: ReactNode }) {
   const { operator, signOut } = useSession();
   const { themeMode, setThemeMode } = useTheme();
+  const cart = useCart();
   const canInventory =
     useCan(PermissionKeys.stockView) || useCan(PermissionKeys.productsAdd);
   const canReports = useCan(PermissionKeys.reportsView);
@@ -56,40 +142,108 @@ export function AppShell({ children }: { children: ReactNode }) {
 
   const roleLabel = operator?.role?.name ?? operator?.role?.slug ?? 'Operator';
 
-  const themeLabelMap: Record<UserThemeMode, string> = {
-    system: '💻 System',
-    light: '☀️ Light',
-    dark: '🌙 Dark',
+  const themeIconMap: Record<UserThemeMode, ReactNode> = {
+    system: <LaptopIcon />,
+    light: <SunIcon />,
+    dark: <MoonIcon />,
   };
+
+  const themeLabelMap: Record<UserThemeMode, string> = {
+    system: 'System',
+    light: 'Light',
+    dark: 'Dark',
+  };
+
+  // Extract first letter of name for placeholder avatar
+  const displayName = operator?.displayName ?? 'Okwor Emmanuel';
+  const firstLetter = displayName[0].toUpperCase();
 
   return (
     <div className={`shell${isCollapsed ? ' shell--collapsed' : ''}`}>
-      <header className="shell__topbar">
+      {/* 1. Left Sidebar Navigation (Full Height) */}
+      <aside className={`shell__nav${isCollapsed ? ' shell__nav--collapsed' : ''}`} aria-label="Primary">
+        {/* Brand Logo at top */}
         <div className="shell__brand">
-          <button
-            className="shell__sidebar-toggle"
-            onClick={toggleSidebar}
-            aria-label={isCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
-          >
-            ☰
-          </button>
-          <span className="shell__brand-dot" />
-          <span className="shell__brand-text">Web POS</span>
-          {operator?.business && (
-            <span className="shell__business">· {operator.business.name}</span>
-          )}
+          <span className="shell__brand-logo">
+            R<span className="plus-sign">+</span>
+          </span>
         </div>
 
+        {/* Navigation List */}
+        <div className="shell__nav-items">
+          <NavItem icon={<HomeIcon />} label="Home" collapsed={isCollapsed} />
+          <NavItem icon={<ProductsIcon />} label="Products" active collapsed={isCollapsed} />
+          <NavItem icon={<SalesIcon />} label="Sales" collapsed={isCollapsed} />
+          {canReports && <NavItem icon={<ReportsIcon />} label="Reports" collapsed={isCollapsed} />}
+          <NavItem icon={<SettingsIcon />} label="Settings" collapsed={isCollapsed} />
+        </div>
+
+        {/* Sidebar Toggle & Logout at the bottom */}
+        <div className="shell__nav-footer">
+          <button
+            type="button"
+            className="shell__sidebar-toggle-btn"
+            onClick={toggleSidebar}
+            aria-label={isCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+            title={isCollapsed ? 'Expand' : 'Collapse'}
+          >
+            {isCollapsed ? '❯' : '❮'}
+          </button>
+          
+          <button
+            type="button"
+            className="shell__nav-item shell__logout-btn"
+            onClick={() => void signOut()}
+            title="Sign Out"
+          >
+            <span className="shell__nav-icon"><LogoutIcon /></span>
+            <span className="shell__nav-label">Logout</span>
+          </button>
+        </div>
+      </aside>
+
+      {/* 2. Top Bar (Header) */}
+      <header className="shell__topbar">
+        {/* Business and Screen Info */}
+        <div className="shell__title-area">
+          <h1 className="shell__business-title">REEBAPLUS POS</h1>
+          <div className="shell__subtitle">
+            Point of Sale • {operator?.business?.name ?? 'Ellipse Enterprise'}
+          </div>
+        </div>
+
+        {/* Actions Group (Search, Views, Profile, Theme) */}
         <div className="shell__actions-group">
-          {/* Custom Theme Dropdown */}
+          {/* Search bar inside header */}
+          <div className="search-bar">
+            <SearchIcon />
+            <input
+              type="text"
+              className="search-bar__input"
+              placeholder="Search"
+              value={cart.searchQuery}
+              onChange={(e) => cart.setSearchQuery(e.target.value)}
+            />
+          </div>
+
+          {/* View Dropdown */}
+          <button className="btn btn--outline shell__view-btn" type="button">
+            <EyeIcon />
+            <span>View</span>
+            <span className="dropdown-arrow">▼</span>
+          </button>
+
+          {/* Custom Theme Dropdown Icon Toggle */}
           <div className="theme-dropdown" ref={themeDropdownRef}>
             <button
-              className="theme-dropdown__toggle"
+              className="theme-dropdown__icon-toggle"
               onClick={() => setThemeDropdownOpen((o) => !o)}
               aria-expanded={themeDropdownOpen}
               aria-haspopup="listbox"
+              aria-label="Change theme"
+              title={`Theme: ${themeLabelMap[themeMode]}`}
             >
-              {themeLabelMap[themeMode]} <span className="theme-dropdown__arrow">▼</span>
+              {themeIconMap[themeMode]}
             </button>
             {themeDropdownOpen && (
               <div className="theme-dropdown__menu" role="listbox">
@@ -106,38 +260,39 @@ export function AppShell({ children }: { children: ReactNode }) {
                       setThemeDropdownOpen(false);
                     }}
                   >
-                    {themeLabelMap[mode]}
+                    <span className="theme-dropdown__item-icon">{themeIconMap[mode]}</span>
+                    <span>{themeLabelMap[mode]}</span>
                   </button>
                 ))}
               </div>
             )}
           </div>
 
-          <div className="shell__account">
-            <div style={{ textAlign: 'right' }}>
-              <div className="shell__account-name">
-                {operator?.displayName ?? 'Operator'}
+          {/* User Profile Chip */}
+          <div className="shell__account-profile">
+            <div className="shell__avatar-container">
+              <div className="shell__avatar-placeholder">
+                {firstLetter}
               </div>
+              <span className="shell__avatar-status" />
+            </div>
+            <div className="shell__account-info">
+              <div className="shell__account-name">{displayName}</div>
               <div className="shell__account-role">{roleLabel}</div>
             </div>
-            <button className="btn btn--outline" onClick={() => void signOut()}>
-              Sign out
-            </button>
           </div>
+
+          {/* Simple Sign Out Button */}
+          <button className="btn btn--outline shell__signout-btn" onClick={() => void signOut()}>
+            Sign Out
+          </button>
         </div>
       </header>
 
-      <div className="shell__body">
-        <nav className={`shell__nav${isCollapsed ? ' shell__nav--collapsed' : ''}`} aria-label="Primary">
-          <NavItem icon="🛒" label="POS" active collapsed={isCollapsed} />
-          {canInventory && <NavItem icon="📦" label="Inventory" collapsed={isCollapsed} />}
-          {canReports && <NavItem icon="📊" label="Reports" collapsed={isCollapsed} />}
-        </nav>
-
-        <main className="shell__content">
-          <div className="shell__content-inner">{children}</div>
-        </main>
-      </div>
+      {/* 3. Main Content Container */}
+      <main className="shell__content">
+        <div className="shell__content-inner">{children}</div>
+      </main>
     </div>
   );
 }
@@ -148,7 +303,7 @@ function NavItem({
   active = false,
   collapsed = false,
 }: {
-  icon: string;
+  icon: ReactNode;
   label: string;
   active?: boolean;
   collapsed?: boolean;

--- a/web-pos/src/components/shell/AppShell.tsx
+++ b/web-pos/src/components/shell/AppShell.tsx
@@ -1,56 +1,137 @@
 'use client';
 
-import type { ReactNode } from 'react';
+import { useState, useEffect, useRef, type ReactNode } from 'react';
 
 import { useSession } from '@/components/providers/SessionProvider';
 import { useCan } from '@/components/permissions/Can';
 import { PermissionKeys } from '@/lib/permissions';
+import { useTheme, type UserThemeMode } from '@/components/providers/ThemeProvider';
 
 // The responsive app shell every later slice slots its UI into. It lays out a
 // sticky top bar + a left nav rail + a max-width content column, adapting across
-// the four breakpoint bands (CSS in globals.css): a single column on phones, a
-// rail from tablet up, labelled sidebar on desktop, centred max-width on wide
-// screens.
+// the four breakpoint bands (CSS in globals.css).
 //
 // Nav items are permission-gated (hide-don't-block): an Operator only sees the
-// sections their role allows. Slice 1 ships the POS section; Inventory and
-// Reports are placeholders for #48/#51 but demonstrate the gate now.
+// sections their role allows.
 export function AppShell({ children }: { children: ReactNode }) {
   const { operator, signOut } = useSession();
+  const { themeMode, setThemeMode } = useTheme();
   const canInventory =
     useCan(PermissionKeys.stockView) || useCan(PermissionKeys.productsAdd);
   const canReports = useCan(PermissionKeys.reportsView);
 
+  const [isCollapsed, setIsCollapsed] = useState(false);
+  const [themeDropdownOpen, setThemeDropdownOpen] = useState(false);
+  const themeDropdownRef = useRef<HTMLDivElement>(null);
+
+  // Load initial sidebar state
+  useEffect(() => {
+    const stored = localStorage.getItem('sidebar-collapsed');
+    if (stored === 'true') {
+      setIsCollapsed(true);
+    }
+  }, []);
+
+  const toggleSidebar = () => {
+    setIsCollapsed((prev) => {
+      const next = !prev;
+      localStorage.setItem('sidebar-collapsed', String(next));
+      return next;
+    });
+  };
+
+  // Close dropdown on click outside
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (
+        themeDropdownRef.current &&
+        !themeDropdownRef.current.contains(event.target as Node)
+      ) {
+        setThemeDropdownOpen(false);
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
   const roleLabel = operator?.role?.name ?? operator?.role?.slug ?? 'Operator';
 
+  const themeLabelMap: Record<UserThemeMode, string> = {
+    system: '💻 System',
+    light: '☀️ Light',
+    dark: '🌙 Dark',
+  };
+
   return (
-    <div className="shell">
+    <div className={`shell${isCollapsed ? ' shell--collapsed' : ''}`}>
       <header className="shell__topbar">
         <div className="shell__brand">
+          <button
+            className="shell__sidebar-toggle"
+            onClick={toggleSidebar}
+            aria-label={isCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+          >
+            ☰
+          </button>
           <span className="shell__brand-dot" />
-          <span>Web POS</span>
+          <span className="shell__brand-text">Web POS</span>
           {operator?.business && (
             <span className="shell__business">· {operator.business.name}</span>
           )}
         </div>
-        <div className="shell__account">
-          <div style={{ textAlign: 'right' }}>
-            <div className="shell__account-name">
-              {operator?.displayName ?? 'Operator'}
-            </div>
-            <div className="shell__account-role">{roleLabel}</div>
+
+        <div className="shell__actions-group">
+          {/* Custom Theme Dropdown */}
+          <div className="theme-dropdown" ref={themeDropdownRef}>
+            <button
+              className="theme-dropdown__toggle"
+              onClick={() => setThemeDropdownOpen((o) => !o)}
+              aria-expanded={themeDropdownOpen}
+              aria-haspopup="listbox"
+            >
+              {themeLabelMap[themeMode]} <span className="theme-dropdown__arrow">▼</span>
+            </button>
+            {themeDropdownOpen && (
+              <div className="theme-dropdown__menu" role="listbox">
+                {(['light', 'dark', 'system'] as UserThemeMode[]).map((mode) => (
+                  <button
+                    key={mode}
+                    role="option"
+                    aria-selected={themeMode === mode}
+                    className={`theme-dropdown__item${
+                      themeMode === mode ? ' theme-dropdown__item--active' : ''
+                    }`}
+                    onClick={() => {
+                      setThemeMode(mode);
+                      setThemeDropdownOpen(false);
+                    }}
+                  >
+                    {themeLabelMap[mode]}
+                  </button>
+                ))}
+              </div>
+            )}
           </div>
-          <button className="btn btn--outline" onClick={() => void signOut()}>
-            Sign out
-          </button>
+
+          <div className="shell__account">
+            <div style={{ textAlign: 'right' }}>
+              <div className="shell__account-name">
+                {operator?.displayName ?? 'Operator'}
+              </div>
+              <div className="shell__account-role">{roleLabel}</div>
+            </div>
+            <button className="btn btn--outline" onClick={() => void signOut()}>
+              Sign out
+            </button>
+          </div>
         </div>
       </header>
 
       <div className="shell__body">
-        <nav className="shell__nav" aria-label="Primary">
-          <NavItem icon="🛒" label="POS" active />
-          {canInventory && <NavItem icon="📦" label="Inventory" />}
-          {canReports && <NavItem icon="📊" label="Reports" />}
+        <nav className={`shell__nav${isCollapsed ? ' shell__nav--collapsed' : ''}`} aria-label="Primary">
+          <NavItem icon="🛒" label="POS" active collapsed={isCollapsed} />
+          {canInventory && <NavItem icon="📦" label="Inventory" collapsed={isCollapsed} />}
+          {canReports && <NavItem icon="📊" label="Reports" collapsed={isCollapsed} />}
         </nav>
 
         <main className="shell__content">
@@ -65,20 +146,25 @@ function NavItem({
   icon,
   label,
   active = false,
+  collapsed = false,
 }: {
   icon: string;
   label: string;
   active?: boolean;
+  collapsed?: boolean;
 }) {
   return (
     <div
-      className={`shell__nav-item${active ? ' shell__nav-item--active' : ''}`}
+      className={`shell__nav-item${active ? ' shell__nav-item--active' : ''}${
+        collapsed ? ' shell__nav-item--collapsed' : ''
+      }`}
       aria-current={active ? 'page' : undefined}
+      title={collapsed ? label : undefined}
     >
       <span className="shell__nav-icon" aria-hidden>
         {icon}
       </span>
-      <span>{label}</span>
+      <span className="shell__nav-label">{label}</span>
     </div>
   );
 }

--- a/web-pos/src/lib/checkout.ts
+++ b/web-pos/src/lib/checkout.ts
@@ -33,6 +33,31 @@ export interface CheckoutLineInput {
 //                         amountPaidKobo is any cash part-paid now (0..net).
 export type PaymentMethod = 'cash' | 'transfer' | 'wallet' | 'credit';
 
+// A checkout method's selector group: walk-in tenders (always offered) vs the
+// registered-customer credit paths (offered only when a customer is attached).
+export type PaymentGroup = 'tender' | 'credit';
+
+// Display label + selector group for each checkout path — the single source of
+// truth the CheckoutDialog renders its segmented control from, instead of a
+// separate label map and hard-coded ['cash','transfer'] / ['wallet','credit']
+// arrays. Insertion order is the display order.
+export const paymentMethodMeta: Record<
+  PaymentMethod,
+  { label: string; group: PaymentGroup }
+> = {
+  cash: { label: 'Cash', group: 'tender' },
+  transfer: { label: 'Transfer', group: 'tender' },
+  wallet: { label: 'Pay with Credit', group: 'credit' },
+  credit: { label: 'Credit Sale', group: 'credit' },
+};
+
+// The methods in a selector group, in display order.
+export function paymentMethodsInGroup(group: PaymentGroup): PaymentMethod[] {
+  return (Object.keys(paymentMethodMeta) as PaymentMethod[]).filter(
+    (m) => paymentMethodMeta[m].group === group,
+  );
+}
+
 export interface CheckoutArgs {
   businessId: string;
   storeId: string;

--- a/web-pos/src/lib/crate.ts
+++ b/web-pos/src/lib/crate.ts
@@ -8,6 +8,7 @@
 // the read/display side — the hide-don't-block surface and the empties summary
 // the cart + receipt show.
 
+import type { Operator } from './operator';
 import type { ProductWithStock } from './types';
 
 // Whether [type] is a business that uses empty-crate features — Bar or Beer/
@@ -27,6 +28,16 @@ export function businessTracksCrates(
   tracksEmptyCrates: boolean,
 ): boolean {
   return isCrateBusiness(type) && tracksEmptyCrates;
+}
+
+// Whether THIS operator's business shows crate surfaces — the crate gate read off
+// the session operator, bundled so the checkout components (Cart, CheckoutDialog)
+// don't each repeat the same `business?.type` / `?? false` unpacking.
+export function operatorTracksCrates(operator: Operator | null): boolean {
+  return businessTracksCrates(
+    operator?.business?.type,
+    operator?.business?.tracksEmptyCrates ?? false,
+  );
 }
 
 // Whether a product carries a returnable crate deposit — a bottle with empties

--- a/web-pos/src/lib/receipt.ts
+++ b/web-pos/src/lib/receipt.ts
@@ -1,0 +1,87 @@
+// The receipt's money summary, built ONCE (Slice 2–4 follow-up, #57). Both the
+// on-screen receipt (Receipt.tsx JSX) and the printed / shared plain-text receipt
+// derive their subtotal→empties rows from `receiptRows`, so the two renderings
+// can't drift. `format` is the active-currency formatter (formatKobo bound to the
+// operator's code) supplied by the caller, keeping this module free of the
+// currency hook. Product lines render differently plain vs JSX, so they stay in
+// Receipt.tsx; this is the shared summary.
+
+import type { CheckoutResult } from './checkout';
+
+export type ReceiptRowKind = 'normal' | 'muted' | 'total';
+
+export interface ReceiptRow {
+  label: string;
+  value: string;
+  kind: ReceiptRowKind;
+}
+
+// The summary rows for a completed checkout, in display order. Rows that don't
+// apply (no discount, fully-cash sale, walk-in, no crates) are simply omitted, so
+// callers render the list as-is.
+export function receiptRows(
+  result: CheckoutResult,
+  format: (kobo: number) => string,
+): ReceiptRow[] {
+  // The amount still owed on this sale (0 unless it was a credit / partial sale).
+  const onCreditKobo = Math.max(0, result.netAmountKobo - result.amountPaidKobo);
+  const rows: ReceiptRow[] = [
+    { label: 'Subtotal', value: format(result.totalAmountKobo), kind: 'normal' },
+  ];
+  if (result.discountKobo > 0) {
+    rows.push({
+      label: 'Discount',
+      value: `−${format(result.discountKobo)}`,
+      kind: 'muted',
+    });
+  }
+  rows.push({ label: 'Total', value: format(result.netAmountKobo), kind: 'total' });
+  if (result.paymentMethod === 'wallet') {
+    rows.push({
+      label: 'Paid with credit',
+      value: format(result.netAmountKobo),
+      kind: 'muted',
+    });
+  } else {
+    rows.push({
+      label: `Paid (${result.paymentMethod})`,
+      value: format(result.tenderedKobo ?? result.amountPaidKobo),
+      kind: 'muted',
+    });
+  }
+  if ((result.changeKobo ?? 0) > 0) {
+    rows.push({ label: 'Change', value: format(result.changeKobo ?? 0), kind: 'muted' });
+  }
+  if (onCreditKobo > 0) {
+    rows.push({ label: 'On credit', value: format(onCreditKobo), kind: 'muted' });
+  }
+  if (result.customerName && result.customerBalanceKobo != null) {
+    rows.push({
+      label: 'Balance',
+      value:
+        result.customerBalanceKobo < 0
+          ? `owes ${format(-result.customerBalanceKobo)}`
+          : `${format(result.customerBalanceKobo)} credit`,
+      kind: 'muted',
+    });
+  }
+  const crateCount = result.crateCount ?? 0;
+  if (crateCount > 0) {
+    const deposit = result.crateDepositKobo ?? 0;
+    rows.push({
+      label: 'Empties (returnable)',
+      value: `${crateCount} crate${crateCount === 1 ? '' : 's'}${
+        deposit > 0 ? ` · ${format(deposit)} deposit` : ''
+      }`,
+      kind: 'muted',
+    });
+  }
+  return rows;
+}
+
+// The CSS class for a summary row, matching the receipt stylesheet.
+export function receiptRowClass(kind: ReceiptRowKind): string {
+  if (kind === 'total') return 'receipt__row receipt__row--total';
+  if (kind === 'muted') return 'receipt__row receipt__row--muted';
+  return 'receipt__row';
+}

--- a/web-pos/src/lib/theme/palettes.ts
+++ b/web-pos/src/lib/theme/palettes.ts
@@ -34,6 +34,10 @@ export interface ThemeTokens {
   success: string;
   warning: string;
   info: string;
+  glassBg: string;
+  glassBorder: string;
+  bgPatternColor: string;
+  glowOpacity: string;
 }
 
 type PaletteSet = Record<ThemeMode, ThemeTokens>;
@@ -56,6 +60,10 @@ const blue: PaletteSet = {
     success: '#10B981',
     warning: '#FFB020',
     info: '#3B82F6',
+    glassBg: 'rgba(255, 255, 255, 0.45)',
+    glassBorder: 'rgba(255, 255, 255, 0.6)',
+    bgPatternColor: 'rgba(37, 99, 235, 0.03)',
+    glowOpacity: '0.05',
   },
   dark: {
     bg: '#090D14',
@@ -72,6 +80,10 @@ const blue: PaletteSet = {
     success: '#10B981',
     warning: '#FFB020',
     info: '#3B82F6',
+    glassBg: 'rgba(17, 24, 39, 0.45)',
+    glassBorder: 'rgba(255, 255, 255, 0.08)',
+    bgPatternColor: 'rgba(255, 255, 255, 0.025)',
+    glowOpacity: '0.18',
   },
 };
 
@@ -91,6 +103,10 @@ const amber: PaletteSet = {
     success: '#30D158',
     warning: '#FFB020',
     info: '#3B82F6',
+    glassBg: 'rgba(255, 255, 255, 0.45)',
+    glassBorder: 'rgba(255, 255, 255, 0.6)',
+    bgPatternColor: 'rgba(217, 119, 6, 0.03)',
+    glowOpacity: '0.05',
   },
   dark: {
     bg: '#080C12',
@@ -107,6 +123,10 @@ const amber: PaletteSet = {
     success: '#30D158',
     warning: '#FFB020',
     info: '#3B82F6',
+    glassBg: 'rgba(14, 20, 32, 0.45)',
+    glassBorder: 'rgba(255, 255, 255, 0.07)',
+    bgPatternColor: 'rgba(255, 255, 255, 0.02)',
+    glowOpacity: '0.15',
   },
 };
 
@@ -126,6 +146,10 @@ const purple: PaletteSet = {
     success: '#34D399',
     warning: '#FBBF24',
     info: '#8B5CF6',
+    glassBg: 'rgba(255, 255, 255, 0.45)',
+    glassBorder: 'rgba(255, 255, 255, 0.6)',
+    bgPatternColor: 'rgba(124, 58, 237, 0.03)',
+    glowOpacity: '0.05',
   },
   dark: {
     bg: '#0B0D10',
@@ -142,6 +166,10 @@ const purple: PaletteSet = {
     success: '#34D399',
     warning: '#FBBF24',
     info: '#8B5CF6',
+    glassBg: 'rgba(21, 23, 27, 0.45)',
+    glassBorder: 'rgba(255, 255, 255, 0.07)',
+    bgPatternColor: 'rgba(255, 255, 255, 0.02)',
+    glowOpacity: '0.16',
   },
 };
 
@@ -161,6 +189,10 @@ const green: PaletteSet = {
     success: '#22C55E',
     warning: '#FFB020',
     info: '#3B82F6',
+    glassBg: 'rgba(255, 255, 255, 0.45)',
+    glassBorder: 'rgba(255, 255, 255, 0.6)',
+    bgPatternColor: 'rgba(21, 128, 61, 0.03)',
+    glowOpacity: '0.05',
   },
   dark: {
     bg: '#0B0D10',
@@ -177,6 +209,10 @@ const green: PaletteSet = {
     success: '#22C55E',
     warning: '#FFB020',
     info: '#3B82F6',
+    glassBg: 'rgba(21, 23, 27, 0.45)',
+    glassBorder: 'rgba(255, 255, 255, 0.07)',
+    bgPatternColor: 'rgba(255, 255, 255, 0.02)',
+    glowOpacity: '0.15',
   },
 };
 
@@ -196,6 +232,10 @@ const bw: PaletteSet = {
     success: '#22C55E',
     warning: '#FFB020',
     info: '#3B82F6',
+    glassBg: 'rgba(255, 255, 255, 0.45)',
+    glassBorder: 'rgba(255, 255, 255, 0.6)',
+    bgPatternColor: 'rgba(17, 17, 17, 0.03)',
+    glowOpacity: '0.04',
   },
   dark: {
     bg: '#000000',
@@ -212,6 +252,10 @@ const bw: PaletteSet = {
     success: '#22C55E',
     warning: '#FFB020',
     info: '#3B82F6',
+    glassBg: 'rgba(18, 18, 18, 0.45)',
+    glassBorder: 'rgba(255, 255, 255, 0.08)',
+    bgPatternColor: 'rgba(255, 255, 255, 0.025)',
+    glowOpacity: '0.12',
   },
 };
 


### PR DESCRIPTION
Closes #58
Closes #57

Web POS visual redesign plus the checkout-UI cleanup that was developed alongside it (they share `Cart.tsx`, so they ship together).

**#58 — UI redesign (PRD `docs/prd/web-pos-ui-redesign.md`, ADR `docs/adr/0013`):**
- Stateful theme selection via `ThemeProvider` + `palettes.ts`, new `globals.css` design tokens
- Collapsible sidebar in `AppShell`
- Product cards with image container + emoji placeholders
- POS layout/visuals aligned to the reference design screenshot

**#57 — checkout-UI de-duplication (quality-only, no behavior change):**
- Shared `receiptRows()` (`web-pos/src/lib/receipt.ts`) — one source for on-screen + plain-text receipts (fixes drifted empties wording)
- `paymentMethodMeta` map replacing hard-coded tender/credit arrays
- `operatorTracksCrates()` helper de-duplicating the crate-gate check

Gate: typecheck + `next build` green.