### PR TITLE
Web POS Slice 7 — Inventory: stock adjustment + approval gate (#50)

### DIFF
--- a/BUILD_LOG.md
+++ b/BUILD_LOG.md
@@ -2,6 +2,36 @@
 
 ---
 
+## 2026-07-05 — Web POS Slice 7: Stock adjustment + approval gate (issue #50)
+
+**What changed.** The Web POS gained stock adjustment with the approval gate,
+mirroring mobile §16.6.1: a stock keeper's change is a pending request; a
+manager/CEO applies immediately and approves/rejects the queue. Stacked on #48.
+Verified: Dart golden green (4/4), all three paths (CEO apply / approve / reject)
+smoke-tested live in a rolled-back transaction, web `tsc` + `next build` green.
+
+- **Migration `0141_web_stock_adjustment_rpcs.sql` (deployed).** `request_stock_
+  adjustment` branches on the CALLER's role (`caller_role_slug` helper, new):
+  CEO/Manager applies immediately (+ an approved audit row); anyone else with
+  `stock.adjust` files a pending request, no inventory change. `approve_stock_
+  adjustment` (approver-only) applies the delta or rejects with no change. Shared
+  `_apply_stock_adjustment` helper mirrors `InventoryDao.adjustStock` (guarded
+  inventory delta + `stock_adjustments` + `stock_transactions('adjustment')`) — no
+  Cost Batch, an adjustment is a correction not an inflow. Both RPCs idempotent /
+  status-guarded.
+- **Golden Suite (`test/golden/stock_adjustment_scenario.dart` + fixtures).**
+  request-vs-apply pinned across the Dart DAO (`stock_adjustment_dart_dao_golden_
+  test.dart`) and the SQL RPC (`web_stock_adjustment_golden_test.dart`, Tier-2).
+  The stock-keeper → pending path is pinned on the Dart arm; the RPC arm (CEO
+  identity, routed to immediate-apply) skips 'request' scenarios — same precedent
+  as the checkout discount clamp.
+- **Web UI.** Per-product "Adjust" action (`AdjustStockDialog`, on `stock.adjust`)
+  that surfaces whether the change applied or was sent for approval, and a
+  manager/CEO `ApprovalsPanel` queue (approve/reject) shown for CEO/Manager roles —
+  mirroring the server's approver rule.
+
+---
+
 ## 2026-07-05 — Web POS Slice 6: Inventory add/edit + receive stock (issue #48)
 
 **What changed.** The Web POS gained inventory management — add/edit products and

--- a/BUILD_LOG.md
+++ b/BUILD_LOG.md
@@ -2,6 +2,15 @@
 
 ---
 
+## 2026-07-05 — Web POS Slice 7 code-review fix (issue #50)
+
+**What changed.** One fix from the `/code-review` of PR #63; web `tsc --noEmit` +
+`next build` green. The Adjust-Stock dialog hardcoded `stores[0]`, so a multi-store
+manager couldn't target a store; it now renders a store `<select>` (shown when the
+business has more than one store), matching the Add-Product / Receive-Stock dialogs.
+
+---
+
 ## 2026-07-05 — Web POS Slice 7: Stock adjustment + approval gate (issue #50)
 
 **What changed.** The Web POS gained stock adjustment with the approval gate,

--- a/supabase/migrations/0141_web_stock_adjustment_rpcs.sql
+++ b/supabase/migrations/0141_web_stock_adjustment_rpcs.sql
@@ -1,0 +1,359 @@
+-- 0141_web_stock_adjustment_rpcs.sql
+--
+-- Reebaplus — Web POS Slice 7 (issue #50). Stock adjustment with the approval
+-- gate for the online web client, mirroring the mobile rule (§16.6.1, v34): a
+-- stock keeper's Add/Remove is a PENDING request (no inventory change); a
+-- manager/CEO's adjustment applies immediately, and a manager/CEO approves or
+-- rejects a pending request.
+--
+-- SERVER DECIDES THE PATH (defence in depth, PRD): request_stock_adjustment
+-- branches on the CALLER's role, not on a client flag — a caller who can approve
+-- (CEO/Manager) applies straight away; anyone else with stock.adjust files a
+-- pending request. approve_stock_adjustment is approver-only. So the web hiding
+-- the wrong button is a convenience; the server enforces who gets which path.
+--
+-- TWO IMPLEMENTATIONS, ONE CONTRACT (ADR 0009): SQL twins of the mobile
+-- StockAdjustmentRequestsDao (requestStockAdjustment / approveRequest /
+-- rejectRequest) + InventoryDao.adjustStock. The request-vs-apply behaviour is
+-- pinned by the golden fixtures (test/golden/stock_adjustment_scenario.dart).
+-- An adjustment is a correction, not an inflow, so — like adjustStock — it does
+-- NOT create a Cost Batch (only Add Product / Receive Stock do, 0140).
+--
+-- DEPLOY ORDER: after 0089 (stock_adjustment_requests) and 0135 (the
+-- caller_has_permission / _assert_caller_owns_business helpers). Additive.
+
+BEGIN;
+
+-- ─── 1. caller_role_slug — the caller's active role slug for this business ────
+--
+-- SECURITY DEFINER, constrained to auth.uid() (can only ever answer about the
+-- caller — same safe pattern as caller_has_permission, 0135). Used to decide the
+-- approval path: 'ceo' / 'manager' can approve, everyone else requests.
+CREATE OR REPLACE FUNCTION public.caller_role_slug(p_business_id uuid)
+RETURNS text
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+DECLARE
+  v_user_id uuid;
+  v_slug    text;
+BEGIN
+  SELECT id INTO v_user_id FROM public.users WHERE auth_user_id = auth.uid() LIMIT 1;
+  IF v_user_id IS NULL THEN
+    RETURN NULL;
+  END IF;
+  SELECT r.slug INTO v_slug
+    FROM public.user_businesses ub
+    JOIN public.roles r ON r.id = ub.role_id
+   WHERE ub.user_id = v_user_id
+     AND ub.business_id = p_business_id
+     AND ub.status = 'active'
+   ORDER BY ub.last_login_at DESC NULLS LAST
+   LIMIT 1;
+  RETURN v_slug;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.caller_role_slug(uuid) FROM public;
+GRANT EXECUTE ON FUNCTION public.caller_role_slug(uuid) TO authenticated, service_role;
+
+
+-- ─── 2. _apply_stock_adjustment — the actual inventory movement ──────────────
+--
+-- Mirrors InventoryDao.adjustStock's default (non-transfer) path: increment or
+-- guarded-decrement inventory, then one stock_adjustments row + one
+-- stock_transactions row referencing it (movement_type 'adjustment', the
+-- adjustment_id ref that satisfies the exactly-one-of-4-refs CHECK). Returns the
+-- on-hand quantity after. A Remove that would take stock negative raises
+-- insufficient_stock (rolling back the caller's transaction). No Cost Batch — an
+-- adjustment is a correction, not an inflow.
+CREATE OR REPLACE FUNCTION public._apply_stock_adjustment(
+  p_business_id uuid,
+  p_product_id  uuid,
+  p_store_id    uuid,
+  p_delta       int,
+  p_reason      text,
+  p_actor_id    uuid
+)
+RETURNS int
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+DECLARE
+  v_now     timestamptz := now();
+  v_new_qty int;
+  v_adj_id  uuid := gen_random_uuid();
+BEGIN
+  IF p_delta = 0 THEN
+    SELECT quantity INTO v_new_qty FROM public.inventory
+     WHERE business_id = p_business_id AND product_id = p_product_id AND store_id = p_store_id;
+    RETURN COALESCE(v_new_qty, 0);
+  END IF;
+
+  IF p_delta > 0 THEN
+    INSERT INTO public.inventory (
+      id, business_id, product_id, store_id, quantity, created_at, last_updated_at
+    )
+    VALUES (
+      gen_random_uuid(), p_business_id, p_product_id, p_store_id, p_delta, v_now, v_now
+    )
+    ON CONFLICT (business_id, product_id, store_id)
+      DO UPDATE SET quantity = public.inventory.quantity + EXCLUDED.quantity,
+                    last_updated_at = v_now
+    RETURNING quantity INTO v_new_qty;
+  ELSE
+    UPDATE public.inventory
+       SET quantity = quantity + p_delta, last_updated_at = v_now
+     WHERE business_id = p_business_id AND product_id = p_product_id
+       AND store_id = p_store_id AND quantity >= -p_delta
+    RETURNING quantity INTO v_new_qty;
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'insufficient_stock'
+        USING ERRCODE = 'P0001',
+              HINT = jsonb_build_object('product_id', p_product_id,
+                                        'store_id', p_store_id,
+                                        'requested_delta', p_delta)::text;
+    END IF;
+  END IF;
+
+  INSERT INTO public.stock_adjustments (
+    id, business_id, product_id, store_id, quantity_diff, reason, performed_by,
+    created_at, last_updated_at
+  )
+  VALUES (
+    v_adj_id, p_business_id, p_product_id, p_store_id, p_delta,
+    COALESCE(p_reason, 'Adjustment'), p_actor_id, v_now, v_now
+  );
+  INSERT INTO public.stock_transactions (
+    id, business_id, product_id, location_id, quantity_delta, movement_type,
+    adjustment_id, performed_by, created_at, last_updated_at
+  )
+  VALUES (
+    gen_random_uuid(), p_business_id, p_product_id, p_store_id, p_delta, 'adjustment',
+    v_adj_id, p_actor_id, v_now, v_now
+  );
+
+  RETURN v_new_qty;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public._apply_stock_adjustment(uuid, uuid, uuid, int, text, uuid) FROM public;
+-- Internal helper: only the SECURITY DEFINER RPCs below call it; not granted to clients.
+
+
+-- ─── 3. request_stock_adjustment — stock keeper requests / manager applies ───
+--
+-- Idempotent on p_request_id.
+CREATE OR REPLACE FUNCTION public.request_stock_adjustment(
+  p_business_id  uuid,
+  p_request_id   uuid,        -- idempotency key (client UUID)
+  p_store_id     uuid,
+  p_product_id   uuid,
+  p_quantity_diff int,
+  p_reason       text,
+  p_summary      text DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+DECLARE
+  v_now       timestamptz := now();
+  v_actor_id  uuid;
+  v_slug      text;
+  v_existing  text;
+  v_summary   text;
+  v_new_qty   int;
+  v_is_approver boolean;
+BEGIN
+  PERFORM public._assert_caller_owns_business(p_business_id);
+
+  IF NOT public.caller_has_permission(p_business_id, 'stock.adjust') THEN
+    RAISE EXCEPTION 'permission_denied: stock.adjust'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  IF p_request_id IS NULL THEN
+    RAISE EXCEPTION 'request_id_required' USING ERRCODE = 'invalid_parameter_value';
+  END IF;
+  IF p_store_id IS NULL OR p_product_id IS NULL THEN
+    RAISE EXCEPTION 'store_and_product_required' USING ERRCODE = 'invalid_parameter_value';
+  END IF;
+  IF COALESCE(p_quantity_diff, 0) = 0 THEN
+    RAISE EXCEPTION 'quantity_diff_must_be_nonzero' USING ERRCODE = 'invalid_parameter_value';
+  END IF;
+
+  -- Idempotent replay.
+  SELECT status INTO v_existing FROM public.stock_adjustment_requests WHERE id = p_request_id;
+  IF v_existing IS NOT NULL THEN
+    RETURN jsonb_build_object('request_id', p_request_id, 'status', v_existing,
+                              'applied', v_existing = 'approved', 'replayed', true);
+  END IF;
+
+  SELECT id INTO v_actor_id FROM public.users WHERE auth_user_id = auth.uid() LIMIT 1;
+  v_slug := public.caller_role_slug(p_business_id);
+  v_is_approver := v_slug IN ('ceo', 'manager');
+  v_summary := COALESCE(NULLIF(btrim(p_summary), ''),
+                        CASE WHEN p_quantity_diff > 0 THEN 'Add ' ELSE 'Remove ' END
+                          || abs(p_quantity_diff)::text || ' unit(s)');
+
+  IF v_is_approver THEN
+    -- Manager/CEO: apply immediately + record an approved request for the audit.
+    v_new_qty := public._apply_stock_adjustment(
+      p_business_id, p_product_id, p_store_id, p_quantity_diff, p_reason, v_actor_id);
+
+    INSERT INTO public.stock_adjustment_requests (
+      id, business_id, product_id, store_id, quantity_diff, reason, summary,
+      requested_by, status, approved_by, approved_at, created_at, last_updated_at
+    )
+    VALUES (
+      p_request_id, p_business_id, p_product_id, p_store_id, p_quantity_diff,
+      COALESCE(p_reason, 'Adjustment'), v_summary, v_actor_id, 'approved',
+      v_actor_id, v_now, v_now, v_now
+    );
+
+    INSERT INTO public.activity_logs (
+      id, business_id, user_id, action, description, product_id, store_id,
+      entity_type, entity_id, created_at, last_updated_at
+    )
+    VALUES (
+      gen_random_uuid(), p_business_id, v_actor_id, 'stock_adjustment_approved',
+      'Applied stock change: ' || v_summary, p_product_id, p_store_id,
+      'stock_adjustment_request', p_request_id, v_now, v_now
+    );
+
+    RETURN jsonb_build_object('request_id', p_request_id, 'status', 'approved',
+                              'applied', true, 'inventory_after', v_new_qty,
+                              'replayed', false);
+  END IF;
+
+  -- Stock keeper: a pending request; NO inventory change.
+  INSERT INTO public.stock_adjustment_requests (
+    id, business_id, product_id, store_id, quantity_diff, reason, summary,
+    requested_by, status, created_at, last_updated_at
+  )
+  VALUES (
+    p_request_id, p_business_id, p_product_id, p_store_id, p_quantity_diff,
+    COALESCE(p_reason, 'Adjustment'), v_summary, v_actor_id, 'pending', v_now, v_now
+  );
+
+  INSERT INTO public.activity_logs (
+    id, business_id, user_id, action, description, product_id, store_id,
+    entity_type, entity_id, created_at, last_updated_at
+  )
+  VALUES (
+    gen_random_uuid(), p_business_id, v_actor_id, 'stock_adjustment_requested',
+    'Requested approval: ' || v_summary, p_product_id, p_store_id,
+    'stock_adjustment_request', p_request_id, v_now, v_now
+  );
+
+  RETURN jsonb_build_object('request_id', p_request_id, 'status', 'pending',
+                            'applied', false, 'replayed', false);
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.request_stock_adjustment(uuid, uuid, uuid, uuid, int, text, text) FROM public;
+GRANT EXECUTE ON FUNCTION public.request_stock_adjustment(uuid, uuid, uuid, uuid, int, text, text)
+  TO authenticated, service_role;
+
+
+-- ─── 4. approve_stock_adjustment — manager/CEO approves or rejects ───────────
+--
+-- Approve applies the movement (adjustStock semantics) and flips the row to
+-- 'approved'; reject flips to 'rejected' with no inventory change. Idempotent:
+-- a request that is not 'pending' returns its current status unchanged.
+CREATE OR REPLACE FUNCTION public.approve_stock_adjustment(
+  p_business_id uuid,
+  p_request_id  uuid,
+  p_approve     boolean,
+  p_reason      text DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+DECLARE
+  v_now      timestamptz := now();
+  v_actor_id uuid;
+  v_slug     text;
+  v_req      public.stock_adjustment_requests%ROWTYPE;
+  v_new_qty  int;
+BEGIN
+  PERFORM public._assert_caller_owns_business(p_business_id);
+
+  v_slug := public.caller_role_slug(p_business_id);
+  IF v_slug NOT IN ('ceo', 'manager') THEN
+    RAISE EXCEPTION 'permission_denied: approve_stock_adjustment'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  SELECT * INTO v_req FROM public.stock_adjustment_requests
+   WHERE id = p_request_id AND business_id = p_business_id
+   FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'request_not_found' USING ERRCODE = 'no_data_found';
+  END IF;
+  IF v_req.status <> 'pending' THEN
+    RETURN jsonb_build_object('request_id', p_request_id, 'status', v_req.status,
+                              'replayed', true);
+  END IF;
+
+  SELECT id INTO v_actor_id FROM public.users WHERE auth_user_id = auth.uid() LIMIT 1;
+
+  IF p_approve THEN
+    v_new_qty := public._apply_stock_adjustment(
+      p_business_id, v_req.product_id, v_req.store_id, v_req.quantity_diff,
+      v_req.reason, v_req.requested_by);
+
+    UPDATE public.stock_adjustment_requests
+       SET status = 'approved', approved_by = v_actor_id, approved_at = v_now,
+           last_updated_at = v_now
+     WHERE id = p_request_id AND business_id = p_business_id;
+
+    INSERT INTO public.activity_logs (
+      id, business_id, user_id, action, description, product_id, store_id,
+      entity_type, entity_id, created_at, last_updated_at
+    )
+    VALUES (
+      gen_random_uuid(), p_business_id, v_actor_id, 'stock_adjustment_approved',
+      'Approved stock change: ' || v_req.summary, v_req.product_id, v_req.store_id,
+      'stock_adjustment_request', p_request_id, v_now, v_now
+    );
+
+    RETURN jsonb_build_object('request_id', p_request_id, 'status', 'approved',
+                              'inventory_after', v_new_qty, 'replayed', false);
+  END IF;
+
+  -- Reject: no inventory change.
+  UPDATE public.stock_adjustment_requests
+     SET status = 'rejected', approved_by = v_actor_id, approved_at = v_now,
+         last_updated_at = v_now
+   WHERE id = p_request_id AND business_id = p_business_id;
+
+  INSERT INTO public.activity_logs (
+    id, business_id, user_id, action, description, product_id, store_id,
+    entity_type, entity_id, created_at, last_updated_at
+  )
+  VALUES (
+    gen_random_uuid(), p_business_id, v_actor_id, 'stock_adjustment_rejected',
+    'Rejected stock change: ' || v_req.summary
+      || COALESCE(' — ' || NULLIF(btrim(p_reason), ''), ''),
+    v_req.product_id, v_req.store_id, 'stock_adjustment_request', p_request_id,
+    v_now, v_now
+  );
+
+  RETURN jsonb_build_object('request_id', p_request_id, 'status', 'rejected',
+                            'replayed', false);
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.approve_stock_adjustment(uuid, uuid, boolean, text) FROM public;
+GRANT EXECUTE ON FUNCTION public.approve_stock_adjustment(uuid, uuid, boolean, text)
+  TO authenticated, service_role;
+
+COMMIT;

--- a/test/golden/fixtures/stock_adjustment_scenarios.json
+++ b/test/golden/fixtures/stock_adjustment_scenarios.json
@@ -1,0 +1,37 @@
+{
+  "_comment": "Stock-adjustment approval-gate golden fixtures (issue #50). Run against the Dart DAO (requestStockAdjustment/approveRequest/rejectRequest) AND the SQL RPCs request_stock_adjustment/approve_stock_adjustment (0141). Rule: pending => no inventory change; approve => apply delta (no Cost Batch); reject => no change. 'request' scenarios pin the stock-keeper->pending path on the Dart arm; the RPC arm skips them (its Tier-2 identity is the CEO, whom the server routes to immediate-apply).",
+  "scenarios": [
+    {
+      "name": "stock keeper request creates a pending row, no inventory change",
+      "operation": "request",
+      "start_qty": 20,
+      "quantity_diff": 10,
+      "reason": "recount found more",
+      "expected": { "status": "pending", "inventory_after": 20 }
+    },
+    {
+      "name": "approving an add applies the delta",
+      "operation": "approve",
+      "start_qty": 20,
+      "quantity_diff": 10,
+      "reason": "recount found more",
+      "expected": { "status": "approved", "inventory_after": 30 }
+    },
+    {
+      "name": "approving a remove applies the negative delta",
+      "operation": "approve",
+      "start_qty": 20,
+      "quantity_diff": -8,
+      "reason": "breakage",
+      "expected": { "status": "approved", "inventory_after": 12 }
+    },
+    {
+      "name": "rejecting a request makes no inventory change",
+      "operation": "reject",
+      "start_qty": 20,
+      "quantity_diff": -5,
+      "reason": "not verified",
+      "expected": { "status": "rejected", "inventory_after": 20 }
+    }
+  ]
+}

--- a/test/golden/stock_adjustment_dart_dao_golden_test.dart
+++ b/test/golden/stock_adjustment_dart_dao_golden_test.dart
@@ -1,0 +1,105 @@
+import 'package:drift/drift.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reebaplus_pos/core/database/app_database.dart';
+import 'package:reebaplus_pos/core/database/uuid_v7.dart';
+
+import '../helpers/dispatch_test_utils.dart';
+import 'stock_adjustment_scenario.dart';
+
+/// Stock-adjustment approval-gate Golden Suite — the DART side (ADR 0009, #50).
+///
+/// Runs the shared fixtures against the real mobile approval path
+/// (StockAdjustmentRequestsDao.requestStockAdjustment / approveRequest /
+/// rejectRequest + InventoryDao.adjustStock) on an in-memory Drift DB. Its Tier-2
+/// twin (web_stock_adjustment_golden_test) runs the SAME fixtures against the
+/// request_stock_adjustment / approve_stock_adjustment RPCs (0141); drift fails
+/// the build. This arm also pins the stock-keeper → pending path ('request'),
+/// which the CEO-identity RPC arm skips.
+void main() {
+  final scenarios = loadStockAdjScenarios();
+  for (final s in scenarios) {
+    test('golden (dart dao): ${s.name}', () async {
+      final boot = await bootstrapTestDb();
+      final db = boot.db;
+      final businessId = boot.businessId;
+      addTearDown(db.close);
+
+      // v1 path so approveRequest's adjustStock writes inventory + the movement
+      // rows locally (v2 defers those to the cloud RPC response).
+      await setFlag(db, 'feature.domain_rpcs_v2.inventory_delta', on: false);
+
+      final storeId = UuidV7.generate();
+      await db.into(db.stores).insert(
+            StoresCompanion.insert(
+                id: Value(storeId), businessId: businessId, name: 'Main'),
+          );
+      final requesterId = UuidV7.generate();
+      await db.into(db.users).insert(
+            UsersCompanion.insert(
+                id: Value(requesterId),
+                businessId: businessId,
+                name: 'Stock Keeper',
+                pin: '0000'),
+          );
+      final approverId = UuidV7.generate();
+      await db.into(db.users).insert(
+            UsersCompanion.insert(
+                id: Value(approverId),
+                businessId: businessId,
+                name: 'Manager',
+                pin: '0001'),
+          );
+
+      final productId = UuidV7.generate();
+      await db.into(db.products).insert(
+            ProductsCompanion.insert(
+                id: Value(productId), businessId: businessId, name: 'Widget'),
+          );
+      await db.into(db.inventory).insert(
+            InventoryCompanion.insert(
+              businessId: businessId,
+              productId: productId,
+              storeId: storeId,
+              quantity: Value(s.startQty),
+            ),
+          );
+
+      // A stock keeper files the request — a pending row, no inventory change.
+      final reqDao = db.stockAdjustmentRequestsDao;
+      await reqDao.requestStockAdjustment(
+        productId: productId,
+        storeId: storeId,
+        quantityDiff: s.quantityDiff,
+        reason: s.reason,
+        summary: s.reason,
+        requestedBy: requesterId,
+      );
+
+      final pending = await (db.select(db.stockAdjustmentRequests)
+            ..where((r) => r.productId.equals(productId)))
+          .getSingle();
+
+      if (s.operation == 'approve') {
+        await reqDao.approveRequest(
+            requestId: pending.id, approverId: approverId);
+      } else if (s.operation == 'reject') {
+        await reqDao.rejectRequest(
+            requestId: pending.id, approverId: approverId);
+      }
+
+      final finalReq = await (db.select(db.stockAdjustmentRequests)
+            ..where((r) => r.id.equals(pending.id)))
+          .getSingle();
+      final inv = await (db.select(db.inventory)
+            ..where(
+                (i) => i.productId.equals(productId) & i.storeId.equals(storeId)))
+          .getSingleOrNull();
+
+      expectStockAdjGolden(
+        s,
+        StockAdjOutcome(
+            status: finalReq.status, inventoryAfter: inv?.quantity ?? 0),
+      );
+    });
+  }
+}

--- a/test/golden/stock_adjustment_scenario.dart
+++ b/test/golden/stock_adjustment_scenario.dart
@@ -1,0 +1,83 @@
+/// Stock-adjustment approval-gate Golden Suite (ADR 0009, issue #50).
+///
+/// Pins the request-vs-apply rule identical across the two implementations:
+///   * the Dart DAO path (mobile)  — StockAdjustmentRequestsDao.requestStock
+///     Adjustment / approveRequest / rejectRequest (+ InventoryDao.adjustStock)
+///   * the SQL RPCs (web)          — request_stock_adjustment / approve_stock_
+///     adjustment (migration 0141)
+///
+/// The rule (§16.6.1, v34): a pending request makes NO inventory change; an
+/// approval applies the delta (adjustStock semantics — no Cost Batch, an
+/// adjustment is a correction not an inflow); a rejection makes no change. Any
+/// drift between the two arms fails the build.
+///
+/// The stock-keeper → pending path is pinned on the DART arm only: the Tier-2 RPC
+/// identity is the business CEO, whom the server routes to immediate-apply — so
+/// 'request' scenarios SKIP on the RPC arm (same precedent as the discount clamp
+/// in the checkout suite). 'approve'/'reject' run on both.
+library;
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+class StockAdjScenario {
+  final String name;
+
+  /// 'request' — a stock keeper files a pending request (no change);
+  /// 'approve'  — a pending request is approved (delta applied);
+  /// 'reject'   — a pending request is rejected (no change).
+  final String operation;
+
+  final int startQty;
+  final int quantityDiff;
+  final String reason;
+
+  final String expectedStatus; // 'pending' | 'approved' | 'rejected'
+  final int expectedInventoryAfter;
+
+  StockAdjScenario._({
+    required this.name,
+    required this.operation,
+    required this.startQty,
+    required this.quantityDiff,
+    required this.reason,
+    required this.expectedStatus,
+    required this.expectedInventoryAfter,
+  });
+
+  factory StockAdjScenario._fromJson(Map<String, dynamic> j) {
+    final exp = j['expected'] as Map<String, dynamic>;
+    return StockAdjScenario._(
+      name: j['name'] as String,
+      operation: j['operation'] as String,
+      startQty: j['start_qty'] as int,
+      quantityDiff: j['quantity_diff'] as int,
+      reason: j['reason'] as String? ?? 'adjustment',
+      expectedStatus: exp['status'] as String,
+      expectedInventoryAfter: exp['inventory_after'] as int,
+    );
+  }
+}
+
+List<StockAdjScenario> loadStockAdjScenarios() {
+  final raw = File('test/golden/fixtures/stock_adjustment_scenarios.json')
+      .readAsStringSync();
+  final json = jsonDecode(raw) as Map<String, dynamic>;
+  return (json['scenarios'] as List)
+      .map((s) => StockAdjScenario._fromJson(s as Map<String, dynamic>))
+      .toList();
+}
+
+class StockAdjOutcome {
+  final String status;
+  final int inventoryAfter;
+  StockAdjOutcome({required this.status, required this.inventoryAfter});
+}
+
+void expectStockAdjGolden(StockAdjScenario s, StockAdjOutcome actual) {
+  expect(actual.status, s.expectedStatus, reason: '${s.name}: request status');
+  expect(actual.inventoryAfter, s.expectedInventoryAfter,
+      reason: '${s.name}: inventory on-hand after the operation');
+}

--- a/test/integration/rpcs/web_stock_adjustment_golden_test.dart
+++ b/test/integration/rpcs/web_stock_adjustment_golden_test.dart
@@ -1,0 +1,144 @@
+@Tags(['integration'])
+library;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reebaplus_pos/core/database/uuid_v7.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import '../../golden/stock_adjustment_scenario.dart';
+import '../../helpers/supabase_test_clients.dart';
+import '../../helpers/supabase_test_env.dart';
+
+/// Stock-adjustment approval-gate Golden Suite — the SQL RPC side (ADR 0009, #50).
+///
+/// Runs the shared fixtures against approve_stock_adjustment (0141) on real dev
+/// Supabase, seeding a pending request via the admin client, then approving /
+/// rejecting via the signed-in CEO userClient; asserts the request status + the
+/// inventory after. 'request' scenarios are SKIPPED here: the Tier-2 identity is
+/// the business CEO, whom request_stock_adjustment routes to immediate-apply, so
+/// the stock-keeper → pending path is pinned on the Dart arm. Tier-2:
+/// auto-skipped when the env vars are absent.
+final String? _skipReason = (() {
+  try {
+    TestEnv.load();
+    return null;
+  } on StateError catch (e) {
+    return e.message;
+  }
+})();
+
+void main() {
+  late TestClients clients;
+  late String businessId;
+
+  String? storeId;
+  final productIds = <String>[];
+  final requestIds = <String>[];
+
+  setUpAll(() async {
+    if (_skipReason != null) return;
+    clients = await TestClients.setUp();
+    businessId = clients.env.businessId;
+  });
+
+  tearDown(() async {
+    if (_skipReason != null) return;
+    Future<void> del(String table, String column, String id) async {
+      try {
+        await clients.adminClient.from(table).delete().eq(column, id);
+      } on PostgrestException catch (e) {
+        if (e.code != 'P0001' && e.code != '23503') rethrow;
+      }
+    }
+
+    for (final id in requestIds) {
+      await del('activity_logs', 'entity_id', id);
+      await del('stock_adjustment_requests', 'id', id);
+    }
+    for (final id in productIds) {
+      await del('stock_transactions', 'product_id', id);
+      await del('stock_adjustments', 'product_id', id);
+      await del('inventory', 'product_id', id);
+      await del('products', 'id', id);
+    }
+    if (storeId != null) await del('stores', 'id', storeId!);
+    storeId = null;
+    productIds.clear();
+    requestIds.clear();
+  });
+
+  tearDownAll(() async {
+    if (_skipReason != null) return;
+    await clients.dispose();
+  });
+
+  final scenarios = loadStockAdjScenarios();
+  for (final s in scenarios) {
+    test('golden (stock-adjust rpc): ${s.name}', () async {
+      final admin = clients.adminClient;
+      final store = UuidV7.generate();
+      storeId = store;
+      await admin.from('stores').insert(
+          {'id': store, 'business_id': businessId, 'name': 'Golden Adj Store'});
+
+      final productId = UuidV7.generate();
+      productIds.add(productId);
+      await admin.from('products').insert(
+          {'id': productId, 'business_id': businessId, 'name': 'Widget'});
+      await admin.from('inventory').insert({
+        'id': UuidV7.generate(),
+        'business_id': businessId,
+        'product_id': productId,
+        'store_id': store,
+        'quantity': s.startQty,
+      });
+
+      // Seed a pending request (as if a stock keeper had raised it).
+      final requestId = UuidV7.generate();
+      requestIds.add(requestId);
+      await admin.from('stock_adjustment_requests').insert({
+        'id': requestId,
+        'business_id': businessId,
+        'product_id': productId,
+        'store_id': store,
+        'quantity_diff': s.quantityDiff,
+        'reason': s.reason,
+        'summary': s.reason,
+        'status': 'pending',
+      });
+
+      // Approve or reject via the RPC as the signed-in CEO.
+      await clients.userClient.rpc('approve_stock_adjustment', params: {
+        'p_business_id': businessId,
+        'p_request_id': requestId,
+        'p_approve': s.operation == 'approve',
+        'p_reason': s.reason,
+      });
+
+      final reqRow = await admin
+          .from('stock_adjustment_requests')
+          .select('status')
+          .eq('id', requestId)
+          .single();
+      final invRow = await admin
+          .from('inventory')
+          .select('quantity')
+          .eq('product_id', productId)
+          .eq('store_id', store)
+          .maybeSingle();
+
+      expectStockAdjGolden(
+        s,
+        StockAdjOutcome(
+          status: reqRow['status'] as String,
+          inventoryAfter:
+              invRow == null ? 0 : (invRow['quantity'] as num).toInt(),
+        ),
+      );
+    },
+        skip: _skipReason ??
+            (s.operation == 'request'
+                ? 'stock-keeper → pending pinned on the Dart arm (Tier-2 identity is CEO)'
+                : null));
+  }
+}

--- a/web-pos/src/app/globals.css
+++ b/web-pos/src/app/globals.css
@@ -1944,3 +1944,90 @@ select.input {
   background: var(--surface2);
   font-size: 15px;
 }
+
+/* ── Stock adjustment + approvals (Slice 7, #50) ──────────────────────────── */
+.inventory__row-actions {
+  display: inline-flex;
+  gap: 6px;
+  justify-content: flex-end;
+}
+.adjust__product {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  padding-bottom: 6px;
+}
+.adjust__preview {
+  min-height: 48px;
+  display: flex;
+  align-items: center;
+  padding: 0 14px;
+  border-radius: var(--radius);
+  background: var(--surface2);
+  font-size: 18px;
+  font-weight: 700;
+}
+
+.approvals {
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: color-mix(in srgb, var(--warning, var(--info)) 8%, var(--surface));
+  padding: 14px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.approvals__title {
+  margin: 0;
+  font-size: 15px;
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.approvals__count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 22px;
+  height: 22px;
+  padding: 0 7px;
+  border-radius: 11px;
+  background: var(--primary);
+  color: var(--on-primary);
+  font-size: 12px;
+}
+.approvals__list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.approvals__item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+  padding: 10px 12px;
+  border-radius: var(--radius);
+  background: var(--surface);
+  border: 1px solid var(--border);
+}
+.approvals__info {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+.approvals__delta {
+  font-weight: 700;
+  color: var(--success);
+}
+.approvals__delta--remove {
+  color: var(--danger, var(--error));
+}
+.approvals__actions {
+  display: inline-flex;
+  gap: 8px;
+}

--- a/web-pos/src/components/inventory/AdjustStockDialog.tsx
+++ b/web-pos/src/components/inventory/AdjustStockDialog.tsx
@@ -1,0 +1,166 @@
+'use client';
+
+import { useState } from 'react';
+
+import { useSession } from '@/components/providers/SessionProvider';
+import { requestStockAdjustment } from '@/lib/stockAdjustments';
+import type { ProductWithStock } from '@/lib/types';
+
+// Raise a stock adjustment for one product. The server decides the outcome from
+// the caller's role: a manager/CEO's change applies immediately; a stock keeper's
+// becomes a pending request. We surface whichever happened.
+export function AdjustStockDialog({
+  product,
+  onSaved,
+  onCancel,
+}: {
+  product: ProductWithStock;
+  onSaved: () => void;
+  onCancel: () => void;
+}) {
+  const { supabase, operator } = useSession();
+  const [mode, setMode] = useState<'add' | 'remove'>('add');
+  const [qty, setQty] = useState('');
+  const [reason, setReason] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+
+  const businessId = operator?.businessId ?? null;
+  const storeId = operator?.stores?.[0]?.id ?? null;
+  const amount = parseInt(qty, 10) || 0;
+  const delta = mode === 'add' ? amount : -amount;
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!businessId || !storeId) {
+      setError('Your session is not linked to a business/store.');
+      return;
+    }
+    if (amount <= 0) {
+      setError('Enter a quantity of one or more.');
+      return;
+    }
+    if (!reason.trim()) {
+      setError('Enter a reason for the adjustment.');
+      return;
+    }
+    setSubmitting(true);
+    setError(null);
+    try {
+      const result = await requestStockAdjustment(supabase, {
+        businessId,
+        storeId,
+        productId: product.id,
+        quantityDiff: delta,
+        reason: reason.trim(),
+      });
+      if (result.applied) {
+        onSaved();
+      } else {
+        // Stock keeper path: a pending request was created — tell them, then close.
+        setNotice('Sent for a manager to approve.');
+        setSubmitting(false);
+        setTimeout(onSaved, 900);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Could not submit the adjustment.');
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="modal-overlay" role="dialog" aria-modal="true" aria-label="Adjust stock">
+      <div className="modal">
+        <div className="modal__head">
+          <h2 className="modal__title">Adjust stock</h2>
+          <button className="modal__close" onClick={onCancel} aria-label="Close">
+            ✕
+          </button>
+        </div>
+
+        <form onSubmit={onSubmit}>
+          <div className="modal__body">
+            {error && <div className="banner banner--error">{error}</div>}
+            {notice && <div className="banner banner--info">{notice}</div>}
+
+            <div className="adjust__product">
+              <span className="inventory__name">{product.name}</span>
+              <span className="muted">In stock: {product.onHand}</span>
+            </div>
+
+            <div className="field">
+              <span className="field__label">Change</span>
+              <div className="segmented" role="group" aria-label="Adjustment direction">
+                <button
+                  type="button"
+                  className={`segmented__opt${mode === 'add' ? ' segmented__opt--active' : ''}`}
+                  onClick={() => setMode('add')}
+                >
+                  Add
+                </button>
+                <button
+                  type="button"
+                  className={`segmented__opt${mode === 'remove' ? ' segmented__opt--active' : ''}`}
+                  onClick={() => setMode('remove')}
+                >
+                  Remove
+                </button>
+              </div>
+            </div>
+
+            <div className="form-row">
+              <div className="field">
+                <label className="field__label" htmlFor="adj-qty">
+                  Quantity
+                </label>
+                <input
+                  id="adj-qty"
+                  className="input"
+                  type="number"
+                  min={1}
+                  step={1}
+                  inputMode="numeric"
+                  value={qty}
+                  onChange={(e) => setQty(e.target.value)}
+                  autoFocus
+                />
+              </div>
+              <div className="field">
+                <span className="field__label">New count</span>
+                <div className="adjust__preview">{product.onHand + delta}</div>
+              </div>
+            </div>
+
+            <div className="field">
+              <label className="field__label" htmlFor="adj-reason">
+                Reason
+              </label>
+              <input
+                id="adj-reason"
+                className="input"
+                value={reason}
+                onChange={(e) => setReason(e.target.value)}
+                placeholder="Recount, breakage, correction…"
+              />
+            </div>
+          </div>
+
+          <div className="modal__foot">
+            <button
+              type="button"
+              className="btn btn--outline"
+              onClick={onCancel}
+              disabled={submitting}
+            >
+              Cancel
+            </button>
+            <button type="submit" className="btn btn--primary" disabled={submitting || !!notice}>
+              {submitting ? 'Submitting…' : 'Submit adjustment'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/web-pos/src/components/inventory/AdjustStockDialog.tsx
+++ b/web-pos/src/components/inventory/AdjustStockDialog.tsx
@@ -27,7 +27,8 @@ export function AdjustStockDialog({
   const [notice, setNotice] = useState<string | null>(null);
 
   const businessId = operator?.businessId ?? null;
-  const storeId = operator?.stores?.[0]?.id ?? null;
+  const stores = operator?.stores ?? [];
+  const [storeId, setStoreId] = useState<string | null>(stores[0]?.id ?? null);
   const amount = parseInt(qty, 10) || 0;
   const delta = mode === 'add' ? amount : -amount;
 
@@ -131,6 +132,26 @@ export function AdjustStockDialog({
                 <div className="adjust__preview">{product.onHand + delta}</div>
               </div>
             </div>
+
+            {stores.length > 1 && (
+              <div className="field">
+                <label className="field__label" htmlFor="adj-store">
+                  Store
+                </label>
+                <select
+                  id="adj-store"
+                  className="input"
+                  value={storeId ?? ''}
+                  onChange={(e) => setStoreId(e.target.value || null)}
+                >
+                  {stores.map((s) => (
+                    <option key={s.id} value={s.id}>
+                      {s.name}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            )}
 
             <div className="field">
               <label className="field__label" htmlFor="adj-reason">

--- a/web-pos/src/components/inventory/ApprovalsPanel.tsx
+++ b/web-pos/src/components/inventory/ApprovalsPanel.tsx
@@ -1,0 +1,106 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+import { useSession } from '@/components/providers/SessionProvider';
+import {
+  approveStockAdjustment,
+  loadPendingAdjustments,
+  type PendingAdjustmentRow,
+} from '@/lib/stockAdjustments';
+
+// The manager/CEO approval queue for pending stock adjustments. Approving applies
+// the delta server-side; rejecting closes it with no change. Rendered only for an
+// operator whose role can approve; the RPC re-checks server-side regardless.
+export function ApprovalsPanel({
+  nameById,
+  onChanged,
+}: {
+  nameById: Map<string, string>;
+  onChanged: () => void;
+}) {
+  const { supabase, operator } = useSession();
+  const [rows, setRows] = useState<PendingAdjustmentRow[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [busyId, setBusyId] = useState<string | null>(null);
+
+  const businessId = operator?.businessId ?? null;
+
+  const refresh = useCallback(async () => {
+    setError(null);
+    try {
+      setRows(await loadPendingAdjustments(supabase));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load requests.');
+    }
+  }, [supabase]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const act = useCallback(
+    async (id: string, approve: boolean) => {
+      if (!businessId) return;
+      setBusyId(id);
+      setError(null);
+      try {
+        await approveStockAdjustment(supabase, { businessId, requestId: id, approve });
+        await refresh();
+        onChanged();
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Action failed.');
+      } finally {
+        setBusyId(null);
+      }
+    },
+    [supabase, businessId, refresh, onChanged],
+  );
+
+  if (rows == null) return null;
+  if (rows.length === 0 && !error) return null;
+
+  return (
+    <section className="approvals" aria-label="Pending stock adjustments">
+      <h2 className="approvals__title">
+        Pending approvals <span className="approvals__count">{rows.length}</span>
+      </h2>
+      {error && <div className="banner banner--error">{error}</div>}
+      <div className="approvals__list">
+        {rows.map((r) => {
+          const add = r.quantity_diff > 0;
+          return (
+            <div key={r.id} className="approvals__item">
+              <div className="approvals__info">
+                <span className="inventory__name">
+                  {nameById.get(r.product_id) ?? 'Product'}
+                </span>
+                <span className={`approvals__delta${add ? '' : ' approvals__delta--remove'}`}>
+                  {add ? '+' : ''}
+                  {r.quantity_diff}
+                </span>
+                <span className="muted">{r.reason}</span>
+              </div>
+              <div className="approvals__actions">
+                <button
+                  className="btn btn--outline btn--sm"
+                  disabled={busyId === r.id}
+                  onClick={() => void act(r.id, false)}
+                >
+                  Reject
+                </button>
+                <button
+                  className="btn btn--primary btn--sm"
+                  disabled={busyId === r.id}
+                  onClick={() => void act(r.id, true)}
+                >
+                  Approve
+                </button>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/web-pos/src/components/inventory/InventoryScreen.tsx
+++ b/web-pos/src/components/inventory/InventoryScreen.tsx
@@ -14,6 +14,8 @@ import {
 import type { ProductWithStock } from '@/lib/types';
 import { ProductFormDialog } from './ProductFormDialog';
 import { ReceiveStockDialog } from './ReceiveStockDialog';
+import { AdjustStockDialog } from './AdjustStockDialog';
+import { ApprovalsPanel } from './ApprovalsPanel';
 
 // Web POS Slice 6 (#48) — Inventory management. A live product list with the two
 // catalogue money-writes: Add/Edit product (products.add) and Receive Stock
@@ -24,10 +26,15 @@ export function InventoryScreen() {
   const { supabase, operator } = useSession();
   const { kobo } = useCurrency();
   const canAdd = useCan(PermissionKeys.productsAdd);
+  const canAdjust = useCan(PermissionKeys.stockAdjust);
   const canReceive =
     useCan(PermissionKeys.stockReceived) ||
     useCan(PermissionKeys.stockAdd) ||
     canAdd;
+  // Approvers (CEO / Manager) see the pending-request queue — mirrors the
+  // server rule in approve_stock_adjustment (0141).
+  const canApprove =
+    operator?.role?.slug === 'ceo' || operator?.role?.slug === 'manager';
 
   const [catalogue, setCatalogue] = useState<Catalogue | null>(null);
   const [refs, setRefs] = useState<InventoryRefs | null>(null);
@@ -35,10 +42,12 @@ export function InventoryScreen() {
   const [error, setError] = useState<string | null>(null);
   const [query, setQuery] = useState('');
 
-  // Dialog state: add a product, edit a specific product, or receive a delivery.
+  // Dialog state: add a product, edit a specific product, receive a delivery,
+  // or adjust one product's stock.
   const [formOpen, setFormOpen] = useState(false);
   const [editing, setEditing] = useState<ProductWithStock | null>(null);
   const [receiveOpen, setReceiveOpen] = useState(false);
+  const [adjusting, setAdjusting] = useState<ProductWithStock | null>(null);
 
   const businessId = operator?.businessId ?? null;
 
@@ -84,8 +93,14 @@ export function InventoryScreen() {
     setFormOpen(false);
     setReceiveOpen(false);
     setEditing(null);
+    setAdjusting(null);
     void refresh();
   }, [refresh]);
+
+  const nameById = useMemo(
+    () => new Map((catalogue?.products ?? []).map((p) => [p.id, p.name])),
+    [catalogue],
+  );
 
   const categoryName = useCallback(
     (id: string | null) =>
@@ -129,6 +144,10 @@ export function InventoryScreen() {
 
       {error && <div className="banner banner--error">{error}</div>}
 
+      {canApprove && (
+        <ApprovalsPanel nameById={nameById} onChanged={() => void refresh()} />
+      )}
+
       <div className="inventory__toolbar">
         <input
           className="input"
@@ -163,7 +182,7 @@ export function InventoryScreen() {
                 <th className="num">Retail</th>
                 <th className="num">Wholesale</th>
                 <th className="num">Cost</th>
-                {canAdd && <th aria-label="Actions" />}
+                {(canAdd || canAdjust) && <th aria-label="Actions" />}
               </tr>
             </thead>
             <tbody>
@@ -191,14 +210,26 @@ export function InventoryScreen() {
                     <td className="num">{kobo(p.retailer_price_kobo)}</td>
                     <td className="num">{kobo(p.wholesaler_price_kobo)}</td>
                     <td className="num">{kobo(p.buying_price_kobo)}</td>
-                    {canAdd && (
+                    {(canAdd || canAdjust) && (
                       <td className="num">
-                        <button
-                          className="btn btn--outline btn--sm"
-                          onClick={() => openEdit(p)}
-                        >
-                          Edit
-                        </button>
+                        <div className="inventory__row-actions">
+                          {canAdjust && (
+                            <button
+                              className="btn btn--outline btn--sm"
+                              onClick={() => setAdjusting(p)}
+                            >
+                              Adjust
+                            </button>
+                          )}
+                          {canAdd && (
+                            <button
+                              className="btn btn--outline btn--sm"
+                              onClick={() => openEdit(p)}
+                            >
+                              Edit
+                            </button>
+                          )}
+                        </div>
                       </td>
                     )}
                   </tr>
@@ -227,6 +258,14 @@ export function InventoryScreen() {
           suppliers={refs.suppliers}
           onSaved={onSaved}
           onCancel={() => setReceiveOpen(false)}
+        />
+      )}
+
+      {adjusting && (
+        <AdjustStockDialog
+          product={adjusting}
+          onSaved={onSaved}
+          onCancel={() => setAdjusting(null)}
         />
       )}
     </div>

--- a/web-pos/src/lib/permissions.ts
+++ b/web-pos/src/lib/permissions.ts
@@ -22,6 +22,7 @@ export const PermissionKeys = {
   productsAdd: 'products.add',
   stockView: 'stock.view',
   stockAdd: 'stock.add',
+  stockAdjust: 'stock.adjust',
   stockReceived: 'stock.received',
   reportsView: 'reports.view',
 } as const;

--- a/web-pos/src/lib/stockAdjustments.ts
+++ b/web-pos/src/lib/stockAdjustments.ts
@@ -1,0 +1,103 @@
+// Web POS Slice 7 (#50) — the stock-adjustment approval gate. A stock keeper's
+// Add/Remove is a pending request (no inventory change); a manager/CEO applies
+// immediately, and approves/rejects a pending request. The server (RPCs
+// request_stock_adjustment / approve_stock_adjustment, 0141) decides the path
+// from the CALLER's role — the web hiding a button is convenience, not the gate.
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+function newId(): string {
+  return typeof crypto !== 'undefined' && 'randomUUID' in crypto
+    ? crypto.randomUUID()
+    : `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
+
+function friendlyError(message: string): string {
+  if (message.includes('insufficient_stock')) {
+    return 'That would take stock below zero. Lower the amount removed.';
+  }
+  if (message.includes('permission_denied')) {
+    return 'You do not have permission to do this.';
+  }
+  if (message.includes('quantity_diff_must_be_nonzero')) {
+    return 'Enter a non-zero quantity.';
+  }
+  if (message.includes('request_not_found')) {
+    return 'That request no longer exists. Refresh the queue.';
+  }
+  if (message.includes('tenant_mismatch') || message.includes('no_business_for_caller')) {
+    return 'Your session is not linked to this business. Sign out and back in.';
+  }
+  return message;
+}
+
+export interface RequestAdjustmentResult {
+  status: 'pending' | 'approved' | 'rejected';
+  applied: boolean;
+}
+
+// Raise an adjustment. The server routes it: a manager/CEO applies it now
+// (applied=true, status 'approved'); anyone else with stock.adjust gets a
+// pending request (applied=false, status 'pending').
+export async function requestStockAdjustment(
+  supabase: SupabaseClient,
+  args: {
+    businessId: string;
+    storeId: string;
+    productId: string;
+    quantityDiff: number;
+    reason: string;
+  },
+): Promise<RequestAdjustmentResult> {
+  const { data, error } = await supabase.rpc('request_stock_adjustment', {
+    p_business_id: args.businessId,
+    p_request_id: newId(),
+    p_store_id: args.storeId,
+    p_product_id: args.productId,
+    p_quantity_diff: args.quantityDiff,
+    p_reason: args.reason,
+  });
+  if (error) throw new Error(friendlyError(error.message));
+  const payload = data as { status: RequestAdjustmentResult['status']; applied: boolean };
+  return { status: payload.status, applied: payload.applied };
+}
+
+// Approve (apply the delta) or reject (no change) a pending request.
+export async function approveStockAdjustment(
+  supabase: SupabaseClient,
+  args: { businessId: string; requestId: string; approve: boolean; reason?: string | null },
+): Promise<'approved' | 'rejected'> {
+  const { data, error } = await supabase.rpc('approve_stock_adjustment', {
+    p_business_id: args.businessId,
+    p_request_id: args.requestId,
+    p_approve: args.approve,
+    p_reason: args.reason ?? null,
+  });
+  if (error) throw new Error(friendlyError(error.message));
+  return (data as { status: 'approved' | 'rejected' }).status;
+}
+
+export interface PendingAdjustmentRow {
+  id: string;
+  product_id: string;
+  store_id: string;
+  quantity_diff: number;
+  reason: string;
+  summary: string;
+  created_at: string;
+}
+
+// Load the pending approval queue (RLS-scoped). Product names are resolved by the
+// caller from the catalogue it already holds.
+export async function loadPendingAdjustments(
+  supabase: SupabaseClient,
+): Promise<PendingAdjustmentRow[]> {
+  const { data, error } = await supabase
+    .from('stock_adjustment_requests')
+    .select('id, product_id, store_id, quantity_diff, reason, summary, created_at')
+    .eq('status', 'pending')
+    .order('created_at', { ascending: true })
+    .returns<PendingAdjustmentRow[]>();
+  if (error) throw new Error(friendlyError(error.message));
+  return data ?? [];
+}


### PR DESCRIPTION
Replaces #63 (auto-closed when the stacked base branch was deleted on #62's merge). Rebased onto main with the code-review fix included.

Server-authoritative stock adjustment with the approval gate (migration `0141`): a stock keeper's change is a pending request; a manager/CEO applies immediately and works the approval queue. Golden request-vs-apply across Dart + SQL. Includes the code-review fix (store selector on the adjust dialog).

Closes #50