### PR TITLE
Web POS Slice 8 — Reports & dashboards (#51)

### DIFF
--- a/BUILD_LOG.md
+++ b/BUILD_LOG.md
@@ -2,6 +2,30 @@
 
 ---
 
+## 2026-07-05 — Web POS Slice 8: Reports & dashboards (issue #51)
+
+**What changed.** Read-only reports on web — sales/revenue dashboard, a profit
+report that excludes Uncosted units transparently, activity logs, and store
+scoping. No write RPCs; aggregation reads only. Stacked on #48 (reuses the
+`NavProvider` view switch). Money rules mirror mobile exactly (verified against
+live data). Web `tsc` + `next build` green.
+
+- **`reports.ts`.** `loadSalesReport` reads counted orders (`status in
+  {pending,completed}` — `orderCountsAsSale`, revenue recognized at checkout) and
+  their order_items (one PostgREST `orders!inner` join, optionally store-scoped)
+  and computes: all-sales revenue + order count; and a profit view over COSTED
+  lines only — a line with no product or `buying_price_kobo <= 0` is excluded from
+  both revenue and COGS and counted as an Uncosted unit, so Revenue − COGS =
+  Gross Profit (mirrors `profit_report_screen.dart`). Plus revenue-by-day and top
+  products. `loadActivityLogs` reads the recent activity feed.
+- **`ReportsScreen`.** Period (Today / 7d / 30d) + store scope (All / each store),
+  KPI tiles, a revenue-by-day mini-chart, a top-products table, and the activity
+  feed. Profit/COGS tiles + the "Excludes N item(s) with no recorded buying
+  price" note are gated on `reports.see_profit`; the screen (and sidebar entry) on
+  `reports.see_sales`. Wired into the sidebar via `NavProvider`.
+
+---
+
 ## 2026-07-05 — Web POS Slice 6: Inventory add/edit + receive stock (issue #48)
 
 **What changed.** The Web POS gained inventory management — add/edit products and

--- a/web-pos/src/app/globals.css
+++ b/web-pos/src/app/globals.css
@@ -1944,3 +1944,125 @@ select.input {
   background: var(--surface2);
   font-size: 15px;
 }
+
+/* ── Reports & dashboards (Slice 8, #51) ──────────────────────────────────── */
+.reports {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  max-width: var(--content-max);
+}
+.reports__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+.reports__filters {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+.reports__store {
+  width: auto;
+  min-width: 150px;
+}
+.stat-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 12px;
+}
+.stat-tile {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 16px 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.stat-tile--accent {
+  border-color: color-mix(in srgb, var(--primary) 45%, transparent);
+  background: color-mix(in srgb, var(--primary) 6%, var(--surface));
+}
+.stat-tile__label {
+  font-size: 12.5px;
+  font-weight: 600;
+  color: var(--subtext);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.stat-tile__value {
+  font-size: 24px;
+  font-weight: 800;
+  color: var(--text);
+}
+.reports__panel {
+  padding: 16px 18px;
+}
+.reports__panel-title {
+  margin: 0 0 12px;
+  font-size: 15px;
+  font-weight: 700;
+}
+.daybars {
+  display: flex;
+  align-items: flex-end;
+  gap: 8px;
+  height: 140px;
+  overflow-x: auto;
+}
+.daybars__col {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 6px;
+  min-width: 26px;
+  flex: 1 0 26px;
+  height: 100%;
+}
+.daybars__bar {
+  width: 60%;
+  min-height: 3px;
+  border-radius: 4px 4px 0 0;
+  background: linear-gradient(
+    to top,
+    color-mix(in srgb, var(--primary) 60%, transparent),
+    var(--primary)
+  );
+}
+.daybars__label {
+  font-size: 10px;
+  color: var(--subtext);
+  white-space: nowrap;
+}
+.activity-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+}
+.activity-list__item {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 0;
+  border-bottom: 1px solid var(--border);
+  font-size: 14px;
+}
+.activity-list__item:last-child {
+  border-bottom: none;
+}
+.activity-list__desc {
+  color: var(--text);
+}
+.activity-list__time {
+  color: var(--subtext);
+  font-size: 12px;
+  white-space: nowrap;
+}

--- a/web-pos/src/app/page.tsx
+++ b/web-pos/src/app/page.tsx
@@ -7,6 +7,7 @@ import { PosScreen } from '@/components/pos/PosScreen';
 import { CartProvider } from '@/components/pos/CartProvider';
 import { NavProvider, useNav } from '@/components/providers/NavProvider';
 import { InventoryScreen } from '@/components/inventory/InventoryScreen';
+import { ReportsScreen } from '@/components/reports/ReportsScreen';
 
 // App entry. The signed-in Supabase session is the Operator (ADR 0011): while it
 // resolves we show a spinner; signed-out shows the sign-in screen; signed-in
@@ -49,6 +50,7 @@ export default function Home() {
 function MainContent() {
   const { view } = useNav();
   if (view === 'inventory') return <InventoryScreen />;
+  if (view === 'reports') return <ReportsScreen />;
   return <PosScreen />;
 }
 

--- a/web-pos/src/components/reports/ReportsScreen.tsx
+++ b/web-pos/src/components/reports/ReportsScreen.tsx
@@ -1,0 +1,232 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import { useSession } from '@/components/providers/SessionProvider';
+import { useCan } from '@/components/permissions/Can';
+import { useCurrency } from '@/hooks/useCurrency';
+import { PermissionKeys } from '@/lib/permissions';
+import {
+  loadSalesReport,
+  loadActivityLogs,
+  type SalesReport,
+  type ActivityLogRow,
+} from '@/lib/reports';
+
+type Period = 'today' | '7d' | '30d';
+
+const PERIODS: { key: Period; label: string }[] = [
+  { key: 'today', label: 'Today' },
+  { key: '7d', label: '7 days' },
+  { key: '30d', label: '30 days' },
+];
+
+function periodStartIso(period: Period): string {
+  const now = new Date();
+  const d = new Date(now);
+  if (period === 'today') {
+    d.setHours(0, 0, 0, 0);
+  } else if (period === '7d') {
+    d.setDate(d.getDate() - 7);
+  } else {
+    d.setDate(d.getDate() - 30);
+  }
+  return d.toISOString();
+}
+
+const ALL_STORES = 'all';
+
+// Web POS Slice 8 (#51) — read-only reports & dashboards. Sales/revenue KPIs, a
+// profit report that excludes Uncosted units transparently (matching mobile),
+// activity logs, and store scoping. Cost/profit figures are gated on
+// reports.see_profit; the whole screen on reports.see_sales (nav gate).
+export function ReportsScreen() {
+  const { supabase, operator } = useSession();
+  const { kobo } = useCurrency();
+  const canSeeProfit = useCan(PermissionKeys.reportsSeeProfit);
+
+  const stores = operator?.stores ?? [];
+  const [period, setPeriod] = useState<Period>('7d');
+  const [storeId, setStoreId] = useState<string>(ALL_STORES);
+  const [report, setReport] = useState<SalesReport | null>(null);
+  const [logs, setLogs] = useState<ActivityLogRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const businessId = operator?.businessId ?? null;
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    const scope = storeId === ALL_STORES ? null : storeId;
+    try {
+      const [r, l] = await Promise.all([
+        loadSalesReport(supabase, { fromIso: periodStartIso(period), storeId: scope }),
+        loadActivityLogs(supabase, { storeId: scope, limit: 40 }),
+      ]);
+      setReport(r);
+      setLogs(l);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load reports.');
+    } finally {
+      setLoading(false);
+    }
+  }, [supabase, period, storeId]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh, businessId]);
+
+  const maxDay = useMemo(
+    () => Math.max(1, ...(report?.byDay ?? []).map((d) => d.revenueKobo)),
+    [report],
+  );
+
+  return (
+    <div className="reports">
+      <div className="reports__header">
+        <h1 className="pos__title">Reports</h1>
+        <div className="reports__filters">
+          {stores.length > 1 && (
+            <select
+              className="input reports__store"
+              value={storeId}
+              onChange={(e) => setStoreId(e.target.value)}
+              aria-label="Store scope"
+            >
+              <option value={ALL_STORES}>All stores</option>
+              {stores.map((s) => (
+                <option key={s.id} value={s.id}>
+                  {s.name}
+                </option>
+              ))}
+            </select>
+          )}
+          <div className="segmented" role="group" aria-label="Period">
+            {PERIODS.map((p) => (
+              <button
+                key={p.key}
+                type="button"
+                className={`segmented__opt${period === p.key ? ' segmented__opt--active' : ''}`}
+                onClick={() => setPeriod(p.key)}
+              >
+                {p.label}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {error && <div className="banner banner--error">{error}</div>}
+
+      {loading && !report ? (
+        <div className="empty-state">
+          <div className="spinner" style={{ margin: '0 auto 12px' }} />
+          Loading reports…
+        </div>
+      ) : report ? (
+        <>
+          <div className="stat-grid">
+            <StatTile label="Sales revenue" value={kobo(report.revenueKobo)} />
+            <StatTile label="Orders" value={report.orderCount.toString()} />
+            {canSeeProfit && (
+              <>
+                <StatTile label="Gross profit" value={kobo(report.grossProfitKobo)} accent />
+                <StatTile label="Cost of goods" value={kobo(report.cogsKobo)} />
+              </>
+            )}
+          </div>
+
+          {canSeeProfit && report.uncostedUnits > 0 && (
+            <div className="banner banner--info">
+              Excludes {report.uncostedUnits} item(s) with no recorded buying price
+              from the profit figures.
+            </div>
+          )}
+
+          {report.byDay.length > 0 && (
+            <section className="card reports__panel">
+              <h2 className="reports__panel-title">Revenue by day</h2>
+              <div className="daybars">
+                {report.byDay.map((d) => (
+                  <div className="daybars__col" key={d.date} title={`${d.date}: ${kobo(d.revenueKobo)}`}>
+                    <div
+                      className="daybars__bar"
+                      style={{ height: `${Math.round((d.revenueKobo / maxDay) * 100)}%` }}
+                    />
+                    <span className="daybars__label">{d.date.slice(5)}</span>
+                  </div>
+                ))}
+              </div>
+            </section>
+          )}
+
+          <section className="card reports__panel">
+            <h2 className="reports__panel-title">Top products</h2>
+            {report.topProducts.length === 0 ? (
+              <p className="muted">No costed sales in this window.</p>
+            ) : (
+              <div className="inventory__table-wrap">
+                <table className="inventory__table">
+                  <thead>
+                    <tr>
+                      <th>Product</th>
+                      <th className="num">Qty</th>
+                      <th className="num">Revenue</th>
+                      {canSeeProfit && <th className="num">Profit</th>}
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {report.topProducts.map((p) => (
+                      <tr key={p.productId}>
+                        <td>{p.name}</td>
+                        <td className="num">{p.qty}</td>
+                        <td className="num">{kobo(p.revenueKobo)}</td>
+                        {canSeeProfit && <td className="num">{kobo(p.profitKobo)}</td>}
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </section>
+
+          <section className="card reports__panel">
+            <h2 className="reports__panel-title">Recent activity</h2>
+            {logs.length === 0 ? (
+              <p className="muted">No activity yet.</p>
+            ) : (
+              <ul className="activity-list">
+                {logs.map((l) => (
+                  <li className="activity-list__item" key={l.id}>
+                    <span className="activity-list__desc">{l.description}</span>
+                    <span className="activity-list__time">
+                      {new Date(l.created_at).toLocaleString()}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </section>
+        </>
+      ) : null}
+    </div>
+  );
+}
+
+function StatTile({
+  label,
+  value,
+  accent = false,
+}: {
+  label: string;
+  value: string;
+  accent?: boolean;
+}) {
+  return (
+    <div className={`stat-tile${accent ? ' stat-tile--accent' : ''}`}>
+      <span className="stat-tile__label">{label}</span>
+      <span className="stat-tile__value">{value}</span>
+    </div>
+  );
+}

--- a/web-pos/src/components/shell/AppShell.tsx
+++ b/web-pos/src/components/shell/AppShell.tsx
@@ -106,7 +106,7 @@ export function AppShell({ children }: { children: ReactNode }) {
   const { view, setView } = useNav();
   const canInventory =
     useCan(PermissionKeys.stockView) || useCan(PermissionKeys.productsAdd);
-  const canReports = useCan(PermissionKeys.reportsView);
+  const canReports = useCan(PermissionKeys.reportsSeeSales);
 
   const [isCollapsed, setIsCollapsed] = useState(false);
   const [themeDropdownOpen, setThemeDropdownOpen] = useState(false);
@@ -190,7 +190,15 @@ export function AppShell({ children }: { children: ReactNode }) {
             />
           )}
           <NavItem icon={<SalesIcon />} label="Sales" collapsed={isCollapsed} />
-          {canReports && <NavItem icon={<ReportsIcon />} label="Reports" collapsed={isCollapsed} />}
+          {canReports && (
+            <NavItem
+              icon={<ReportsIcon />}
+              label="Reports"
+              active={view === 'reports'}
+              collapsed={isCollapsed}
+              onClick={() => setView('reports')}
+            />
+          )}
           <NavItem icon={<SettingsIcon />} label="Settings" collapsed={isCollapsed} />
         </div>
 

--- a/web-pos/src/lib/permissions.ts
+++ b/web-pos/src/lib/permissions.ts
@@ -24,6 +24,9 @@ export const PermissionKeys = {
   stockAdd: 'stock.add',
   stockReceived: 'stock.received',
   reportsView: 'reports.view',
+  reportsSeeSales: 'reports.see_sales',
+  reportsSeeProfit: 'reports.see_profit',
+  reportsSeeCostPrices: 'reports.see_cost_prices',
 } as const;
 
 export type PermissionKey =

--- a/web-pos/src/lib/reports.ts
+++ b/web-pos/src/lib/reports.ts
@@ -1,0 +1,172 @@
+// Web POS Slice 8 (#51) — read-only reports & dashboards. No write RPCs: these
+// are RLS-scoped aggregation reads the UI computes over. The money rules mirror
+// mobile EXACTLY (ADR 0009 decisions, not its Dart):
+//   * A sale is any order NOT reversed — status in {pending, completed}
+//     (orderCountsAsSale); revenue is recognized at checkout, never at Confirm.
+//   * The profit report EXCLUDES Uncosted units (a line with no product or
+//     buying_price_kobo <= 0) from BOTH revenue and COGS, and reports their count
+//     separately — so Revenue − COGS always equals Gross Profit.
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+// The order statuses that count as a recognized sale (mirrors mobile
+// orderRevenueStatuses — pending|completed, never cancelled/refunded).
+export const SALE_STATUSES = ['pending', 'completed'] as const;
+
+export interface SalesReport {
+  // All recognized-sale revenue in the window (net), incl. uncosted lines.
+  revenueKobo: number;
+  orderCount: number;
+  // Profit view — costed lines only (uncosted excluded from both sides).
+  costedRevenueKobo: number;
+  cogsKobo: number;
+  grossProfitKobo: number;
+  uncostedUnits: number;
+  byDay: { date: string; revenueKobo: number }[];
+  topProducts: {
+    productId: string;
+    name: string;
+    qty: number;
+    revenueKobo: number;
+    profitKobo: number;
+  }[];
+}
+
+interface OrderRow {
+  net_amount_kobo: number | null;
+  created_at: string;
+}
+
+interface ItemRow {
+  product_id: string | null;
+  quantity: number;
+  unit_price_kobo: number;
+  buying_price_kobo: number;
+  products: { name: string } | { name: string }[] | null;
+}
+
+function productName(p: ItemRow['products']): string {
+  if (!p) return 'Unknown';
+  return Array.isArray(p) ? (p[0]?.name ?? 'Unknown') : p.name;
+}
+
+// Load the sales/revenue + profit numbers for a window, optionally scoped to a
+// store. Uses a PostgREST inner-join filter so item rows are already restricted
+// to counted orders in the window (one round trip), matching the orders read.
+export async function loadSalesReport(
+  supabase: SupabaseClient,
+  args: { fromIso: string; storeId?: string | null },
+): Promise<SalesReport> {
+  let ordersQuery = supabase
+    .from('orders')
+    .select('net_amount_kobo, created_at')
+    .in('status', SALE_STATUSES as unknown as string[])
+    .gte('created_at', args.fromIso);
+  if (args.storeId) ordersQuery = ordersQuery.eq('store_id', args.storeId);
+
+  let itemsQuery = supabase
+    .from('order_items')
+    .select(
+      'product_id, quantity, unit_price_kobo, buying_price_kobo, orders!inner(status, created_at, store_id), products(name)',
+    )
+    .in('orders.status', SALE_STATUSES as unknown as string[])
+    .gte('orders.created_at', args.fromIso);
+  if (args.storeId) itemsQuery = itemsQuery.eq('orders.store_id', args.storeId);
+
+  const [ordersRes, itemsRes] = await Promise.all([
+    ordersQuery.returns<OrderRow[]>(),
+    itemsQuery.returns<ItemRow[]>(),
+  ]);
+  if (ordersRes.error) throw new Error(ordersRes.error.message);
+  if (itemsRes.error) throw new Error(itemsRes.error.message);
+
+  const orders = ordersRes.data ?? [];
+  const items = itemsRes.data ?? [];
+
+  let revenueKobo = 0;
+  const byDayMap = new Map<string, number>();
+  for (const o of orders) {
+    const net = o.net_amount_kobo ?? 0;
+    revenueKobo += net;
+    const day = o.created_at.slice(0, 10);
+    byDayMap.set(day, (byDayMap.get(day) ?? 0) + net);
+  }
+
+  let costedRevenueKobo = 0;
+  let cogsKobo = 0;
+  let uncostedUnits = 0;
+  const byProduct = new Map<
+    string,
+    { name: string; qty: number; revenueKobo: number; cogsKobo: number }
+  >();
+  for (const i of items) {
+    // Uncosted line (no product, or no recorded buying price) — excluded from
+    // the profit math on both sides, counted separately (mirrors mobile).
+    if (!i.product_id || i.buying_price_kobo <= 0) {
+      uncostedUnits += i.quantity;
+      continue;
+    }
+    const lineRevenue = i.quantity * i.unit_price_kobo;
+    const lineCogs = i.quantity * i.buying_price_kobo;
+    costedRevenueKobo += lineRevenue;
+    cogsKobo += lineCogs;
+    const acc = byProduct.get(i.product_id) ?? {
+      name: productName(i.products),
+      qty: 0,
+      revenueKobo: 0,
+      cogsKobo: 0,
+    };
+    acc.qty += i.quantity;
+    acc.revenueKobo += lineRevenue;
+    acc.cogsKobo += lineCogs;
+    byProduct.set(i.product_id, acc);
+  }
+
+  const byDay = [...byDayMap.entries()]
+    .map(([date, kobo]) => ({ date, revenueKobo: kobo }))
+    .sort((a, b) => a.date.localeCompare(b.date));
+
+  const topProducts = [...byProduct.entries()]
+    .map(([productId, a]) => ({
+      productId,
+      name: a.name,
+      qty: a.qty,
+      revenueKobo: a.revenueKobo,
+      profitKobo: a.revenueKobo - a.cogsKobo,
+    }))
+    .sort((a, b) => b.profitKobo - a.profitKobo)
+    .slice(0, 8);
+
+  return {
+    revenueKobo,
+    orderCount: orders.length,
+    costedRevenueKobo,
+    cogsKobo,
+    grossProfitKobo: costedRevenueKobo - cogsKobo,
+    uncostedUnits,
+    byDay,
+    topProducts,
+  };
+}
+
+export interface ActivityLogRow {
+  id: string;
+  action: string;
+  description: string;
+  created_at: string;
+}
+
+export async function loadActivityLogs(
+  supabase: SupabaseClient,
+  args: { storeId?: string | null; limit?: number } = {},
+): Promise<ActivityLogRow[]> {
+  let q = supabase
+    .from('activity_logs')
+    .select('id, action, description, created_at')
+    .order('created_at', { ascending: false })
+    .limit(args.limit ?? 50);
+  if (args.storeId) q = q.eq('store_id', args.storeId);
+  const { data, error } = await q.returns<ActivityLogRow[]>();
+  if (error) throw new Error(error.message);
+  return data ?? [];
+}


### PR DESCRIPTION
Replaces #65 (auto-closed when the stacked base branch was deleted on #62's merge). Rebased onto main.

Read-only reports on web — sales/revenue dashboard, a profit report that excludes Uncosted units transparently ("Excludes N item(s) with no recorded buying price", mirroring the mobile profit report), activity logs, and store scoping. No write RPCs; aggregation reads only. Gated on `reports.see_sales` / `reports.see_profit`.

Closes #51