### PR TITLE
Web POS Slice 5 — Live consistency (Realtime) (#49)

### DIFF
--- a/BUILD_LOG.md
+++ b/BUILD_LOG.md
@@ -2,6 +2,28 @@
 
 ---
 
+## 2026-07-05 — Web POS Slice 5: Live consistency / Realtime (issue #49)
+
+**What changed.** The Web POS grid now stays live with the mobile tills via
+Supabase Realtime — no manual refresh. Pure web-client feature (all operational
+tables were already in the `supabase_realtime` publication; no migration). Web
+`tsc` + `next build` green.
+
+- **`useRealtimeRefresh` hook (`web-pos/src/hooks/useRealtimeRefresh.ts`).** One
+  business-scoped channel subscribes to `postgres_changes` on `products`,
+  `inventory`, `cost_batches`, `orders` (filtered `business_id=eq.<id>`, matching
+  the RLS the channel authorizes with). Rather than diff individual events, any
+  change triggers a debounced re-pull of the same RLS-scoped read Slice 1 wired —
+  reconciliation stays trivially correct (the screen re-derives from the
+  authoritative cloud rows). Reconnect/backfill: a re-SUBSCRIBED channel and a
+  tab regaining focus/connectivity both re-pull, so a dropped socket never leaves
+  the view stale. Returns a `connecting | live | offline` status.
+- **`PosScreen`** wires the hook to its catalogue `refresh` and shows a small
+  Live/Offline badge; a price edit, stock change, or new order on any device now
+  appears in the grid automatically.
+
+---
+
 ## 2026-07-05 — Web POS checkout-UI cleanup (issue #57)
 
 **What changed.** Quality-only de-duplication of the Slice 2–4 web checkout; no

--- a/web-pos/src/app/globals.css
+++ b/web-pos/src/app/globals.css
@@ -1766,3 +1766,45 @@ input {
   color: var(--subtext);
   font-weight: 500;
 }
+
+/* ── Realtime live indicator (Slice 5, #49) ───────────────────────────────── */
+.live-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 600;
+  border: 1px solid var(--border);
+  color: var(--subtext);
+  background: color-mix(in srgb, var(--surface2) 70%, transparent);
+  white-space: nowrap;
+}
+.live-badge__dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: currentColor;
+}
+.live-badge--live {
+  color: var(--success);
+  border-color: color-mix(in srgb, var(--success) 40%, transparent);
+}
+.live-badge--live .live-badge__dot {
+  animation: live-pulse 1.8s ease-in-out infinite;
+}
+.live-badge--connecting {
+  color: var(--warning, var(--info));
+}
+.live-badge--offline {
+  color: var(--danger, var(--error));
+  border-color: color-mix(in srgb, var(--danger, var(--error)) 40%, transparent);
+}
+@keyframes live-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.35; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .live-badge--live .live-badge__dot { animation: none; }
+}

--- a/web-pos/src/components/pos/PosScreen.tsx
+++ b/web-pos/src/components/pos/PosScreen.tsx
@@ -6,6 +6,7 @@ import { useSession } from '@/components/providers/SessionProvider';
 import { useCan } from '@/components/permissions/Can';
 import { useCurrency } from '@/hooks/useCurrency';
 import { useCustomers } from '@/hooks/useCustomers';
+import { useRealtimeRefresh, type RealtimeStatus } from '@/hooks/useRealtimeRefresh';
 import { PermissionKeys } from '@/lib/permissions';
 import { loadCatalogue, type Catalogue } from '@/lib/catalogue';
 import type { CheckoutResult } from '@/lib/checkout';
@@ -60,6 +61,16 @@ export function PosScreen() {
     void refresh();
   }, [refresh, businessId]);
 
+  // Slice 5 (#49): live consistency. A price/stock/order change on any device
+  // re-pulls the catalogue so the grid never goes stale; a dropped-then-restored
+  // socket backfills automatically.
+  const liveStatus = useRealtimeRefresh({
+    supabase,
+    businessId,
+    tables: ['products', 'inventory', 'cost_batches', 'orders'],
+    onChange: refresh,
+  });
+
   const filtered = useMemo(() => {
     if (!catalogue) return [];
     let items = catalogue.products;
@@ -112,6 +123,7 @@ export function PosScreen() {
       <div className="pos">
         <div className="pos__header">
           <h1 className="pos__title">Point of Sale</h1>
+          <LiveBadge status={liveStatus} />
           <button
             className="btn btn--outline btn--refresh"
             onClick={() => void refresh()}
@@ -239,6 +251,27 @@ export function PosScreen() {
         <Receipt result={result} onDone={onDone} />
       )}
     </div>
+  );
+}
+
+// A small live/offline indicator for the Realtime connection (Slice 5).
+function LiveBadge({ status }: { status: RealtimeStatus }) {
+  const label =
+    status === 'live' ? 'Live' : status === 'connecting' ? 'Connecting…' : 'Offline';
+  return (
+    <span
+      className={`live-badge live-badge--${status}`}
+      title={
+        status === 'live'
+          ? 'Connected — the grid updates automatically'
+          : status === 'offline'
+            ? 'Reconnecting — pull to refresh if needed'
+            : 'Connecting…'
+      }
+    >
+      <span className="live-badge__dot" aria-hidden />
+      {label}
+    </span>
   );
 }
 

--- a/web-pos/src/hooks/useRealtimeRefresh.ts
+++ b/web-pos/src/hooks/useRealtimeRefresh.ts
@@ -1,0 +1,101 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+// Web POS Slice 5 (#49) — live consistency via Supabase Realtime. The web is
+// online-first (ADR 0007): rather than diff individual change events into local
+// state, we subscribe to the operational tables and, on any change, trigger a
+// debounced re-pull of the affected read (the same RLS-scoped query Slice 1
+// wired). This keeps the reconciliation trivially correct — the screen always
+// re-derives from the authoritative cloud rows — while still feeling live.
+//
+// Reconnect/backfill (AC): a channel that drops and re-subscribes fires onChange
+// on re-SUBSCRIBED, and a tab that regains focus/connectivity refreshes too, so a
+// dropped socket never leaves the view stale.
+
+export type RealtimeStatus = 'connecting' | 'live' | 'offline';
+
+// One Realtime channel per business, listening to the given tables (all scoped
+// to business_id via the filter — matches the RLS the channel authorizes with).
+// [onChange] is called (debounced) on any insert/update/delete and on reconnect.
+export function useRealtimeRefresh({
+  supabase,
+  businessId,
+  tables,
+  onChange,
+  debounceMs = 350,
+}: {
+  supabase: SupabaseClient;
+  businessId: string | null;
+  tables: string[];
+  onChange: () => void;
+  debounceMs?: number;
+}): RealtimeStatus {
+  const [status, setStatus] = useState<RealtimeStatus>('connecting');
+
+  // Keep the latest callback without re-subscribing on every render.
+  const onChangeRef = useRef(onChange);
+  onChangeRef.current = onChange;
+
+  // A stable key so the effect only re-runs when the actual table set changes.
+  const tablesKey = tables.join(',');
+
+  useEffect(() => {
+    if (!businessId) return;
+
+    let debounce: ReturnType<typeof setTimeout> | undefined;
+    const fire = () => {
+      if (debounce) clearTimeout(debounce);
+      debounce = setTimeout(() => onChangeRef.current(), debounceMs);
+    };
+
+    // Whether we've been subscribed at least once — a later SUBSCRIBED then
+    // means a reconnect, so we backfill by re-pulling.
+    let hadConnection = false;
+
+    const channel = supabase.channel(`web-pos:${businessId}`);
+    for (const table of tablesKey.split(',')) {
+      channel.on(
+        'postgres_changes',
+        {
+          event: '*',
+          schema: 'public',
+          table,
+          filter: `business_id=eq.${businessId}`,
+        },
+        fire,
+      );
+    }
+    channel.subscribe((channelStatus) => {
+      if (channelStatus === 'SUBSCRIBED') {
+        setStatus('live');
+        if (hadConnection) fire(); // reconnect → backfill anything missed
+        hadConnection = true;
+      } else if (
+        channelStatus === 'CHANNEL_ERROR' ||
+        channelStatus === 'TIMED_OUT' ||
+        channelStatus === 'CLOSED'
+      ) {
+        setStatus('offline');
+      }
+    });
+
+    // A tab that regains focus or connectivity re-pulls (covers a socket that
+    // dropped while backgrounded / offline).
+    const onWake = () => {
+      if (document.visibilityState === 'visible') fire();
+    };
+    window.addEventListener('online', fire);
+    document.addEventListener('visibilitychange', onWake);
+
+    return () => {
+      if (debounce) clearTimeout(debounce);
+      window.removeEventListener('online', fire);
+      document.removeEventListener('visibilitychange', onWake);
+      void supabase.removeChannel(channel);
+    };
+  }, [supabase, businessId, tablesKey, debounceMs]);
+
+  return status;
+}


### PR DESCRIPTION
Closes #49. Phase-1 Web POS live consistency (epic #46). Independent of the inventory slices — branches off `main`.

## What
`useRealtimeRefresh` (`web-pos/src/hooks/useRealtimeRefresh.ts`): one business-scoped Supabase Realtime channel subscribes to `postgres_changes` on `products`, `inventory`, `cost_batches`, and `orders` (filtered `business_id=eq.<id>`, matching the RLS the channel authorizes with). Instead of diffing individual events, any change triggers a **debounced re-pull** of the same RLS-scoped read Slice 1 wired, so reconciliation stays trivially correct — the grid always re-derives from the authoritative cloud rows. `PosScreen` wires it to its catalogue refresh and shows a Live/Offline badge.

**Reconnect/backfill:** a re-`SUBSCRIBED` channel and a tab regaining focus/connectivity both re-pull, so a dropped socket never leaves the view stale.

No migration — every operational table is already in the `supabase_realtime` publication.

## Verification
- `web-pos`: `tsc --noEmit` + `next build` green.
- Live cross-client behavior (price edit / stock / new order propagating, reconnect re-sync) is a QA-gate item requiring two live clients.

## Acceptance criteria (#49)
- [x] A price edited on a mobile device appears in the web grid without a manual refresh *(re-pull on `products` change)*
- [x] Stock counts update live as other tills sell *(re-pull on `inventory` change)*
- [x] A web/mobile sale appears on the other client live *(web already writes ordinary cloud rows; web subscribes to `orders`)*
- [x] After a dropped/restored connection the web re-syncs *(reconnect + focus/online backfill)*
- [x] Responsive; honors the CEO palette