### PR TITLE
Web POS Slice 6 — Inventory: add/edit product + receive stock (#48)

### DIFF
--- a/BUILD_LOG.md
+++ b/BUILD_LOG.md
@@ -2,6 +2,30 @@
 
 ---
 
+## 2026-07-05 — Web POS Slice 6 code-review fixes (issue #48)
+
+**What changed.** Three fixes from the `/code-review` of PR #62; no new surface.
+Verified: web `tsc --noEmit` + `next build` green; the cost-0 no-clobber and the
+positive-cost update both re-checked live in a rolled-back CEO transaction.
+
+- **`receive_stock` cost-0 scalar clobber (correctness).** A receive line with cost 0
+  (an uncosted delivery) was unconditionally writing `products.buying_price_kobo = 0`,
+  wiping the product's existing scalar cost. Now `buying_price_kobo` only moves on a
+  costed line (`CASE WHEN v_buy > 0 THEN v_buy ELSE buying_price_kobo END`), matching
+  the mobile "oldest COSTED batch, no-clobber" rule. Batch handling was already right
+  (the uncosted batch is still created).
+- **`add_product` idempotency tenant-scoping.** The replay existence check now filters
+  `AND business_id = p_business_id` (like `update_product`), so a UUID collision with
+  another tenant's product can't short-circuit the insert or return a foreign row.
+- **Store selector (AC "opening stock, store").** The Add-Product and Receive-Stock
+  dialogs hardcoded `stores[0]`; they now render a store `<select>` (shown when the
+  business has more than one store) so a multi-store manager picks the target store.
+
+Migration `0140` was edited in place (not yet merged) and both functions were
+re-deployed live via `CREATE OR REPLACE`.
+
+---
+
 ## 2026-07-05 — Web POS Slice 6: Inventory add/edit + receive stock (issue #48)
 
 **What changed.** The Web POS gained inventory management — add/edit products and

--- a/BUILD_LOG.md
+++ b/BUILD_LOG.md
@@ -2,6 +2,42 @@
 
 ---
 
+## 2026-07-05 — Web POS Slice 6: Inventory add/edit + receive stock (issue #48)
+
+**What changed.** The Web POS gained inventory management — add/edit products and
+receive supplier deliveries — behind three new server-authoritative RPCs, with the
+Cost Batch producer rule pinned across Dart and SQL by a new golden dimension.
+Verified: Dart golden green (6/6), `add_product`/`receive_stock` smoke-tested live
+against a real CEO in a rolled-back transaction, web `tsc --noEmit` + `next build`
+green.
+
+- **Migration `0140_web_inventory_rpcs.sql` (deployed).** `add_product` (product +
+  opening stock straight to inventory + the opening Cost Batch, no supplier),
+  `update_product` (details/prices; stock + batches untouched), and `receive_stock`
+  (supplier invoice debit + optional payment credit + per line: inventory upsert,
+  price persistence, a stock movement, and a receipt-dated Cost Batch). SQL twins of
+  the mobile Dart path (`CostBatchesDao.recordInflowBatch`, `InventoryDao.adjustStock`,
+  `SupplierAccountService`); each reuses the 0135 `caller_has_permission` /
+  `_assert_caller_owns_business` helpers and re-checks the permission server-side.
+  A receive line mirrors `adjustStock`'s default path — one `stock_adjustments` row
+  + a `stock_transactions` row referencing it (the `adjustment_id` ref that satisfies
+  the exactly-one-of-4-refs CHECK). Idempotent on the client id (product / receipt).
+- **Batch-creation Golden Suite (`test/golden/inventory_scenario.dart` + fixtures,
+  two runners).** A second golden dimension beside checkout: the rule "one inflow ⇒
+  one fresh batch {qty_remaining=qty_original=quantity, cost=max(cost,0), received_at},
+  never merged; cost 0 ⇒ uncosted" is run against the Dart producers
+  (`inventory_dart_dao_golden_test.dart`) and the SQL RPCs
+  (`web_inventory_golden_test.dart`, Tier-2). Covers costed/uncosted/no-opening-stock
+  Add Product and receive with existing batch / partial payment / uncosted lines.
+- **Web UI (`web-pos/src/components/inventory/*`, `lib/inventory.ts`).** An Inventory
+  view (responsive table, low-stock highlight), an add/edit Product dialog, and a
+  Receive Stock dialog (supplier + dated lines + invoice total + payment). Sidebar
+  navigation is now a client-side view switch (`NavProvider`); actions are
+  hide-don't-block on `products.add` / `stock.received`\|`stock.add`. Money via the
+  business-currency helpers; prices entered in major units, stored as `*_kobo`.
+
+---
+
 ## 2026-07-05 — Web POS checkout-UI cleanup (issue #57)
 
 **What changed.** Quality-only de-duplication of the Slice 2–4 web checkout; no

--- a/supabase/migrations/0140_web_inventory_rpcs.sql
+++ b/supabase/migrations/0140_web_inventory_rpcs.sql
@@ -1,0 +1,496 @@
+-- 0140_web_inventory_rpcs.sql
+--
+-- Reebaplus — Web POS Slice 6 (issue #48). The server-authoritative inventory
+-- write RPCs for the online web client: add_product / update_product (catalogue
+-- writes incl. the opening Cost Batch) and receive_stock (a supplier delivery:
+-- stock increase + supplier invoice/payment + a receipt-dated Cost Batch).
+--
+-- WHY RPCs (ADR 0008): the web is online-first and never writes tenant rows via
+-- PostgREST — each money-write is one atomic SECURITY DEFINER transaction behind
+-- RLS, enforcing the caller's permission server-side (defence in depth; the web
+-- also hides the action). Amounts are *_kobo BIGINT end to end (0130).
+--
+-- TWO IMPLEMENTATIONS, ONE CONTRACT (ADR 0009): these are the SQL twins of the
+-- mobile Dart inventory path —
+--   * add_product   ↔ CatalogDao add-product + CostBatchesDao.recordInflowBatch
+--   * receive_stock ↔ ReceiveStockService.confirmReceipt (InventoryDao.adjustStock
+--                     + SupplierAccountService + CostBatchesDao.recordInflowBatch)
+-- The Cost Batch producer rule is pinned identical to Dart by the batch-creation
+-- Golden-Scenario Suite (test/golden/inventory_scenario.dart), which runs the same
+-- fixtures against both. The rule (F1/F6, ADR 0005): one inflow ⇒ one fresh batch
+-- {qty_remaining = qty_original = quantity, cost_kobo = GREATEST(cost, 0),
+-- received_at}. A batch is NEVER merged with another; cost 0 ⇒ an UNCOSTED batch.
+--
+-- ADD PRODUCT vs RECEIVE STOCK (ADR 0005/0006): Add Product writes opening stock
+-- STRAIGHT to inventory with NO supplier/invoice/payable and creates the opening
+-- Cost Batch. Receive Stock logs a delivery — it posts the supplier invoice (a
+-- debit), an optional payment (a credit), a stock movement per line, and a
+-- receipt-dated Cost Batch at the delivery cost.
+--
+-- STOCK MOVEMENT PARITY: a receive line mirrors mobile InventoryDao.adjustStock's
+-- default path — one stock_adjustments row (reason 'Stock received') + one
+-- stock_transactions row referencing it (movement_type 'adjustment', the
+-- adjustment_id ref that satisfies the exactly-one-of-4-refs CHECK). Add Product's
+-- opening stock is an opening balance, not a movement, so it writes no
+-- stock_transactions row (matches the Dart opening-stock path).
+--
+-- DEPLOY ORDER: after 0132 (cost_batches), 0102 (supplier_ledger_entries) and
+-- 0135 (the caller_has_permission / _assert_caller_owns_business helpers this
+-- reuses). Additive server logic — inert until called by the web client.
+
+BEGIN;
+
+-- ─── 1. add_product — create a product + opening stock + opening Cost Batch ───
+--
+-- Idempotent on p_product_id (the client-minted UUID): a replay returns the
+-- existing product without re-applying inventory / the opening batch.
+CREATE OR REPLACE FUNCTION public.add_product(
+  p_business_id           uuid,
+  p_product_id            uuid,        -- idempotency key (client UUID)
+  p_store_id              uuid,
+  p_name                  text,
+  p_category_id           uuid    DEFAULT NULL,
+  p_unit                  text    DEFAULT 'Piece',
+  p_size                  text    DEFAULT NULL,
+  p_retailer_price_kobo   bigint  DEFAULT 0,
+  p_wholesaler_price_kobo bigint  DEFAULT 0,
+  p_buying_price_kobo     bigint  DEFAULT 0,   -- opening batch cost (0 ⇒ uncosted)
+  p_opening_stock         int     DEFAULT 0,
+  p_track_empties         boolean DEFAULT false,
+  p_manufacturer_id       uuid    DEFAULT NULL,
+  p_low_stock_threshold   int     DEFAULT 5
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+DECLARE
+  v_now        timestamptz := now();
+  v_actor_id   uuid;
+  v_existing   boolean;
+  v_product    jsonb;
+  v_inv_id     uuid;
+  v_batch_id   uuid;
+  v_cost       bigint := GREATEST(COALESCE(p_buying_price_kobo, 0), 0);
+BEGIN
+  PERFORM public._assert_caller_owns_business(p_business_id);
+
+  IF NOT public.caller_has_permission(p_business_id, 'products.add') THEN
+    RAISE EXCEPTION 'permission_denied: products.add'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  IF p_product_id IS NULL THEN
+    RAISE EXCEPTION 'product_id_required' USING ERRCODE = 'invalid_parameter_value';
+  END IF;
+  IF p_store_id IS NULL THEN
+    RAISE EXCEPTION 'store_id_required' USING ERRCODE = 'invalid_parameter_value';
+  END IF;
+  IF p_name IS NULL OR btrim(p_name) = '' THEN
+    RAISE EXCEPTION 'name_required' USING ERRCODE = 'invalid_parameter_value';
+  END IF;
+  IF COALESCE(p_opening_stock, 0) < 0 THEN
+    RAISE EXCEPTION 'opening_stock_must_be_non_negative'
+      USING ERRCODE = 'invalid_parameter_value';
+  END IF;
+
+  -- Idempotent replay.
+  SELECT true INTO v_existing FROM public.products WHERE id = p_product_id;
+  IF v_existing THEN
+    SELECT to_jsonb(p.*) INTO v_product FROM public.products p WHERE p.id = p_product_id;
+    RETURN jsonb_build_object('product', v_product, 'replayed', true);
+  END IF;
+
+  SELECT id INTO v_actor_id FROM public.users WHERE auth_user_id = auth.uid() LIMIT 1;
+
+  INSERT INTO public.products (
+    id, business_id, category_id, manufacturer_id, name, unit, size,
+    retailer_price_kobo, wholesaler_price_kobo, buying_price_kobo,
+    track_empties, low_stock_threshold, is_available, is_deleted,
+    created_at, last_updated_at
+  )
+  VALUES (
+    p_product_id, p_business_id, p_category_id, p_manufacturer_id, btrim(p_name),
+    COALESCE(p_unit, 'Piece'), p_size,
+    COALESCE(p_retailer_price_kobo, 0), COALESCE(p_wholesaler_price_kobo, 0), v_cost,
+    COALESCE(p_track_empties, false), COALESCE(p_low_stock_threshold, 5), true, false,
+    v_now, v_now
+  );
+
+  -- Opening stock → straight to inventory (an opening balance, not a movement:
+  -- no supplier/invoice, no stock_transactions row) + the opening Cost Batch.
+  IF COALESCE(p_opening_stock, 0) > 0 THEN
+    v_inv_id := gen_random_uuid();
+    INSERT INTO public.inventory (
+      id, business_id, product_id, store_id, quantity, created_at, last_updated_at
+    )
+    VALUES (
+      v_inv_id, p_business_id, p_product_id, p_store_id, p_opening_stock, v_now, v_now
+    );
+
+    v_batch_id := gen_random_uuid();
+    INSERT INTO public.cost_batches (
+      id, business_id, product_id, store_id,
+      qty_remaining, qty_original, cost_kobo, received_at, created_at, last_updated_at
+    )
+    VALUES (
+      v_batch_id, p_business_id, p_product_id, p_store_id,
+      p_opening_stock, p_opening_stock, v_cost, v_now, v_now, v_now
+    );
+  END IF;
+
+  INSERT INTO public.activity_logs (
+    id, business_id, user_id, action, description, product_id, store_id,
+    entity_type, entity_id, created_at, last_updated_at
+  )
+  VALUES (
+    gen_random_uuid(), p_business_id, v_actor_id, 'product.created',
+    'Added product ' || btrim(p_name)
+      || CASE WHEN COALESCE(p_opening_stock, 0) > 0
+              THEN ' with opening stock ' || p_opening_stock::text ELSE '' END,
+    p_product_id, p_store_id, 'product', p_product_id, v_now, v_now
+  );
+
+  SELECT to_jsonb(p.*) INTO v_product FROM public.products p WHERE p.id = p_product_id;
+  RETURN jsonb_build_object(
+    'product',    v_product,
+    'batch_id',   v_batch_id,
+    'replayed',   false
+  );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.add_product(uuid, uuid, uuid, text, uuid, text, text, bigint, bigint, bigint, int, boolean, uuid, int) FROM public;
+GRANT EXECUTE ON FUNCTION public.add_product(uuid, uuid, uuid, text, uuid, text, text, bigint, bigint, bigint, int, boolean, uuid, int)
+  TO authenticated, service_role;
+
+
+-- ─── 2. update_product — edit catalogue details / prices ─────────────────────
+--
+-- Edits the product's mutable fields only. Editing buying_price_kobo updates the
+-- scalar display cost; it does NOT retroactively re-cost historical batches (that
+-- is the recost family 0133) — a new cost applies to future inflows. Inventory
+-- and Cost Batches are untouched (an edit is not a stock movement).
+CREATE OR REPLACE FUNCTION public.update_product(
+  p_business_id           uuid,
+  p_product_id            uuid,
+  p_name                  text    DEFAULT NULL,
+  p_category_id           uuid    DEFAULT NULL,
+  p_unit                  text    DEFAULT NULL,
+  p_size                  text    DEFAULT NULL,
+  p_retailer_price_kobo   bigint  DEFAULT NULL,
+  p_wholesaler_price_kobo bigint  DEFAULT NULL,
+  p_buying_price_kobo     bigint  DEFAULT NULL,
+  p_track_empties         boolean DEFAULT NULL,
+  p_manufacturer_id       uuid    DEFAULT NULL,
+  p_low_stock_threshold   int     DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+DECLARE
+  v_now      timestamptz := now();
+  v_actor_id uuid;
+  v_product  jsonb;
+  v_found    boolean;
+BEGIN
+  PERFORM public._assert_caller_owns_business(p_business_id);
+
+  IF NOT public.caller_has_permission(p_business_id, 'products.add') THEN
+    RAISE EXCEPTION 'permission_denied: products.add'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  IF p_product_id IS NULL THEN
+    RAISE EXCEPTION 'product_id_required' USING ERRCODE = 'invalid_parameter_value';
+  END IF;
+
+  SELECT true INTO v_found
+    FROM public.products
+   WHERE id = p_product_id AND business_id = p_business_id;
+  IF NOT v_found THEN
+    RAISE EXCEPTION 'product_not_found' USING ERRCODE = 'no_data_found';
+  END IF;
+
+  SELECT id INTO v_actor_id FROM public.users WHERE auth_user_id = auth.uid() LIMIT 1;
+
+  -- COALESCE keeps a column unchanged when its param is NULL (partial update).
+  UPDATE public.products
+     SET name                  = COALESCE(NULLIF(btrim(p_name), ''), name),
+         category_id           = COALESCE(p_category_id, category_id),
+         unit                  = COALESCE(p_unit, unit),
+         size                  = COALESCE(p_size, size),
+         retailer_price_kobo   = COALESCE(p_retailer_price_kobo, retailer_price_kobo),
+         wholesaler_price_kobo = COALESCE(p_wholesaler_price_kobo, wholesaler_price_kobo),
+         buying_price_kobo     = COALESCE(p_buying_price_kobo, buying_price_kobo),
+         track_empties         = COALESCE(p_track_empties, track_empties),
+         manufacturer_id       = COALESCE(p_manufacturer_id, manufacturer_id),
+         low_stock_threshold   = COALESCE(p_low_stock_threshold, low_stock_threshold),
+         last_updated_at       = v_now
+   WHERE id = p_product_id AND business_id = p_business_id;
+
+  INSERT INTO public.activity_logs (
+    id, business_id, user_id, action, description, product_id,
+    entity_type, entity_id, created_at, last_updated_at
+  )
+  VALUES (
+    gen_random_uuid(), p_business_id, v_actor_id, 'product.updated',
+    'Updated product details', p_product_id, 'product', p_product_id, v_now, v_now
+  );
+
+  SELECT to_jsonb(p.*) INTO v_product FROM public.products p WHERE p.id = p_product_id;
+  RETURN jsonb_build_object('product', v_product);
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.update_product(uuid, uuid, text, uuid, text, text, bigint, bigint, bigint, boolean, uuid, int) FROM public;
+GRANT EXECUTE ON FUNCTION public.update_product(uuid, uuid, text, uuid, text, text, bigint, bigint, bigint, boolean, uuid, int)
+  TO authenticated, service_role;
+
+
+-- ─── 3. receive_stock — log a supplier delivery ──────────────────────────────
+--
+-- p_lines : [{ "product_id": <uuid>, "quantity": <int>, "buying_price_kobo": <bigint>,
+--              "retailer_price_kobo": <bigint?>, "wholesaler_price_kobo": <bigint?> }, ...]
+--
+-- One receipt = one supplier, all-or-nothing. Posts: the supplier invoice (debit),
+-- an optional payment (credit), and per line — inventory increase, updated prices,
+-- a stock movement (adjustment), and a receipt-dated Cost Batch at the line cost.
+--
+-- Idempotent on p_receipt_id: the summary activity_logs row is written with
+-- id = p_receipt_id, so a replay short-circuits before any side effect.
+CREATE OR REPLACE FUNCTION public.receive_stock(
+  p_business_id      uuid,
+  p_receipt_id       uuid,          -- idempotency key (client UUID)
+  p_supplier_id      uuid,
+  p_store_id         uuid,
+  p_lines            jsonb,
+  p_received_at      timestamptz DEFAULT now(),
+  p_amount_paid_kobo bigint      DEFAULT 0,
+  p_payment_method   text        DEFAULT 'cash',
+  p_note             text        DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+DECLARE
+  v_now         timestamptz := now();
+  v_received_at timestamptz := COALESCE(p_received_at, v_now);
+  v_actor_id    uuid;
+  v_existing    boolean;
+  v_invoice_tot bigint;
+  v_units       int;
+  v_line        jsonb;
+  v_product_id  uuid;
+  v_qty         int;
+  v_buy         bigint;
+  v_retail      bigint;
+  v_wholesale   bigint;
+  v_adj_id      uuid;
+  v_inv_id      uuid;
+  v_batch_id    uuid;
+  v_new_qty     int;
+  v_pay         bigint := GREATEST(COALESCE(p_amount_paid_kobo, 0), 0);
+  v_method      text   := COALESCE(p_payment_method, 'cash');
+  v_inv_after   jsonb  := '[]'::jsonb;
+  v_batch_ids   jsonb  := '[]'::jsonb;
+BEGIN
+  PERFORM public._assert_caller_owns_business(p_business_id);
+
+  -- Receive is granted to the stock-add / receive roles (a stock keeper adds qty
+  -- directly on this flow, by design) as well as anyone who can add products.
+  IF NOT (public.caller_has_permission(p_business_id, 'stock.received')
+       OR public.caller_has_permission(p_business_id, 'stock.add')
+       OR public.caller_has_permission(p_business_id, 'products.add')) THEN
+    RAISE EXCEPTION 'permission_denied: stock.received'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  IF p_receipt_id IS NULL THEN
+    RAISE EXCEPTION 'receipt_id_required' USING ERRCODE = 'invalid_parameter_value';
+  END IF;
+  IF p_supplier_id IS NULL THEN
+    RAISE EXCEPTION 'supplier_id_required' USING ERRCODE = 'invalid_parameter_value';
+  END IF;
+  IF p_store_id IS NULL THEN
+    RAISE EXCEPTION 'store_id_required' USING ERRCODE = 'invalid_parameter_value';
+  END IF;
+  IF jsonb_typeof(p_lines) <> 'array' OR jsonb_array_length(p_lines) = 0 THEN
+    RAISE EXCEPTION 'lines_required' USING ERRCODE = 'invalid_parameter_value';
+  END IF;
+  IF v_method NOT IN ('cash', 'transfer', 'pos', 'other') THEN
+    RAISE EXCEPTION 'payment_method_invalid' USING ERRCODE = 'invalid_parameter_value';
+  END IF;
+
+  -- Idempotent replay (the summary log row IS the receipt marker).
+  SELECT true INTO v_existing FROM public.activity_logs WHERE id = p_receipt_id;
+  IF v_existing THEN
+    RETURN jsonb_build_object('replayed', true);
+  END IF;
+
+  SELECT id INTO v_actor_id FROM public.users WHERE auth_user_id = auth.uid() LIMIT 1;
+
+  SELECT
+    COALESCE(SUM((l->>'quantity')::int * GREATEST((l->>'buying_price_kobo')::bigint, 0)), 0),
+    COALESCE(SUM((l->>'quantity')::int), 0)
+  INTO v_invoice_tot, v_units
+  FROM jsonb_array_elements(p_lines) AS l;
+
+  -- 1. Supplier invoice — a debit (goods received; we now owe the supplier).
+  --    Skip a zero-value invoice (stock/batches still post).
+  IF v_invoice_tot > 0 THEN
+    INSERT INTO public.supplier_ledger_entries (
+      id, business_id, supplier_id, store_id, type, amount_kobo, signed_amount_kobo,
+      reference_type, activity_date, reference_note, performed_by, created_at, last_updated_at
+    )
+    VALUES (
+      gen_random_uuid(), p_business_id, p_supplier_id, p_store_id, 'debit',
+      v_invoice_tot, -v_invoice_tot, 'invoice', v_received_at, p_note, v_actor_id, v_now, v_now
+    );
+  END IF;
+
+  -- 2. Optional payment — a credit (money paid to the supplier).
+  IF v_pay > 0 THEN
+    INSERT INTO public.supplier_ledger_entries (
+      id, business_id, supplier_id, store_id, type, amount_kobo, signed_amount_kobo,
+      reference_type, payment_method, activity_date, reference_note, performed_by,
+      created_at, last_updated_at
+    )
+    VALUES (
+      gen_random_uuid(), p_business_id, p_supplier_id, p_store_id, 'credit',
+      v_pay, v_pay, 'payment_' || v_method, v_method, v_received_at,
+      COALESCE(p_note, 'Payment for received stock'), v_actor_id, v_now, v_now
+    );
+  END IF;
+
+  -- 3. Per line: inventory increase + prices + stock movement + Cost Batch.
+  FOR v_line IN SELECT * FROM jsonb_array_elements(p_lines) LOOP
+    v_product_id := (v_line->>'product_id')::uuid;
+    v_qty        := (v_line->>'quantity')::int;
+    v_buy        := GREATEST(COALESCE((v_line->>'buying_price_kobo')::bigint, 0), 0);
+    v_retail     := NULLIF(v_line->>'retailer_price_kobo', '')::bigint;
+    v_wholesale  := NULLIF(v_line->>'wholesaler_price_kobo', '')::bigint;
+
+    IF v_product_id IS NULL THEN
+      RAISE EXCEPTION 'product_id_required_per_line' USING ERRCODE = 'invalid_parameter_value';
+    END IF;
+    IF v_qty IS NULL OR v_qty <= 0 THEN
+      RAISE EXCEPTION 'line_quantity_must_be_positive' USING ERRCODE = 'invalid_parameter_value';
+    END IF;
+
+    -- Inventory upsert (create the row or add to it) — mirrors adjustStock's
+    -- ON CONFLICT increment.
+    INSERT INTO public.inventory (
+      id, business_id, product_id, store_id, quantity, created_at, last_updated_at
+    )
+    VALUES (
+      gen_random_uuid(), p_business_id, v_product_id, p_store_id, v_qty, v_now, v_now
+    )
+    ON CONFLICT (business_id, product_id, store_id)
+      DO UPDATE SET quantity = public.inventory.quantity + EXCLUDED.quantity,
+                    last_updated_at = v_now
+    RETURNING quantity INTO v_new_qty;
+
+    -- Persist the delivery's prices onto the product (mirrors updateProductPrices):
+    -- the buying price is always the receipt cost; retail/wholesale only when sent.
+    UPDATE public.products
+       SET buying_price_kobo     = v_buy,
+           retailer_price_kobo   = COALESCE(v_retail, retailer_price_kobo),
+           wholesaler_price_kobo = COALESCE(v_wholesale, wholesaler_price_kobo),
+           last_updated_at       = v_now
+     WHERE id = v_product_id AND business_id = p_business_id;
+
+    -- Stock movement (adjustment): the stock_adjustments row + the
+    -- stock_transactions row referencing it (satisfies the one-ref CHECK).
+    v_adj_id := gen_random_uuid();
+    INSERT INTO public.stock_adjustments (
+      id, business_id, product_id, store_id, quantity_diff, reason, performed_by,
+      created_at, last_updated_at
+    )
+    VALUES (
+      v_adj_id, p_business_id, v_product_id, p_store_id, v_qty, 'Stock received',
+      v_actor_id, v_now, v_now
+    );
+    INSERT INTO public.stock_transactions (
+      id, business_id, product_id, location_id, quantity_delta, movement_type,
+      adjustment_id, performed_by, created_at, last_updated_at
+    )
+    VALUES (
+      gen_random_uuid(), p_business_id, v_product_id, p_store_id, v_qty, 'adjustment',
+      v_adj_id, v_actor_id, v_now, v_now
+    );
+
+    -- Receipt-dated Cost Batch at the line's buying price (0 ⇒ uncosted). One
+    -- inflow ⇒ one fresh batch, never merged (F6 / ADR 0005).
+    v_batch_id := gen_random_uuid();
+    INSERT INTO public.cost_batches (
+      id, business_id, product_id, store_id,
+      qty_remaining, qty_original, cost_kobo, received_at, created_at, last_updated_at
+    )
+    VALUES (
+      v_batch_id, p_business_id, v_product_id, p_store_id,
+      v_qty, v_qty, v_buy, v_received_at, v_now, v_now
+    );
+
+    v_inv_after := v_inv_after || jsonb_build_object(
+      'product_id', v_product_id, 'store_id', p_store_id, 'quantity', v_new_qty);
+    v_batch_ids := v_batch_ids || to_jsonb(v_batch_id);
+  END LOOP;
+
+  -- 4. Summary activity log — id = p_receipt_id is the idempotency marker.
+  INSERT INTO public.activity_logs (
+    id, business_id, user_id, action, description, store_id,
+    entity_type, entity_id, created_at, last_updated_at
+  )
+  VALUES (
+    p_receipt_id, p_business_id, v_actor_id, 'stock.received',
+    'Received ' || jsonb_array_length(p_lines)::text || ' product(s), '
+      || v_units::text || ' unit(s)',
+    p_store_id, 'supplier', p_supplier_id, v_now, v_now
+  );
+
+  RETURN jsonb_build_object(
+    'receipt_id',       p_receipt_id,
+    'invoice_total_kobo', v_invoice_tot,
+    'amount_paid_kobo', v_pay,
+    'units',            v_units,
+    'inventory_after',  v_inv_after,
+    'batch_ids',        v_batch_ids,
+    'replayed',         false
+  );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.receive_stock(uuid, uuid, uuid, uuid, jsonb, timestamptz, bigint, text, text) FROM public;
+GRANT EXECUTE ON FUNCTION public.receive_stock(uuid, uuid, uuid, uuid, jsonb, timestamptz, bigint, text, text)
+  TO authenticated, service_role;
+
+COMMIT;
+
+-- =============================================================================
+-- Verification (paste into the SQL editor while authenticated as a business user):
+--
+--   1. Functions exist:
+--        SELECT proname FROM pg_proc
+--         WHERE pronamespace = 'public'::regnamespace
+--           AND proname IN ('add_product','update_product','receive_stock')
+--         ORDER BY proname;   -- expect 3 rows
+--
+--   2. Tenant guard fires for another business:
+--        SELECT public.add_product('<other-biz>', gen_random_uuid(), '<store>', 'X');
+--        -- expect ERROR: tenant_mismatch
+--
+--   3. add_product with opening stock 10 @ 500 creates products + inventory(10)
+--      + one cost_batches row {qty_remaining 10, qty_original 10, cost_kobo 500}.
+--
+--   4. receive_stock posts a supplier invoice (debit), increments inventory, and
+--      pushes one receipt-dated cost_batches row per line at the delivery cost.
+--
+--   5. Idempotent replay: a second add_product / receive_stock with the same id
+--      returns replayed=true and applies nothing new.
+-- =============================================================================

--- a/supabase/migrations/0140_web_inventory_rpcs.sql
+++ b/supabase/migrations/0140_web_inventory_rpcs.sql
@@ -95,10 +95,12 @@ BEGIN
       USING ERRCODE = 'invalid_parameter_value';
   END IF;
 
-  -- Idempotent replay.
-  SELECT true INTO v_existing FROM public.products WHERE id = p_product_id;
+  -- Idempotent replay (tenant-scoped: never short-circuit on a foreign row).
+  SELECT true INTO v_existing
+    FROM public.products WHERE id = p_product_id AND business_id = p_business_id;
   IF v_existing THEN
-    SELECT to_jsonb(p.*) INTO v_product FROM public.products p WHERE p.id = p_product_id;
+    SELECT to_jsonb(p.*) INTO v_product
+      FROM public.products p WHERE p.id = p_product_id AND p.business_id = p_business_id;
     RETURN jsonb_build_object('product', v_product, 'replayed', true);
   END IF;
 
@@ -397,9 +399,11 @@ BEGIN
     RETURNING quantity INTO v_new_qty;
 
     -- Persist the delivery's prices onto the product (mirrors updateProductPrices):
-    -- the buying price is always the receipt cost; retail/wholesale only when sent.
+    -- a costed line updates the scalar buying price; a 0-cost (uncosted) line must
+    -- NOT clobber the existing scalar cost (mirrors the mobile "oldest COSTED batch,
+    -- no-clobber" rule). Retail/wholesale only when sent.
     UPDATE public.products
-       SET buying_price_kobo     = v_buy,
+       SET buying_price_kobo     = CASE WHEN v_buy > 0 THEN v_buy ELSE buying_price_kobo END,
            retailer_price_kobo   = COALESCE(v_retail, retailer_price_kobo),
            wholesaler_price_kobo = COALESCE(v_wholesale, wholesaler_price_kobo),
            last_updated_at       = v_now

--- a/test/golden/fixtures/inventory_scenarios.json
+++ b/test/golden/fixtures/inventory_scenarios.json
@@ -1,0 +1,144 @@
+{
+  "_comment": "Batch-creation golden fixtures (issue #48). Run against the Dart producers (CostBatchesDao.recordInflowBatch + SupplierAccountService) AND the SQL RPCs add_product/receive_stock (0140). The rule: one inflow => one fresh Cost Batch {qty_remaining=qty_original=quantity, cost_kobo=max(cost,0), received_at}, never merged; cost 0 => uncosted. Add Product => opening batch, no supplier. Receive Stock => receipt-dated batch + supplier invoice(debit) + optional payment(credit). add_product batches key on the sentinel 'opening' (received_at=now); receive batches key on their controlled date.",
+  "scenarios": [
+    {
+      "name": "add product with costed opening stock",
+      "operation": "add_product",
+      "product": {
+        "name": "Cola 50cl",
+        "unit": "Bottle",
+        "retailer_price_kobo": 60000,
+        "wholesaler_price_kobo": 55000,
+        "buying_price_kobo": 50000
+      },
+      "opening_stock": 12,
+      "expected": {
+        "batches": [
+          { "received_at": "opening", "qty_remaining": 12, "qty_original": 12, "cost_kobo": 50000 }
+        ],
+        "inventory_after": 12,
+        "supplier_balance_after_kobo": null
+      }
+    },
+    {
+      "name": "add product with uncosted opening stock (cost 0)",
+      "operation": "add_product",
+      "product": {
+        "name": "Sachet Water",
+        "unit": "Sachet",
+        "retailer_price_kobo": 5000,
+        "wholesaler_price_kobo": 4000,
+        "buying_price_kobo": 0
+      },
+      "opening_stock": 8,
+      "expected": {
+        "batches": [
+          { "received_at": "opening", "qty_remaining": 8, "qty_original": 8, "cost_kobo": 0 }
+        ],
+        "inventory_after": 8,
+        "supplier_balance_after_kobo": null
+      }
+    },
+    {
+      "name": "add product with no opening stock creates no batch",
+      "operation": "add_product",
+      "product": {
+        "name": "Empty Catalogue Item",
+        "unit": "Piece",
+        "retailer_price_kobo": 10000,
+        "wholesaler_price_kobo": 9000,
+        "buying_price_kobo": 7000
+      },
+      "opening_stock": 0,
+      "expected": {
+        "batches": [],
+        "inventory_after": 0,
+        "supplier_balance_after_kobo": null
+      }
+    },
+    {
+      "name": "receive stock adds a new batch behind the existing one, invoice fully paid",
+      "operation": "receive",
+      "product": {
+        "name": "Water 75cl",
+        "unit": "Bottle",
+        "retailer_price_kobo": 40000,
+        "wholesaler_price_kobo": 36000,
+        "buying_price_kobo": 28000
+      },
+      "receive": {
+        "existing_stock": 5,
+        "existing_batches": [
+          { "qty": 5, "cost_kobo": 28000, "received_at": "2026-01-01" }
+        ],
+        "lines": [
+          { "quantity": 10, "buying_price_kobo": 30000, "received_at": "2026-02-01" }
+        ],
+        "amount_paid_kobo": 300000,
+        "payment_method": "cash"
+      },
+      "expected": {
+        "batches": [
+          { "received_at": "2026-01-01", "qty_remaining": 5, "qty_original": 5, "cost_kobo": 28000 },
+          { "received_at": "2026-02-01", "qty_remaining": 10, "qty_original": 10, "cost_kobo": 30000 }
+        ],
+        "inventory_after": 15,
+        "supplier_balance_after_kobo": 0
+      }
+    },
+    {
+      "name": "receive stock with partial payment leaves a supplier debt",
+      "operation": "receive",
+      "product": {
+        "name": "Juice 100cl",
+        "unit": "Bottle",
+        "retailer_price_kobo": 35000,
+        "wholesaler_price_kobo": 32000,
+        "buying_price_kobo": 25000
+      },
+      "receive": {
+        "existing_stock": 0,
+        "existing_batches": [],
+        "lines": [
+          { "quantity": 8, "buying_price_kobo": 25000, "received_at": "2026-03-01" }
+        ],
+        "amount_paid_kobo": 50000,
+        "payment_method": "transfer"
+      },
+      "expected": {
+        "batches": [
+          { "received_at": "2026-03-01", "qty_remaining": 8, "qty_original": 8, "cost_kobo": 25000 }
+        ],
+        "inventory_after": 8,
+        "supplier_balance_after_kobo": -150000
+      }
+    },
+    {
+      "name": "receive uncosted stock (cost 0) posts no invoice",
+      "operation": "receive",
+      "product": {
+        "name": "Promo Cup",
+        "unit": "Piece",
+        "retailer_price_kobo": 0,
+        "wholesaler_price_kobo": 0,
+        "buying_price_kobo": 0
+      },
+      "receive": {
+        "existing_stock": 0,
+        "existing_batches": [],
+        "lines": [
+          { "quantity": 5, "buying_price_kobo": 0, "received_at": "2026-04-01" }
+        ],
+        "amount_paid_kobo": 0,
+        "payment_method": "cash"
+      },
+      "expected": {
+        "batches": [
+          { "received_at": "2026-04-01", "qty_remaining": 5, "qty_original": 5, "cost_kobo": 0 }
+        ],
+        "inventory_after": 5,
+        "supplier_balance_after_kobo": 0
+      }
+    }
+  ]
+}

--- a/test/golden/inventory_dart_dao_golden_test.dart
+++ b/test/golden/inventory_dart_dao_golden_test.dart
@@ -1,0 +1,191 @@
+import 'package:drift/drift.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reebaplus_pos/core/database/app_database.dart';
+import 'package:reebaplus_pos/core/database/uuid_v7.dart';
+import 'package:reebaplus_pos/shared/services/supplier_account_service.dart';
+
+import '../helpers/dispatch_test_utils.dart';
+import 'inventory_scenario.dart';
+
+/// Batch-creation Golden Suite — the DART producer side (ADR 0009, issue #48).
+///
+/// Runs the shared inventory fixtures against the real mobile producers on an
+/// in-memory Drift DB: Add Product's opening stock (inventory + CostBatchesDao.
+/// recordInflowBatch) and Receive Stock (InventoryDao.adjustStock + recordInflow
+/// Batch + SupplierAccountService). Its Tier-2 twin (web_inventory_golden_test)
+/// runs the SAME fixtures against add_product / receive_stock (0140); any drift in
+/// the Cost Batch producer rule between the two fails the build.
+String _dateKey(DateTime d) {
+  final u = d.toUtc();
+  return '${u.year.toString().padLeft(4, '0')}-'
+      '${u.month.toString().padLeft(2, '0')}-'
+      '${u.day.toString().padLeft(2, '0')}';
+}
+
+void main() {
+  final scenarios = loadInventoryScenarios();
+  for (final s in scenarios) {
+    test('golden (dart producers): ${s.name}', () async {
+      final boot = await bootstrapTestDb();
+      final db = boot.db;
+      final businessId = boot.businessId;
+      addTearDown(db.close);
+
+      // v1 path so adjustStock writes stock_adjustments + stock_transactions
+      // locally (the v2 path defers those to the cloud RPC response).
+      await setFlag(db, 'feature.domain_rpcs_v2.inventory_delta', on: false);
+
+      final storeId = UuidV7.generate();
+      await db.into(db.stores).insert(
+            StoresCompanion.insert(
+                id: Value(storeId), businessId: businessId, name: 'Main'),
+          );
+      final staffId = UuidV7.generate();
+      await db.into(db.users).insert(
+            UsersCompanion.insert(
+                id: Value(staffId),
+                businessId: businessId,
+                name: 'Manager',
+                pin: '0000'),
+          );
+
+      final productId = UuidV7.generate();
+      await db.into(db.products).insert(
+            ProductsCompanion.insert(
+              id: Value(productId),
+              businessId: businessId,
+              name: s.productName,
+              unit: Value(s.unit),
+              retailerPriceKobo: Value(s.retailerPriceKobo),
+              wholesalerPriceKobo: Value(s.wholesalerPriceKobo),
+              buyingPriceKobo: Value(s.buyingPriceKobo),
+            ),
+          );
+
+      String? supplierId;
+      SupplierAccountService? accounts;
+
+      if (s.operation == 'add_product') {
+        // Add Product: opening stock straight to inventory + the opening batch.
+        if (s.openingStock > 0) {
+          await db.into(db.inventory).insert(
+                InventoryCompanion.insert(
+                  businessId: businessId,
+                  productId: productId,
+                  storeId: storeId,
+                  quantity: Value(s.openingStock),
+                ),
+              );
+          await db.costBatchesDao.recordInflowBatch(
+            productId: productId,
+            storeId: storeId,
+            quantity: s.openingStock,
+            costKobo: s.buyingPriceKobo,
+          );
+        }
+      } else {
+        // Receive Stock: seed the pre-existing state, then run the receipt.
+        if (s.existingStock > 0) {
+          await db.into(db.inventory).insert(
+                InventoryCompanion.insert(
+                  businessId: businessId,
+                  productId: productId,
+                  storeId: storeId,
+                  quantity: Value(s.existingStock),
+                ),
+              );
+        }
+        for (final b in s.existingBatches) {
+          await db.into(db.costBatches).insert(
+                CostBatchesCompanion.insert(
+                  id: Value(UuidV7.generate()),
+                  businessId: businessId,
+                  productId: productId,
+                  storeId: storeId,
+                  qtyRemaining: b.qty,
+                  qtyOriginal: b.qty,
+                  costKobo: Value(b.costKobo),
+                  receivedAt: Value(b.receivedAtUtc),
+                ),
+              );
+        }
+        supplierId = UuidV7.generate();
+        await db.into(db.suppliers).insert(
+              SuppliersCompanion.insert(
+                  id: Value(supplierId), businessId: businessId, name: 'Golden Supplier'),
+            );
+
+        final invoiceTotal = s.lines.fold<int>(
+            0,
+            (sum, l) =>
+                sum + l.quantity * (l.buyingPriceKobo < 0 ? 0 : l.buyingPriceKobo));
+        final receiptDate = s.lines.first.receivedAtUtc;
+        accounts = SupplierAccountService(db);
+        if (invoiceTotal > 0) {
+          await accounts.recordInvoice(
+            supplierId: supplierId,
+            amountKobo: invoiceTotal,
+            dateReceived: receiptDate,
+            staffId: staffId,
+            storeId: storeId,
+          );
+        }
+        if (s.amountPaidKobo > 0) {
+          await accounts.recordPayment(
+            supplierId: supplierId,
+            amountKobo: s.amountPaidKobo,
+            method: s.paymentMethod,
+            paidOn: receiptDate,
+            staffId: staffId,
+            storeId: storeId,
+            referenceNote: 'golden receipt',
+          );
+        }
+        for (final line in s.lines) {
+          await db.inventoryDao
+              .adjustStock(productId, storeId, line.quantity, 'Stock received', staffId);
+          await db.costBatchesDao.recordInflowBatch(
+            productId: productId,
+            storeId: storeId,
+            quantity: line.quantity,
+            costKobo: line.buyingPriceKobo,
+            receivedAt: line.receivedAtUtc,
+          );
+        }
+      }
+
+      // ── Collect the resulting rows in fixture terms ────────────────────────
+      final batchRows = await (db.select(db.costBatches)
+            ..where((b) => b.productId.equals(productId)))
+          .get();
+      final batches = <String, ExpectedInvBatch>{};
+      for (final b in batchRows) {
+        final key =
+            s.operation == 'add_product' ? 'opening' : _dateKey(b.receivedAt);
+        batches[key] = ExpectedInvBatch({
+          'received_at': key,
+          'qty_remaining': b.qtyRemaining,
+          'qty_original': b.qtyOriginal,
+          'cost_kobo': b.costKobo,
+        });
+      }
+
+      final invRow = await (db.select(db.inventory)
+            ..where((i) => i.productId.equals(productId) & i.storeId.equals(storeId)))
+          .getSingleOrNull();
+
+      final supplierBalance = (s.operation == 'receive' && accounts != null)
+          ? await accounts.getBalanceKobo(supplierId!)
+          : null;
+
+      expectInventoryGolden(
+        s,
+        InventoryOutcome(
+          batches: batches,
+          inventoryAfter: invRow?.quantity ?? 0,
+          supplierBalanceAfterKobo: supplierBalance,
+        ),
+      );
+    });
+  }
+}

--- a/test/golden/inventory_scenario.dart
+++ b/test/golden/inventory_scenario.dart
@@ -1,0 +1,191 @@
+/// The batch-creation Golden-Scenario Suite (ADR 0009, issue #48).
+///
+/// A second golden dimension beside the checkout suite (golden_scenario.dart):
+/// it pins the FIFO **Cost Batch producer** rule identical across the two
+/// implementations of inventory inflow —
+///   * the Dart DAO path (mobile)  — test/golden/inventory_dart_dao_golden_test.dart
+///     (CostBatchesDao.recordInflowBatch + inventory + SupplierAccountService)
+///   * the SQL RPCs (web)          — test/integration/rpcs/web_inventory_golden_test.dart
+///     (add_product / receive_stock, migration 0140)
+///
+/// The rule under test (F1/F6, ADR 0005): one inflow ⇒ one fresh Cost Batch
+/// {qty_remaining = qty_original = quantity, cost_kobo = max(cost, 0),
+/// received_at}, never merged with another; cost 0 ⇒ an UNCOSTED batch. Add
+/// Product writes opening stock straight to inventory with no supplier; Receive
+/// Stock posts a supplier invoice (debit) + optional payment (credit) and a
+/// receipt-dated batch per line. Any drift between the two arms fails the build.
+library;
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+// ─── Fixtures (input) ────────────────────────────────────────────────────────
+
+/// A cost batch already on the queue before the operation runs (Receive Stock
+/// scenarios seed these so the assertion covers pre-existing layers too).
+class FxInvExistingBatch {
+  final int qty;
+  final int costKobo;
+  final String receivedAt; // date-only, unique per product ⇒ doubles as the key
+  FxInvExistingBatch(this.qty, this.costKobo, this.receivedAt);
+
+  DateTime get receivedAtUtc {
+    final p = receivedAt.split('-').map(int.parse).toList();
+    return DateTime.utc(p[0], p[1], p[2]);
+  }
+}
+
+/// One Receive Stock line: units received at a per-unit cost, receipt-dated.
+class FxReceiveLine {
+  final int quantity;
+  final int buyingPriceKobo;
+  final String receivedAt;
+  FxReceiveLine(this.quantity, this.buyingPriceKobo, this.receivedAt);
+
+  DateTime get receivedAtUtc {
+    final p = receivedAt.split('-').map(int.parse).toList();
+    return DateTime.utc(p[0], p[1], p[2]);
+  }
+}
+
+/// One expected cost_batches row, keyed by receivedAt (unique per scenario).
+class ExpectedInvBatch {
+  final String receivedAt;
+  final int qtyRemaining;
+  final int qtyOriginal;
+  final int costKobo;
+  ExpectedInvBatch(Map<String, dynamic> j)
+      : receivedAt = j['received_at'] as String,
+        qtyRemaining = j['qty_remaining'] as int,
+        qtyOriginal = j['qty_original'] as int,
+        costKobo = j['cost_kobo'] as int;
+
+  String get signature => '$qtyRemaining|$qtyOriginal|$costKobo';
+}
+
+class InventoryScenario {
+  final String name;
+
+  /// 'add_product' — creates a product with opening stock; or
+  /// 'receive'      — receives a supplier delivery for an existing product.
+  final String operation;
+
+  // Product under test.
+  final String productName;
+  final String unit;
+  final int retailerPriceKobo;
+  final int wholesalerPriceKobo;
+  final int buyingPriceKobo;
+
+  // add_product only: opening stock valued at buyingPriceKobo.
+  final int openingStock;
+
+  // receive only:
+  final int existingStock;
+  final List<FxInvExistingBatch> existingBatches;
+  final List<FxReceiveLine> lines;
+  final int amountPaidKobo;
+  final String paymentMethod;
+
+  // Expected results (the contract).
+  final Map<String, ExpectedInvBatch> expectedBatches; // receivedAt → row
+  final int expectedInventoryAfter;
+  final int? expectedSupplierBalanceAfterKobo; // receive only; null for add
+
+  InventoryScenario._({
+    required this.name,
+    required this.operation,
+    required this.productName,
+    required this.unit,
+    required this.retailerPriceKobo,
+    required this.wholesalerPriceKobo,
+    required this.buyingPriceKobo,
+    required this.openingStock,
+    required this.existingStock,
+    required this.existingBatches,
+    required this.lines,
+    required this.amountPaidKobo,
+    required this.paymentMethod,
+    required this.expectedBatches,
+    required this.expectedInventoryAfter,
+    required this.expectedSupplierBalanceAfterKobo,
+  });
+
+  factory InventoryScenario._fromJson(Map<String, dynamic> j) {
+    final exp = j['expected'] as Map<String, dynamic>;
+    final batches = <String, ExpectedInvBatch>{};
+    for (final b in (exp['batches'] as List)) {
+      final e = ExpectedInvBatch(b as Map<String, dynamic>);
+      batches[e.receivedAt] = e;
+    }
+    final receive = j['receive'] as Map<String, dynamic>?;
+    return InventoryScenario._(
+      name: j['name'] as String,
+      operation: j['operation'] as String,
+      productName: j['product']['name'] as String,
+      unit: j['product']['unit'] as String? ?? 'Piece',
+      retailerPriceKobo: j['product']['retailer_price_kobo'] as int? ?? 0,
+      wholesalerPriceKobo: j['product']['wholesaler_price_kobo'] as int? ?? 0,
+      buyingPriceKobo: j['product']['buying_price_kobo'] as int? ?? 0,
+      openingStock: j['opening_stock'] as int? ?? 0,
+      existingStock: receive?['existing_stock'] as int? ?? 0,
+      existingBatches: ((receive?['existing_batches'] as List?) ?? const [])
+          .map((b) => FxInvExistingBatch(
+              b['qty'] as int, b['cost_kobo'] as int, b['received_at'] as String))
+          .toList(),
+      lines: ((receive?['lines'] as List?) ?? const [])
+          .map((l) => FxReceiveLine(l['quantity'] as int,
+              l['buying_price_kobo'] as int, l['received_at'] as String))
+          .toList(),
+      amountPaidKobo: receive?['amount_paid_kobo'] as int? ?? 0,
+      paymentMethod: receive?['payment_method'] as String? ?? 'cash',
+      expectedBatches: batches,
+      expectedInventoryAfter: exp['inventory_after'] as int,
+      expectedSupplierBalanceAfterKobo:
+          exp['supplier_balance_after_kobo'] as int?,
+    );
+  }
+}
+
+List<InventoryScenario> loadInventoryScenarios() {
+  final raw =
+      File('test/golden/fixtures/inventory_scenarios.json').readAsStringSync();
+  final json = jsonDecode(raw) as Map<String, dynamic>;
+  return (json['scenarios'] as List)
+      .map((s) => InventoryScenario._fromJson(s as Map<String, dynamic>))
+      .toList();
+}
+
+// ─── Actual (a runner's result, in fixture terms) ────────────────────────────
+
+class InventoryOutcome {
+  /// receivedAt (date-only) → {qty_remaining, qty_original, cost_kobo}.
+  final Map<String, ExpectedInvBatch> batches;
+  final int inventoryAfter;
+  final int? supplierBalanceAfterKobo;
+  InventoryOutcome({
+    required this.batches,
+    required this.inventoryAfter,
+    this.supplierBalanceAfterKobo,
+  });
+}
+
+/// The shared assertion. Both runners collect their resulting rows into an
+/// [InventoryOutcome] and call this; drift on either arm fails the build.
+void expectInventoryGolden(InventoryScenario s, InventoryOutcome actual) {
+  final expectedSigs = {
+    for (final e in s.expectedBatches.entries) e.key: e.value.signature
+  };
+  final actualSigs = {
+    for (final e in actual.batches.entries) e.key: e.value.signature
+  };
+  expect(actualSigs, equals(expectedSigs),
+      reason:
+          '${s.name}: cost_batches produced (receivedAt → qty_remaining|qty_original|cost)');
+  expect(actual.inventoryAfter, s.expectedInventoryAfter,
+      reason: '${s.name}: inventory on-hand after the inflow');
+  expect(actual.supplierBalanceAfterKobo, s.expectedSupplierBalanceAfterKobo,
+      reason: '${s.name}: supplier ledger balance after the delivery');
+}

--- a/test/integration/rpcs/web_inventory_golden_test.dart
+++ b/test/integration/rpcs/web_inventory_golden_test.dart
@@ -1,0 +1,221 @@
+@Tags(['integration'])
+library;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reebaplus_pos/core/database/uuid_v7.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import '../../golden/inventory_scenario.dart';
+import '../../helpers/supabase_test_clients.dart';
+import '../../helpers/supabase_test_env.dart';
+
+/// Batch-creation Golden Suite — the SQL RPC side (ADR 0009, issue #48).
+///
+/// Runs the SAME inventory fixtures as the Dart producer runner
+/// (test/golden/inventory_dart_dao_golden_test.dart) against the server-
+/// authoritative add_product / receive_stock RPCs (migration 0140) on real dev
+/// Supabase. Any drift in the Cost Batch producer rule between the two fails the
+/// build. Tier-2: hits live Supabase, auto-skipped when the env vars are absent.
+/// Seeds via the service-role adminClient; invokes the RPC via the signed-in
+/// userClient (the RPCs read auth.uid() for the tenant + permission guards).
+final String? _skipReason = (() {
+  try {
+    TestEnv.load();
+    return null;
+  } on StateError catch (e) {
+    return e.message;
+  }
+})();
+
+String _dateKey(String iso) => iso.substring(0, 10);
+
+void main() {
+  late TestClients clients;
+  late String businessId;
+
+  String? storeId;
+  String? supplierId;
+  final productIds = <String>[];
+  final receiptIds = <String>[];
+
+  setUpAll(() async {
+    if (_skipReason != null) return;
+    clients = await TestClients.setUp();
+    businessId = clients.env.businessId;
+  });
+
+  tearDown(() async {
+    if (_skipReason != null) return;
+    Future<void> del(String table, String column, String id) async {
+      try {
+        await clients.adminClient.from(table).delete().eq(column, id);
+      } on PostgrestException catch (e) {
+        // supplier_ledger_entries / activity are append-only in places → P0001;
+        // FK parents can 23503. Both are expected in the shared test business.
+        if (e.code != 'P0001' && e.code != '23503') rethrow;
+      }
+    }
+
+    for (final id in productIds) {
+      await del('stock_transactions', 'product_id', id);
+      await del('stock_adjustments', 'product_id', id);
+      await del('cost_batches', 'product_id', id);
+      await del('inventory', 'product_id', id);
+      await del('activity_logs', 'product_id', id);
+      await del('products', 'id', id);
+    }
+    for (final id in receiptIds) {
+      await del('activity_logs', 'id', id);
+    }
+    if (supplierId != null) {
+      await del('supplier_ledger_entries', 'supplier_id', supplierId!);
+      await del('suppliers', 'id', supplierId!);
+    }
+    if (storeId != null) {
+      await del('stores', 'id', storeId!);
+    }
+    storeId = null;
+    supplierId = null;
+    productIds.clear();
+    receiptIds.clear();
+  });
+
+  tearDownAll(() async {
+    if (_skipReason != null) return;
+    await clients.dispose();
+  });
+
+  final scenarios = loadInventoryScenarios();
+  for (final s in scenarios) {
+    test('golden (inventory rpc): ${s.name}', () async {
+      final admin = clients.adminClient;
+      final store = UuidV7.generate();
+      storeId = store;
+      await admin.from('stores').insert({
+        'id': store,
+        'business_id': businessId,
+        'name': 'Golden Inv Store',
+      });
+
+      final productId = UuidV7.generate();
+      productIds.add(productId);
+      final batches = <String, ExpectedInvBatch>{};
+      int? supplierBalance;
+
+      if (s.operation == 'add_product') {
+        // add_product creates the product + opening stock + opening batch.
+        await clients.userClient.rpc('add_product', params: {
+          'p_business_id': businessId,
+          'p_product_id': productId,
+          'p_store_id': store,
+          'p_name': s.productName,
+          'p_unit': s.unit,
+          'p_retailer_price_kobo': s.retailerPriceKobo,
+          'p_wholesaler_price_kobo': s.wholesalerPriceKobo,
+          'p_buying_price_kobo': s.buyingPriceKobo,
+          'p_opening_stock': s.openingStock,
+        });
+      } else {
+        // Receive Stock: seed the product + pre-existing state, then the receipt.
+        await admin.from('products').insert({
+          'id': productId,
+          'business_id': businessId,
+          'name': s.productName,
+          'unit': s.unit,
+          'retailer_price_kobo': s.retailerPriceKobo,
+          'wholesaler_price_kobo': s.wholesalerPriceKobo,
+          'buying_price_kobo': s.buyingPriceKobo,
+        });
+        if (s.existingStock > 0) {
+          await admin.from('inventory').insert({
+            'id': UuidV7.generate(),
+            'business_id': businessId,
+            'product_id': productId,
+            'store_id': store,
+            'quantity': s.existingStock,
+          });
+        }
+        for (final b in s.existingBatches) {
+          await admin.from('cost_batches').insert({
+            'id': UuidV7.generate(),
+            'business_id': businessId,
+            'product_id': productId,
+            'store_id': store,
+            'qty_remaining': b.qty,
+            'qty_original': b.qty,
+            'cost_kobo': b.costKobo,
+            'received_at': b.receivedAtUtc.toIso8601String(),
+          });
+        }
+        final supplier = UuidV7.generate();
+        supplierId = supplier;
+        await admin.from('suppliers').insert({
+          'id': supplier,
+          'business_id': businessId,
+          'name': 'Golden Supplier',
+        });
+
+        final receiptId = UuidV7.generate();
+        receiptIds.add(receiptId);
+        await clients.userClient.rpc('receive_stock', params: {
+          'p_business_id': businessId,
+          'p_receipt_id': receiptId,
+          'p_supplier_id': supplier,
+          'p_store_id': store,
+          'p_received_at': s.lines.first.receivedAtUtc.toIso8601String(),
+          'p_lines': [
+            for (final l in s.lines)
+              {
+                'product_id': productId,
+                'quantity': l.quantity,
+                'buying_price_kobo': l.buyingPriceKobo,
+              }
+          ],
+          'p_amount_paid_kobo': s.amountPaidKobo,
+          'p_payment_method': s.paymentMethod,
+          'p_note': 'golden receipt',
+        });
+
+        final ledger = await admin
+            .from('supplier_ledger_entries')
+            .select('signed_amount_kobo')
+            .eq('supplier_id', supplier);
+        supplierBalance = ledger.fold<int>(
+            0, (sum, r) => sum + (r['signed_amount_kobo'] as num).toInt());
+      }
+
+      // ── Collect the resulting cost batches + inventory ─────────────────────
+      final batchRows = await admin
+          .from('cost_batches')
+          .select('qty_remaining, qty_original, cost_kobo, received_at')
+          .eq('product_id', productId);
+      for (final b in batchRows) {
+        final key = s.operation == 'add_product'
+            ? 'opening'
+            : _dateKey(b['received_at'] as String);
+        batches[key] = ExpectedInvBatch({
+          'received_at': key,
+          'qty_remaining': (b['qty_remaining'] as num).toInt(),
+          'qty_original': (b['qty_original'] as num).toInt(),
+          'cost_kobo': (b['cost_kobo'] as num).toInt(),
+        });
+      }
+
+      final invRow = await admin
+          .from('inventory')
+          .select('quantity')
+          .eq('product_id', productId)
+          .eq('store_id', store)
+          .maybeSingle();
+
+      expectInventoryGolden(
+        s,
+        InventoryOutcome(
+          batches: batches,
+          inventoryAfter: invRow == null ? 0 : (invRow['quantity'] as num).toInt(),
+          supplierBalanceAfterKobo: supplierBalance,
+        ),
+      );
+    }, skip: _skipReason);
+  }
+}

--- a/web-pos/src/app/globals.css
+++ b/web-pos/src/app/globals.css
@@ -1766,3 +1766,181 @@ input {
   color: var(--subtext);
   font-weight: 500;
 }
+
+/* ── Inventory (Slice 6, #48) ─────────────────────────────────────────────── */
+.inventory {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  max-width: var(--content-max);
+}
+.inventory__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+.inventory__subtitle {
+  margin: 2px 0 0;
+  font-size: 13px;
+}
+.inventory__actions {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+.inventory__toolbar {
+  max-width: 360px;
+}
+.inventory__toolbar .input {
+  width: 100%;
+}
+
+/* The table scrolls inside its own container on narrow screens — the page body
+   never scrolls sideways (responsive AC). */
+.inventory__table-wrap {
+  overflow-x: auto;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface);
+}
+.inventory__table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 14px;
+  min-width: 640px;
+}
+.inventory__table th,
+.inventory__table td {
+  padding: 12px 14px;
+  text-align: left;
+  border-bottom: 1px solid var(--border);
+  white-space: nowrap;
+}
+.inventory__table th {
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--subtext);
+  font-weight: 700;
+}
+.inventory__table tbody tr:last-child td {
+  border-bottom: none;
+}
+.inventory__table .num {
+  text-align: right;
+}
+.inventory__name {
+  font-weight: 600;
+  color: var(--text);
+}
+.inventory__meta {
+  font-size: 12px;
+  color: var(--subtext);
+  margin-top: 2px;
+}
+.inventory__stock {
+  font-weight: 700;
+}
+.inventory__stock--low {
+  color: var(--danger, var(--error));
+}
+
+/* ── Shared form helpers ──────────────────────────────────────────────────── */
+.form-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 14px;
+}
+@media (max-width: 520px) {
+  .form-row {
+    grid-template-columns: 1fr;
+  }
+}
+select.input {
+  appearance: none;
+  background-image: linear-gradient(45deg, transparent 50%, var(--subtext) 50%),
+    linear-gradient(135deg, var(--subtext) 50%, transparent 50%);
+  background-position: calc(100% - 20px) 55%, calc(100% - 15px) 55%;
+  background-size: 5px 5px, 5px 5px;
+  background-repeat: no-repeat;
+  padding-right: 36px;
+}
+.field--check {
+  justify-content: center;
+}
+.check {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+}
+.check input {
+  width: 18px;
+  height: 18px;
+}
+.btn--sm {
+  min-height: 34px;
+  padding: 0 12px;
+  font-size: 13px;
+}
+.modal--wide {
+  max-width: 640px;
+}
+
+/* ── Receive-stock lines ──────────────────────────────────────────────────── */
+.receive-lines {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 10px;
+}
+.receive-line {
+  display: grid;
+  grid-template-columns: 1fr 72px 100px auto 34px;
+  gap: 8px;
+  align-items: center;
+}
+.receive-line__name {
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.receive-line__qty,
+.receive-line__cost {
+  min-height: 40px;
+  padding: 0 10px;
+}
+.receive-line__total {
+  font-weight: 700;
+  text-align: right;
+  font-size: 13.5px;
+}
+@media (max-width: 520px) {
+  .receive-line {
+    grid-template-columns: 1fr 60px 34px;
+    grid-template-areas:
+      'name name name'
+      'qty cost remove';
+  }
+  .receive-line__name {
+    grid-area: name;
+  }
+  .receive-line__total {
+    display: none;
+  }
+}
+.receive-invoice {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 14px;
+  margin: 4px 0 8px;
+  border-radius: var(--radius);
+  background: var(--surface2);
+  font-size: 15px;
+}

--- a/web-pos/src/app/page.tsx
+++ b/web-pos/src/app/page.tsx
@@ -5,6 +5,8 @@ import { LoginForm } from '@/components/auth/LoginForm';
 import { AppShell } from '@/components/shell/AppShell';
 import { PosScreen } from '@/components/pos/PosScreen';
 import { CartProvider } from '@/components/pos/CartProvider';
+import { NavProvider, useNav } from '@/components/providers/NavProvider';
+import { InventoryScreen } from '@/components/inventory/InventoryScreen';
 
 // App entry. The signed-in Supabase session is the Operator (ADR 0011): while it
 // resolves we show a spinner; signed-out shows the sign-in screen; signed-in
@@ -32,12 +34,22 @@ export default function Home() {
   }
 
   return (
-    <CartProvider>
-      <AppShell>
-        <PosScreen />
-      </AppShell>
-    </CartProvider>
+    <NavProvider>
+      <CartProvider>
+        <AppShell>
+          <MainContent />
+        </AppShell>
+      </CartProvider>
+    </NavProvider>
   );
+}
+
+// The content area renders the active view (sidebar-driven, NavProvider). The
+// cart lives above this so it survives switching to Inventory and back.
+function MainContent() {
+  const { view } = useNav();
+  if (view === 'inventory') return <InventoryScreen />;
+  return <PosScreen />;
 }
 
 function FullscreenSpinner({ label }: { label: string }) {

--- a/web-pos/src/components/inventory/InventoryScreen.tsx
+++ b/web-pos/src/components/inventory/InventoryScreen.tsx
@@ -1,0 +1,234 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import { useSession } from '@/components/providers/SessionProvider';
+import { useCan } from '@/components/permissions/Can';
+import { useCurrency } from '@/hooks/useCurrency';
+import { PermissionKeys } from '@/lib/permissions';
+import { loadCatalogue, type Catalogue } from '@/lib/catalogue';
+import {
+  loadInventoryRefs,
+  type InventoryRefs,
+} from '@/lib/inventory';
+import type { ProductWithStock } from '@/lib/types';
+import { ProductFormDialog } from './ProductFormDialog';
+import { ReceiveStockDialog } from './ReceiveStockDialog';
+
+// Web POS Slice 6 (#48) — Inventory management. A live product list with the two
+// catalogue money-writes: Add/Edit product (products.add) and Receive Stock
+// (stock.received / stock.add). Hide-don't-block: the action buttons appear only
+// when the Operator's role allows them; the RPCs re-check server-side. Reads are
+// RLS-scoped PostgREST (Realtime auto-refresh is Slice 5, #49).
+export function InventoryScreen() {
+  const { supabase, operator } = useSession();
+  const { kobo } = useCurrency();
+  const canAdd = useCan(PermissionKeys.productsAdd);
+  const canReceive =
+    useCan(PermissionKeys.stockReceived) ||
+    useCan(PermissionKeys.stockAdd) ||
+    canAdd;
+
+  const [catalogue, setCatalogue] = useState<Catalogue | null>(null);
+  const [refs, setRefs] = useState<InventoryRefs | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [query, setQuery] = useState('');
+
+  // Dialog state: add a product, edit a specific product, or receive a delivery.
+  const [formOpen, setFormOpen] = useState(false);
+  const [editing, setEditing] = useState<ProductWithStock | null>(null);
+  const [receiveOpen, setReceiveOpen] = useState(false);
+
+  const businessId = operator?.businessId ?? null;
+
+  const refresh = useCallback(async () => {
+    setError(null);
+    try {
+      const [cat, ref] = await Promise.all([
+        loadCatalogue(supabase),
+        loadInventoryRefs(supabase),
+      ]);
+      setCatalogue(cat);
+      setRefs(ref);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load inventory.');
+    } finally {
+      setLoading(false);
+    }
+  }, [supabase]);
+
+  useEffect(() => {
+    setLoading(true);
+    void refresh();
+  }, [refresh, businessId]);
+
+  const filtered = useMemo(() => {
+    if (!catalogue) return [];
+    const q = query.toLowerCase().trim();
+    if (!q) return catalogue.products;
+    return catalogue.products.filter((p) => p.name.toLowerCase().includes(q));
+  }, [catalogue, query]);
+
+  const openAdd = useCallback(() => {
+    setEditing(null);
+    setFormOpen(true);
+  }, []);
+
+  const openEdit = useCallback((p: ProductWithStock) => {
+    setEditing(p);
+    setFormOpen(true);
+  }, []);
+
+  const onSaved = useCallback(() => {
+    setFormOpen(false);
+    setReceiveOpen(false);
+    setEditing(null);
+    void refresh();
+  }, [refresh]);
+
+  const categoryName = useCallback(
+    (id: string | null) =>
+      id ? (catalogue?.categories.find((c) => c.id === id)?.name ?? '—') : '—',
+    [catalogue],
+  );
+
+  return (
+    <div className="inventory">
+      <div className="inventory__header">
+        <div>
+          <h1 className="pos__title">Inventory</h1>
+          <p className="muted inventory__subtitle">
+            {catalogue ? `${catalogue.products.length} product(s)` : ' '}
+          </p>
+        </div>
+        <div className="inventory__actions">
+          <button
+            className="btn btn--outline"
+            onClick={() => void refresh()}
+            disabled={loading}
+          >
+            Refresh
+          </button>
+          {canReceive && (
+            <button
+              className="btn btn--outline"
+              onClick={() => setReceiveOpen(true)}
+              disabled={!catalogue || catalogue.products.length === 0}
+            >
+              Receive stock
+            </button>
+          )}
+          {canAdd && (
+            <button className="btn btn--primary" onClick={openAdd}>
+              + Add product
+            </button>
+          )}
+        </div>
+      </div>
+
+      {error && <div className="banner banner--error">{error}</div>}
+
+      <div className="inventory__toolbar">
+        <input
+          className="input"
+          type="search"
+          placeholder="Search products…"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+        />
+      </div>
+
+      {loading && !catalogue ? (
+        <div className="empty-state">
+          <div className="spinner" style={{ margin: '0 auto 12px' }} />
+          Loading inventory…
+        </div>
+      ) : filtered.length === 0 ? (
+        <div className="empty-state">
+          {catalogue && catalogue.products.length === 0
+            ? canAdd
+              ? 'No products yet. Add your first product to get started.'
+              : 'No products yet.'
+            : 'No products match your search.'}
+        </div>
+      ) : (
+        <div className="inventory__table-wrap">
+          <table className="inventory__table">
+            <thead>
+              <tr>
+                <th>Product</th>
+                <th>Category</th>
+                <th className="num">In stock</th>
+                <th className="num">Retail</th>
+                <th className="num">Wholesale</th>
+                <th className="num">Cost</th>
+                {canAdd && <th aria-label="Actions" />}
+              </tr>
+            </thead>
+            <tbody>
+              {filtered.map((p) => {
+                const low =
+                  p.low_stock_threshold != null &&
+                  p.onHand <= p.low_stock_threshold;
+                return (
+                  <tr key={p.id}>
+                    <td>
+                      <div className="inventory__name">{p.name}</div>
+                      <div className="inventory__meta">
+                        {p.unit ?? 'Piece'}
+                        {p.size ? ` · ${p.size}` : ''}
+                      </div>
+                    </td>
+                    <td>{categoryName(p.category_id)}</td>
+                    <td className="num">
+                      <span
+                        className={`inventory__stock${low ? ' inventory__stock--low' : ''}`}
+                      >
+                        {p.onHand}
+                      </span>
+                    </td>
+                    <td className="num">{kobo(p.retailer_price_kobo)}</td>
+                    <td className="num">{kobo(p.wholesaler_price_kobo)}</td>
+                    <td className="num">{kobo(p.buying_price_kobo)}</td>
+                    {canAdd && (
+                      <td className="num">
+                        <button
+                          className="btn btn--outline btn--sm"
+                          onClick={() => openEdit(p)}
+                        >
+                          Edit
+                        </button>
+                      </td>
+                    )}
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {formOpen && refs && (
+        <ProductFormDialog
+          product={editing}
+          categories={refs.categories}
+          onSaved={onSaved}
+          onCancel={() => {
+            setFormOpen(false);
+            setEditing(null);
+          }}
+        />
+      )}
+
+      {receiveOpen && refs && catalogue && (
+        <ReceiveStockDialog
+          products={catalogue.products}
+          suppliers={refs.suppliers}
+          onSaved={onSaved}
+          onCancel={() => setReceiveOpen(false)}
+        />
+      )}
+    </div>
+  );
+}

--- a/web-pos/src/components/inventory/ProductFormDialog.tsx
+++ b/web-pos/src/components/inventory/ProductFormDialog.tsx
@@ -1,0 +1,337 @@
+'use client';
+
+import { useState } from 'react';
+
+import { useSession } from '@/components/providers/SessionProvider';
+import { useCurrency } from '@/hooks/useCurrency';
+import {
+  addProduct,
+  updateProduct,
+  PRODUCT_UNITS,
+  type ProductUnit,
+} from '@/lib/inventory';
+import type { CategoryRow, ProductWithStock } from '@/lib/types';
+
+// Naira (major-unit) input → kobo (bigint). Empty / invalid ⇒ 0.
+function toKobo(naira: string): number {
+  const n = parseFloat(naira);
+  return Number.isFinite(n) && n > 0 ? Math.round(n * 100) : 0;
+}
+function fromKobo(kobo: number | null | undefined): string {
+  return kobo && kobo > 0 ? (kobo / 100).toString() : '';
+}
+
+const SIZES = ['', 'big', 'medium', 'small'] as const;
+
+// Add or edit a product. Add creates the product + opening stock + opening Cost
+// Batch via add_product; Edit changes details/prices via update_product (stock
+// and Cost Batches are untouched — use Receive Stock to add units). Both RPCs
+// re-check products.add server-side.
+export function ProductFormDialog({
+  product,
+  categories,
+  onSaved,
+  onCancel,
+}: {
+  product: ProductWithStock | null;
+  categories: CategoryRow[];
+  onSaved: () => void;
+  onCancel: () => void;
+}) {
+  const { supabase, operator } = useSession();
+  const { code } = useCurrency();
+  const isEdit = product != null;
+
+  const [name, setName] = useState(product?.name ?? '');
+  const [unit, setUnit] = useState<ProductUnit>(
+    (product?.unit as ProductUnit) ?? 'Piece',
+  );
+  const [size, setSize] = useState(product?.size ?? '');
+  const [categoryId, setCategoryId] = useState(product?.category_id ?? '');
+  const [retail, setRetail] = useState(fromKobo(product?.retailer_price_kobo));
+  const [wholesale, setWholesale] = useState(
+    fromKobo(product?.wholesaler_price_kobo),
+  );
+  const [buying, setBuying] = useState(fromKobo(product?.buying_price_kobo));
+  const [openingStock, setOpeningStock] = useState('');
+  const [lowStock, setLowStock] = useState(
+    (product?.low_stock_threshold ?? 5).toString(),
+  );
+  const [trackEmpties, setTrackEmpties] = useState(
+    product?.track_empties ?? false,
+  );
+
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const businessId = operator?.businessId ?? null;
+  const storeId = operator?.stores?.[0]?.id ?? null;
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!businessId) {
+      setError('Your session is not linked to a business.');
+      return;
+    }
+    if (!name.trim()) {
+      setError('Enter a product name.');
+      return;
+    }
+    setSubmitting(true);
+    setError(null);
+    try {
+      if (isEdit && product) {
+        await updateProduct(supabase, {
+          businessId,
+          productId: product.id,
+          name: name.trim(),
+          categoryId: categoryId || null,
+          unit,
+          size: size || null,
+          retailerPriceKobo: toKobo(retail),
+          wholesalerPriceKobo: toKobo(wholesale),
+          buyingPriceKobo: toKobo(buying),
+          trackEmpties,
+          lowStockThreshold: parseInt(lowStock, 10) || 5,
+        });
+      } else {
+        if (!storeId) {
+          setError('This account has no store set up yet.');
+          setSubmitting(false);
+          return;
+        }
+        await addProduct(supabase, {
+          businessId,
+          storeId,
+          name: name.trim(),
+          categoryId: categoryId || null,
+          unit,
+          size: size || null,
+          retailerPriceKobo: toKobo(retail),
+          wholesalerPriceKobo: toKobo(wholesale),
+          buyingPriceKobo: toKobo(buying),
+          openingStock: parseInt(openingStock, 10) || 0,
+          trackEmpties,
+          lowStockThreshold: parseInt(lowStock, 10) || 5,
+        });
+      }
+      onSaved();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Could not save the product.');
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div
+      className="modal-overlay"
+      role="dialog"
+      aria-modal="true"
+      aria-label={isEdit ? 'Edit product' : 'Add product'}
+    >
+      <div className="modal">
+        <div className="modal__head">
+          <h2 className="modal__title">{isEdit ? 'Edit product' : 'Add product'}</h2>
+          <button className="modal__close" onClick={onCancel} aria-label="Close">
+            ✕
+          </button>
+        </div>
+
+        <form onSubmit={onSubmit}>
+          <div className="modal__body">
+            {error && <div className="banner banner--error">{error}</div>}
+
+            <div className="field">
+              <label className="field__label" htmlFor="p-name">
+                Name
+              </label>
+              <input
+                id="p-name"
+                className="input"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                autoFocus
+                required
+              />
+            </div>
+
+            <div className="form-row">
+              <div className="field">
+                <label className="field__label" htmlFor="p-unit">
+                  Unit
+                </label>
+                <select
+                  id="p-unit"
+                  className="input"
+                  value={unit}
+                  onChange={(e) => setUnit(e.target.value as ProductUnit)}
+                >
+                  {PRODUCT_UNITS.map((u) => (
+                    <option key={u} value={u}>
+                      {u}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div className="field">
+                <label className="field__label" htmlFor="p-size">
+                  Size
+                </label>
+                <select
+                  id="p-size"
+                  className="input"
+                  value={size}
+                  onChange={(e) => setSize(e.target.value)}
+                >
+                  {SIZES.map((s) => (
+                    <option key={s} value={s}>
+                      {s === '' ? '—' : s}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            </div>
+
+            <div className="field">
+              <label className="field__label" htmlFor="p-category">
+                Category
+              </label>
+              <select
+                id="p-category"
+                className="input"
+                value={categoryId}
+                onChange={(e) => setCategoryId(e.target.value)}
+              >
+                <option value="">Uncategorised</option>
+                {categories.map((c) => (
+                  <option key={c.id} value={c.id}>
+                    {c.name ?? 'Unnamed'}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div className="form-row">
+              <div className="field">
+                <label className="field__label" htmlFor="p-retail">
+                  Retail price ({code})
+                </label>
+                <input
+                  id="p-retail"
+                  className="input"
+                  type="number"
+                  min={0}
+                  step="0.01"
+                  inputMode="decimal"
+                  value={retail}
+                  onChange={(e) => setRetail(e.target.value)}
+                />
+              </div>
+              <div className="field">
+                <label className="field__label" htmlFor="p-wholesale">
+                  Wholesale price ({code})
+                </label>
+                <input
+                  id="p-wholesale"
+                  className="input"
+                  type="number"
+                  min={0}
+                  step="0.01"
+                  inputMode="decimal"
+                  value={wholesale}
+                  onChange={(e) => setWholesale(e.target.value)}
+                />
+              </div>
+            </div>
+
+            <div className="form-row">
+              <div className="field">
+                <label className="field__label" htmlFor="p-buying">
+                  Cost price ({code})
+                </label>
+                <input
+                  id="p-buying"
+                  className="input"
+                  type="number"
+                  min={0}
+                  step="0.01"
+                  inputMode="decimal"
+                  value={buying}
+                  onChange={(e) => setBuying(e.target.value)}
+                />
+                <span className="field__hint">
+                  {isEdit
+                    ? 'Applies to future stock; past batches keep their cost.'
+                    : 'The opening stock is valued at this cost.'}
+                </span>
+              </div>
+              {!isEdit && (
+                <div className="field">
+                  <label className="field__label" htmlFor="p-opening">
+                    Opening stock
+                  </label>
+                  <input
+                    id="p-opening"
+                    className="input"
+                    type="number"
+                    min={0}
+                    step="1"
+                    inputMode="numeric"
+                    value={openingStock}
+                    onChange={(e) => setOpeningStock(e.target.value)}
+                    placeholder="0"
+                  />
+                </div>
+              )}
+            </div>
+
+            <div className="form-row">
+              <div className="field">
+                <label className="field__label" htmlFor="p-lowstock">
+                  Low-stock alert at
+                </label>
+                <input
+                  id="p-lowstock"
+                  className="input"
+                  type="number"
+                  min={0}
+                  step="1"
+                  inputMode="numeric"
+                  value={lowStock}
+                  onChange={(e) => setLowStock(e.target.value)}
+                />
+              </div>
+              <div className="field field--check">
+                <label className="check">
+                  <input
+                    type="checkbox"
+                    checked={trackEmpties}
+                    onChange={(e) => setTrackEmpties(e.target.checked)}
+                  />
+                  <span>Track empty crates</span>
+                </label>
+                <span className="field__hint">
+                  For returnable bottles that carry a deposit.
+                </span>
+              </div>
+            </div>
+          </div>
+
+          <div className="modal__foot">
+            <button
+              type="button"
+              className="btn btn--outline"
+              onClick={onCancel}
+              disabled={submitting}
+            >
+              Cancel
+            </button>
+            <button type="submit" className="btn btn--primary" disabled={submitting}>
+              {submitting ? 'Saving…' : isEdit ? 'Save changes' : 'Add product'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/web-pos/src/components/inventory/ProductFormDialog.tsx
+++ b/web-pos/src/components/inventory/ProductFormDialog.tsx
@@ -65,7 +65,8 @@ export function ProductFormDialog({
   const [error, setError] = useState<string | null>(null);
 
   const businessId = operator?.businessId ?? null;
-  const storeId = operator?.stores?.[0]?.id ?? null;
+  const stores = operator?.stores ?? [];
+  const [storeId, setStoreId] = useState<string | null>(stores[0]?.id ?? null);
 
   async function onSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -284,6 +285,29 @@ export function ProductFormDialog({
                 </div>
               )}
             </div>
+
+            {!isEdit && stores.length > 1 && (
+              <div className="field">
+                <label className="field__label" htmlFor="p-store">
+                  Store
+                </label>
+                <select
+                  id="p-store"
+                  className="input"
+                  value={storeId ?? ''}
+                  onChange={(e) => setStoreId(e.target.value || null)}
+                >
+                  {stores.map((s) => (
+                    <option key={s.id} value={s.id}>
+                      {s.name}
+                    </option>
+                  ))}
+                </select>
+                <span className="field__hint">
+                  Opening stock lands in this store.
+                </span>
+              </div>
+            )}
 
             <div className="form-row">
               <div className="field">

--- a/web-pos/src/components/inventory/ReceiveStockDialog.tsx
+++ b/web-pos/src/components/inventory/ReceiveStockDialog.tsx
@@ -56,7 +56,8 @@ export function ReceiveStockDialog({
   const [error, setError] = useState<string | null>(null);
 
   const businessId = operator?.businessId ?? null;
-  const storeId = operator?.stores?.[0]?.id ?? null;
+  const stores = operator?.stores ?? [];
+  const [storeId, setStoreId] = useState<string | null>(stores[0]?.id ?? null);
 
   const available = useMemo(
     () => products.filter((p) => !lines.some((l) => l.productId === p.id)),
@@ -199,6 +200,27 @@ export function ReceiveStockDialog({
                 />
               </div>
             </div>
+
+            {stores.length > 1 && (
+              <div className="field">
+                <label className="field__label" htmlFor="r-store">
+                  Store
+                </label>
+                <select
+                  id="r-store"
+                  className="input"
+                  value={storeId ?? ''}
+                  onChange={(e) => setStoreId(e.target.value || null)}
+                >
+                  {stores.map((s) => (
+                    <option key={s.id} value={s.id}>
+                      {s.name}
+                    </option>
+                  ))}
+                </select>
+                <span className="field__hint">Stock is received into this store.</span>
+              </div>
+            )}
 
             <div className="field">
               <span className="field__label">Products received</span>

--- a/web-pos/src/components/inventory/ReceiveStockDialog.tsx
+++ b/web-pos/src/components/inventory/ReceiveStockDialog.tsx
@@ -1,0 +1,346 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+
+import { useSession } from '@/components/providers/SessionProvider';
+import { useCurrency } from '@/hooks/useCurrency';
+import {
+  receiveStock,
+  RECEIVE_PAYMENT_METHODS,
+  type ReceivePaymentMethod,
+} from '@/lib/inventory';
+import type { ProductWithStock, SupplierRow } from '@/lib/types';
+
+function toKobo(naira: string): number {
+  const n = parseFloat(naira);
+  return Number.isFinite(n) && n > 0 ? Math.round(n * 100) : 0;
+}
+function fromKobo(kobo: number | null | undefined): string {
+  return kobo && kobo > 0 ? (kobo / 100).toString() : '';
+}
+
+interface DraftLine {
+  productId: string;
+  name: string;
+  quantity: string;
+  buying: string; // Naira
+}
+
+// Log a supplier delivery: increases stock, posts the supplier invoice (debit) +
+// an optional payment (credit), and pushes a receipt-dated Cost Batch per line at
+// the delivery cost. Mirrors the mobile Receive Stock flow; the receive_stock RPC
+// does it all atomically server-side and re-checks the permission.
+export function ReceiveStockDialog({
+  products,
+  suppliers,
+  onSaved,
+  onCancel,
+}: {
+  products: ProductWithStock[];
+  suppliers: SupplierRow[];
+  onSaved: () => void;
+  onCancel: () => void;
+}) {
+  const { supabase, operator } = useSession();
+  const { code, kobo } = useCurrency();
+
+  const today = new Date().toISOString().slice(0, 10);
+  const [supplierId, setSupplierId] = useState(suppliers[0]?.id ?? '');
+  const [receivedAt, setReceivedAt] = useState(today);
+  const [lines, setLines] = useState<DraftLine[]>([]);
+  const [picker, setPicker] = useState('');
+  const [method, setMethod] = useState<ReceivePaymentMethod>('cash');
+  const [amountPaid, setAmountPaid] = useState('');
+  const [note, setNote] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const businessId = operator?.businessId ?? null;
+  const storeId = operator?.stores?.[0]?.id ?? null;
+
+  const available = useMemo(
+    () => products.filter((p) => !lines.some((l) => l.productId === p.id)),
+    [products, lines],
+  );
+
+  const invoiceTotalKobo = useMemo(
+    () =>
+      lines.reduce(
+        (sum, l) => sum + (parseInt(l.quantity, 10) || 0) * toKobo(l.buying),
+        0,
+      ),
+    [lines],
+  );
+
+  function addLine(productId: string) {
+    const p = products.find((x) => x.id === productId);
+    if (!p) return;
+    setLines((prev) => [
+      ...prev,
+      {
+        productId: p.id,
+        name: p.name,
+        quantity: '1',
+        buying: fromKobo(p.buying_price_kobo),
+      },
+    ]);
+    setPicker('');
+  }
+
+  function updateLine(productId: string, patch: Partial<DraftLine>) {
+    setLines((prev) =>
+      prev.map((l) => (l.productId === productId ? { ...l, ...patch } : l)),
+    );
+  }
+
+  function removeLine(productId: string) {
+    setLines((prev) => prev.filter((l) => l.productId !== productId));
+  }
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!businessId || !storeId) {
+      setError('Your session is not linked to a business/store.');
+      return;
+    }
+    if (!supplierId) {
+      setError('Choose a supplier for this delivery.');
+      return;
+    }
+    const cleaned = lines
+      .map((l) => ({
+        productId: l.productId,
+        quantity: parseInt(l.quantity, 10) || 0,
+        buyingPriceKobo: toKobo(l.buying),
+      }))
+      .filter((l) => l.quantity > 0);
+    if (cleaned.length === 0) {
+      setError('Add at least one line with a quantity of one or more.');
+      return;
+    }
+    setSubmitting(true);
+    setError(null);
+    try {
+      await receiveStock(supabase, {
+        businessId,
+        supplierId,
+        storeId,
+        receivedAt: new Date(receivedAt).toISOString(),
+        lines: cleaned,
+        amountPaidKobo: toKobo(amountPaid),
+        paymentMethod: method,
+        note: note.trim() || null,
+      });
+      onSaved();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Could not record the delivery.');
+      setSubmitting(false);
+    }
+  }
+
+  const noSuppliers = suppliers.length === 0;
+
+  return (
+    <div
+      className="modal-overlay"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Receive stock"
+    >
+      <div className="modal modal--wide">
+        <div className="modal__head">
+          <h2 className="modal__title">Receive stock</h2>
+          <button className="modal__close" onClick={onCancel} aria-label="Close">
+            ✕
+          </button>
+        </div>
+
+        <form onSubmit={onSubmit}>
+          <div className="modal__body">
+            {error && <div className="banner banner--error">{error}</div>}
+            {noSuppliers && (
+              <div className="banner">
+                No suppliers yet — add a supplier on the mobile app first, then
+                record the delivery here.
+              </div>
+            )}
+
+            <div className="form-row">
+              <div className="field">
+                <label className="field__label" htmlFor="r-supplier">
+                  Supplier
+                </label>
+                <select
+                  id="r-supplier"
+                  className="input"
+                  value={supplierId}
+                  onChange={(e) => setSupplierId(e.target.value)}
+                  disabled={noSuppliers}
+                >
+                  <option value="">Choose a supplier…</option>
+                  {suppliers.map((s) => (
+                    <option key={s.id} value={s.id}>
+                      {s.name ?? 'Unnamed supplier'}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div className="field">
+                <label className="field__label" htmlFor="r-date">
+                  Date received
+                </label>
+                <input
+                  id="r-date"
+                  className="input"
+                  type="date"
+                  value={receivedAt}
+                  max={today}
+                  onChange={(e) => setReceivedAt(e.target.value)}
+                />
+              </div>
+            </div>
+
+            <div className="field">
+              <span className="field__label">Products received</span>
+              {lines.length === 0 ? (
+                <p className="muted">No lines yet — add a product below.</p>
+              ) : (
+                <div className="receive-lines">
+                  {lines.map((l) => (
+                    <div key={l.productId} className="receive-line">
+                      <span className="receive-line__name">{l.name}</span>
+                      <input
+                        className="input receive-line__qty"
+                        type="number"
+                        min={1}
+                        step={1}
+                        inputMode="numeric"
+                        aria-label={`Quantity of ${l.name}`}
+                        value={l.quantity}
+                        onChange={(e) =>
+                          updateLine(l.productId, { quantity: e.target.value })
+                        }
+                      />
+                      <input
+                        className="input receive-line__cost"
+                        type="number"
+                        min={0}
+                        step="0.01"
+                        inputMode="decimal"
+                        aria-label={`Unit cost of ${l.name} in ${code}`}
+                        value={l.buying}
+                        onChange={(e) =>
+                          updateLine(l.productId, { buying: e.target.value })
+                        }
+                      />
+                      <span className="receive-line__total">
+                        {kobo((parseInt(l.quantity, 10) || 0) * toKobo(l.buying))}
+                      </span>
+                      <button
+                        type="button"
+                        className="btn btn--outline btn--sm"
+                        onClick={() => removeLine(l.productId)}
+                        aria-label={`Remove ${l.name}`}
+                      >
+                        ✕
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              )}
+
+              {available.length > 0 && (
+                <select
+                  className="input"
+                  value={picker}
+                  onChange={(e) => e.target.value && addLine(e.target.value)}
+                >
+                  <option value="">+ Add a product…</option>
+                  {available.map((p) => (
+                    <option key={p.id} value={p.id}>
+                      {p.name}
+                    </option>
+                  ))}
+                </select>
+              )}
+            </div>
+
+            <div className="receive-invoice">
+              <span>Invoice total</span>
+              <strong>{kobo(invoiceTotalKobo)}</strong>
+            </div>
+
+            <div className="form-row">
+              <div className="field">
+                <label className="field__label" htmlFor="r-paid">
+                  Amount paid now ({code})
+                </label>
+                <input
+                  id="r-paid"
+                  className="input"
+                  type="number"
+                  min={0}
+                  step="0.01"
+                  inputMode="decimal"
+                  value={amountPaid}
+                  onChange={(e) => setAmountPaid(e.target.value)}
+                  placeholder="0"
+                />
+              </div>
+              <div className="field">
+                <label className="field__label" htmlFor="r-method">
+                  Payment method
+                </label>
+                <select
+                  id="r-method"
+                  className="input"
+                  value={method}
+                  onChange={(e) =>
+                    setMethod(e.target.value as ReceivePaymentMethod)
+                  }
+                >
+                  {RECEIVE_PAYMENT_METHODS.map((m) => (
+                    <option key={m} value={m}>
+                      {m[0].toUpperCase() + m.slice(1)}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            </div>
+
+            <div className="field">
+              <label className="field__label" htmlFor="r-note">
+                Note / reference (optional)
+              </label>
+              <input
+                id="r-note"
+                className="input"
+                value={note}
+                onChange={(e) => setNote(e.target.value)}
+                placeholder="Invoice number, bank reference…"
+              />
+            </div>
+          </div>
+
+          <div className="modal__foot">
+            <button
+              type="button"
+              className="btn btn--outline"
+              onClick={onCancel}
+              disabled={submitting}
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              className="btn btn--primary"
+              disabled={submitting || noSuppliers || lines.length === 0}
+            >
+              {submitting ? 'Recording…' : 'Record delivery'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/web-pos/src/components/providers/NavProvider.tsx
+++ b/web-pos/src/components/providers/NavProvider.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import {
+  createContext,
+  useContext,
+  useMemo,
+  useState,
+  type ReactNode,
+} from 'react';
+
+// The in-app "view" the shell shows. The Web POS is a single signed-in surface
+// (ADR 0011) rather than a multi-route site, so navigation is a client-side view
+// switch held above the shell — the sidebar sets it, the content area renders it.
+// Slice 6 (#48) adds 'inventory'; later slices add their own.
+export type AppView = 'pos' | 'inventory' | 'reports';
+
+interface NavContextValue {
+  view: AppView;
+  setView: (view: AppView) => void;
+}
+
+const NavContext = createContext<NavContextValue | null>(null);
+
+export function NavProvider({ children }: { children: ReactNode }) {
+  const [view, setView] = useState<AppView>('pos');
+  const value = useMemo<NavContextValue>(() => ({ view, setView }), [view]);
+  return <NavContext.Provider value={value}>{children}</NavContext.Provider>;
+}
+
+export function useNav(): NavContextValue {
+  const ctx = useContext(NavContext);
+  if (!ctx) throw new Error('useNav must be used within a NavProvider');
+  return ctx;
+}

--- a/web-pos/src/components/shell/AppShell.tsx
+++ b/web-pos/src/components/shell/AppShell.tsx
@@ -7,6 +7,7 @@ import { useCan } from '@/components/permissions/Can';
 import { PermissionKeys } from '@/lib/permissions';
 import { useTheme, type UserThemeMode } from '@/components/providers/ThemeProvider';
 import { useCart } from '@/components/pos/CartProvider';
+import { useNav } from '@/components/providers/NavProvider';
 
 // Outline SVG Icons for Sidebar & Header
 const HomeIcon = () => (
@@ -102,6 +103,7 @@ export function AppShell({ children }: { children: ReactNode }) {
   const { operator, signOut } = useSession();
   const { themeMode, setThemeMode } = useTheme();
   const cart = useCart();
+  const { view, setView } = useNav();
   const canInventory =
     useCan(PermissionKeys.stockView) || useCan(PermissionKeys.productsAdd);
   const canReports = useCan(PermissionKeys.reportsView);
@@ -171,8 +173,22 @@ export function AppShell({ children }: { children: ReactNode }) {
 
         {/* Navigation List */}
         <div className="shell__nav-items">
-          <NavItem icon={<HomeIcon />} label="Home" collapsed={isCollapsed} />
-          <NavItem icon={<ProductsIcon />} label="Products" active collapsed={isCollapsed} />
+          <NavItem
+            icon={<HomeIcon />}
+            label="Sell"
+            active={view === 'pos'}
+            collapsed={isCollapsed}
+            onClick={() => setView('pos')}
+          />
+          {canInventory && (
+            <NavItem
+              icon={<ProductsIcon />}
+              label="Products"
+              active={view === 'inventory'}
+              collapsed={isCollapsed}
+              onClick={() => setView('inventory')}
+            />
+          )}
           <NavItem icon={<SalesIcon />} label="Sales" collapsed={isCollapsed} />
           {canReports && <NavItem icon={<ReportsIcon />} label="Reports" collapsed={isCollapsed} />}
           <NavItem icon={<SettingsIcon />} label="Settings" collapsed={isCollapsed} />
@@ -302,24 +318,47 @@ function NavItem({
   label,
   active = false,
   collapsed = false,
+  onClick,
 }: {
   icon: ReactNode;
   label: string;
   active?: boolean;
   collapsed?: boolean;
+  onClick?: () => void;
 }) {
-  return (
-    <div
-      className={`shell__nav-item${active ? ' shell__nav-item--active' : ''}${
-        collapsed ? ' shell__nav-item--collapsed' : ''
-      }`}
-      aria-current={active ? 'page' : undefined}
-      title={collapsed ? label : undefined}
-    >
+  const className = `shell__nav-item${active ? ' shell__nav-item--active' : ''}${
+    collapsed ? ' shell__nav-item--collapsed' : ''
+  }`;
+  const inner = (
+    <>
       <span className="shell__nav-icon" aria-hidden>
         {icon}
       </span>
       <span className="shell__nav-label">{label}</span>
+    </>
+  );
+
+  // Interactive items are real buttons (keyboard + a11y); inert ones stay a div.
+  if (onClick) {
+    return (
+      <button
+        type="button"
+        className={className}
+        aria-current={active ? 'page' : undefined}
+        title={collapsed ? label : undefined}
+        onClick={onClick}
+      >
+        {inner}
+      </button>
+    );
+  }
+  return (
+    <div
+      className={className}
+      aria-current={active ? 'page' : undefined}
+      title={collapsed ? label : undefined}
+    >
+      {inner}
     </div>
   );
 }

--- a/web-pos/src/lib/inventory.ts
+++ b/web-pos/src/lib/inventory.ts
@@ -1,0 +1,234 @@
+// Web POS Slice 6 (#48) — the inventory money-writes. Like checkout (Slice 2),
+// the web never writes catalogue/stock rows through PostgREST: it calls the
+// server-authoritative RPCs add_product / update_product / receive_stock
+// (migration 0140, ADR 0008), each one atomic transaction that also enforces the
+// caller's permission server-side. Amounts are `*_kobo` bigint end to end.
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+import type { CategoryRow, ProductRow, SupplierRow } from './types';
+
+// A product unit the catalogue understands (mirrors the cloud products.unit
+// CHECK). 'Piece' is the neutral default for a non-returnable item.
+export const PRODUCT_UNITS = [
+  'Bottle',
+  'Can',
+  'PET',
+  'Sachet',
+  'Keg',
+  'Crate',
+  'Pack',
+  'Carton',
+  'Piece',
+  'Bag',
+  'Box',
+  'Tin',
+  'Other',
+] as const;
+export type ProductUnit = (typeof PRODUCT_UNITS)[number];
+
+// A supplier payment tender for Receive Stock (mirrors supplier_ledger_entries).
+export const RECEIVE_PAYMENT_METHODS = ['cash', 'transfer', 'pos', 'other'] as const;
+export type ReceivePaymentMethod = (typeof RECEIVE_PAYMENT_METHODS)[number];
+
+function newId(): string {
+  return typeof crypto !== 'undefined' && 'randomUUID' in crypto
+    ? crypto.randomUUID()
+    : `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
+
+// Map an RPC error token to an operator-facing message (mirrors checkout.ts).
+function friendlyError(message: string): string {
+  if (message.includes('permission_denied')) {
+    return 'You do not have permission to do this. Ask a manager.';
+  }
+  if (message.includes('name_required')) {
+    return 'Enter a product name.';
+  }
+  if (message.includes('lines_required') || message.includes('line_quantity_must_be_positive')) {
+    return 'Add at least one line with a quantity of one or more.';
+  }
+  if (message.includes('opening_stock_must_be_non_negative')) {
+    return 'Opening stock cannot be negative.';
+  }
+  if (message.includes('product_not_found')) {
+    return 'That product no longer exists. Refresh and try again.';
+  }
+  if (message.includes('supplier_id_required')) {
+    return 'Choose a supplier for this delivery.';
+  }
+  if (message.includes('store_id_required')) {
+    return 'This account has no store set up yet.';
+  }
+  if (message.includes('tenant_mismatch') || message.includes('no_business_for_caller')) {
+    return 'Your session is not linked to this business. Sign out and back in.';
+  }
+  return message;
+}
+
+export interface AddProductArgs {
+  businessId: string;
+  storeId: string;
+  name: string;
+  categoryId?: string | null;
+  unit: ProductUnit;
+  size?: string | null;
+  retailerPriceKobo: number;
+  wholesalerPriceKobo: number;
+  buyingPriceKobo: number;
+  openingStock: number;
+  trackEmpties?: boolean;
+  manufacturerId?: string | null;
+  lowStockThreshold?: number;
+}
+
+export async function addProduct(
+  supabase: SupabaseClient,
+  args: AddProductArgs,
+): Promise<ProductRow> {
+  const { data, error } = await supabase.rpc('add_product', {
+    p_business_id: args.businessId,
+    p_product_id: newId(),
+    p_store_id: args.storeId,
+    p_name: args.name.trim(),
+    p_category_id: args.categoryId ?? null,
+    p_unit: args.unit,
+    p_size: args.size ?? null,
+    p_retailer_price_kobo: args.retailerPriceKobo,
+    p_wholesaler_price_kobo: args.wholesalerPriceKobo,
+    p_buying_price_kobo: args.buyingPriceKobo,
+    p_opening_stock: args.openingStock,
+    p_track_empties: args.trackEmpties ?? false,
+    p_manufacturer_id: args.manufacturerId ?? null,
+    p_low_stock_threshold: args.lowStockThreshold ?? 5,
+  });
+  if (error) throw new Error(friendlyError(error.message));
+  return (data as { product: ProductRow }).product;
+}
+
+export interface UpdateProductArgs {
+  businessId: string;
+  productId: string;
+  name?: string;
+  categoryId?: string | null;
+  unit?: ProductUnit;
+  size?: string | null;
+  retailerPriceKobo?: number;
+  wholesalerPriceKobo?: number;
+  buyingPriceKobo?: number;
+  trackEmpties?: boolean;
+  manufacturerId?: string | null;
+  lowStockThreshold?: number;
+}
+
+export async function updateProduct(
+  supabase: SupabaseClient,
+  args: UpdateProductArgs,
+): Promise<ProductRow> {
+  const { data, error } = await supabase.rpc('update_product', {
+    p_business_id: args.businessId,
+    p_product_id: args.productId,
+    p_name: args.name ?? null,
+    p_category_id: args.categoryId ?? null,
+    p_unit: args.unit ?? null,
+    p_size: args.size ?? null,
+    p_retailer_price_kobo: args.retailerPriceKobo ?? null,
+    p_wholesaler_price_kobo: args.wholesalerPriceKobo ?? null,
+    p_buying_price_kobo: args.buyingPriceKobo ?? null,
+    p_track_empties: args.trackEmpties ?? null,
+    p_manufacturer_id: args.manufacturerId ?? null,
+    p_low_stock_threshold: args.lowStockThreshold ?? null,
+  });
+  if (error) throw new Error(friendlyError(error.message));
+  return (data as { product: ProductRow }).product;
+}
+
+export interface ReceiveStockLine {
+  productId: string;
+  quantity: number;
+  buyingPriceKobo: number;
+  // Optional edited sell prices persisted alongside the delivery.
+  retailerPriceKobo?: number | null;
+  wholesalerPriceKobo?: number | null;
+}
+
+export interface ReceiveStockArgs {
+  businessId: string;
+  supplierId: string;
+  storeId: string;
+  receivedAt?: string; // ISO; defaults server-side to now
+  lines: ReceiveStockLine[];
+  amountPaidKobo: number;
+  paymentMethod: ReceivePaymentMethod;
+  note?: string | null;
+}
+
+export interface ReceiveStockResult {
+  invoiceTotalKobo: number;
+  amountPaidKobo: number;
+  units: number;
+}
+
+export async function receiveStock(
+  supabase: SupabaseClient,
+  args: ReceiveStockArgs,
+): Promise<ReceiveStockResult> {
+  const { data, error } = await supabase.rpc('receive_stock', {
+    p_business_id: args.businessId,
+    p_receipt_id: newId(),
+    p_supplier_id: args.supplierId,
+    p_store_id: args.storeId,
+    p_lines: args.lines.map((l) => ({
+      product_id: l.productId,
+      quantity: l.quantity,
+      buying_price_kobo: l.buyingPriceKobo,
+      retailer_price_kobo: l.retailerPriceKobo ?? null,
+      wholesaler_price_kobo: l.wholesalerPriceKobo ?? null,
+    })),
+    p_received_at: args.receivedAt ?? null,
+    p_amount_paid_kobo: args.amountPaidKobo,
+    p_payment_method: args.paymentMethod,
+    p_note: args.note ?? null,
+  });
+  if (error) throw new Error(friendlyError(error.message));
+  const payload = data as {
+    invoice_total_kobo: number;
+    amount_paid_kobo: number;
+    units: number;
+  };
+  return {
+    invoiceTotalKobo: payload.invoice_total_kobo,
+    amountPaidKobo: payload.amount_paid_kobo,
+    units: payload.units,
+  };
+}
+
+export interface InventoryRefs {
+  categories: CategoryRow[];
+  suppliers: SupplierRow[];
+}
+
+// Reference data for the add/edit + receive forms (categories for the picker,
+// suppliers for a delivery). RLS-scoped to the Operator's business.
+export async function loadInventoryRefs(
+  supabase: SupabaseClient,
+): Promise<InventoryRefs> {
+  const [categoriesRes, suppliersRes] = await Promise.all([
+    supabase
+      .from('categories')
+      .select('id, business_id, name, is_deleted')
+      .eq('is_deleted', false)
+      .order('name', { ascending: true })
+      .returns<CategoryRow[]>(),
+    supabase
+      .from('suppliers')
+      .select('id, business_id, name, is_deleted')
+      .eq('is_deleted', false)
+      .order('name', { ascending: true })
+      .returns<SupplierRow[]>(),
+  ]);
+  return {
+    categories: categoriesRes.data ?? [],
+    suppliers: suppliersRes.data ?? [],
+  };
+}

--- a/web-pos/src/lib/permissions.ts
+++ b/web-pos/src/lib/permissions.ts
@@ -21,6 +21,8 @@ export const PermissionKeys = {
   salesMake: 'sales.make',
   productsAdd: 'products.add',
   stockView: 'stock.view',
+  stockAdd: 'stock.add',
+  stockReceived: 'stock.received',
   reportsView: 'reports.view',
 } as const;
 

--- a/web-pos/src/lib/types.ts
+++ b/web-pos/src/lib/types.ts
@@ -99,6 +99,15 @@ export interface ProductRow {
   manufacturer_id: string | null;
 }
 
+// A supplier (Slice 6, #48) — the party a Receive Stock delivery is booked
+// against. The delivery's invoice/payment post to this supplier's ledger.
+export interface SupplierRow {
+  id: string;
+  business_id: string;
+  name: string | null;
+  is_deleted: boolean | null;
+}
+
 // A manufacturer with its per-crate deposit rate (deposit_amount_kobo). The
 // deposit value of empties is per-manufacturer, shared across its products.
 export interface ManufacturerRow {


### PR DESCRIPTION
Closes #48. Phase-1 Web POS inventory management (epic #46).

## What
Server-authoritative inventory RPCs + web UI, following ADR 0008 (RPC write API) and 0009 (two implementations, one contract).

### Server — `supabase/migrations/0140_web_inventory_rpcs.sql` (deployed)
- **`add_product`** — creates a product; opening stock goes straight to inventory with the opening Cost Batch (costed or uncosted). No supplier/invoice/payable (ADR 0005/0006).
- **`update_product`** — edits details/prices; inventory and Cost Batches are untouched.
- **`receive_stock`** — logs a supplier delivery: supplier invoice (debit) + optional payment (credit), and per line an inventory increase, price persistence, a stock movement, and a receipt-dated Cost Batch at the delivery cost.
- SQL twins of the mobile Dart path (`recordInflowBatch`, `adjustStock`, `SupplierAccountService`); each re-checks the caller's permission server-side (`products.add` / `stock.received`\|`stock.add`) and is idempotent on the client-minted id.

### Correctness guardrail — batch-creation Golden Suite
New golden dimension (`test/golden/inventory_scenario.dart` + `fixtures/inventory_scenarios.json`) pinning the Cost Batch producer rule identical across the **Dart DAO** (`inventory_dart_dao_golden_test.dart`) and the **SQL RPC** (`test/integration/rpcs/web_inventory_golden_test.dart`, Tier-2). Drift fails the build.

### Web UI — `web-pos/src/components/inventory/*`, `lib/inventory.ts`
Inventory view (responsive table + low-stock highlight), add/edit Product dialog, Receive Stock dialog. Sidebar nav is now a client-side view switch (`NavProvider`). Hide-don't-block on the same keys the RPCs enforce; money via the business-currency helpers, stored as `*_kobo`.

## Verification
- Dart golden suite green (6/6 scenarios).
- `add_product` + `receive_stock` smoke-tested live against a real CEO inside a rolled-back transaction (product/inventory/batch/supplier-ledger all correct, permission + tenant guards enforced, nothing persisted).
- `web-pos`: `tsc --noEmit` + `next build` green.

## Acceptance criteria (#48)
- [x] Manager can add a product on web; appears in the grid with the opening Cost Batch
- [x] Manager can edit a product's prices/details
- [x] Manager can Receive Stock; a new Cost Batch is pushed at the delivery cost and stock increases
- [x] Add Product creates no supplier invoice/payable; Receive Stock does
- [x] Golden fixtures for opening/receive batch costing run against the Dart DAO and the SQL RPC
- [x] Responsive across breakpoints; CEO palette; server-side permission enforcement

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Inventory view with search, low-stock highlighting, and product receive/add dialogs.
  * Added navigation switching between Selling, Inventory, and Reports.
  * Introduced server-authoritative inventory RPCs for adding/updating products and receiving stock.
* **Bug Fixes**
  * Prevented duplicate submissions and cross-tenant collisions during inventory writes.
  * Fixed buying-cost handling when line costs are zero and improved store selection in dialogs.
* **Tests**
  * Added/expanded golden fixtures and golden test suites to validate batching and costing outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->