### PR TITLE
Web POS cleanup — de-duplicate RPC helpers (#68)

### DIFF
--- a/BUILD_LOG.md
+++ b/BUILD_LOG.md
@@ -2,6 +2,23 @@
 
 ---
 
+## 2026-07-05 — Web POS: de-duplicate RPC helpers (issue #68)
+
+**What changed.** Quality-only cleanup from the epic-#46 code review; no behaviour
+change (`tsc` + `next build` green, every friendly-error string preserved).
+
+- **New `web-pos/src/lib/rpc.ts`.** `newId()` (was copy-pasted in `inventory.ts` +
+  `stockAdjustments.ts` and inlined in `checkout.ts`) and `friendlyRpcError(message,
+  cases)` — the shared match loop + the identical `tenant_mismatch` /
+  `no_business_for_caller` fallback every RPC can raise. Each caller keeps its own
+  domain case table (the domain messages legitimately differ).
+- **`toKobo` / `fromKobo` moved into `lib/currency.ts`** beside `formatKobo`; the
+  Add-Product and Receive-Stock dialogs import them instead of each defining a copy.
+- `checkout.ts` / `inventory.ts` / `stockAdjustments.ts` now import the shared
+  helpers; their `friendlyError` is a thin wrapper over `friendlyRpcError`.
+
+---
+
 ## 2026-07-05 — Web POS Slice 8: Reports & dashboards (issue #51)
 
 **What changed.** Read-only reports on web — sales/revenue dashboard, a profit

--- a/web-pos/src/components/inventory/ProductFormDialog.tsx
+++ b/web-pos/src/components/inventory/ProductFormDialog.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 
 import { useSession } from '@/components/providers/SessionProvider';
 import { useCurrency } from '@/hooks/useCurrency';
+import { fromKobo, toKobo } from '@/lib/currency';
 import {
   addProduct,
   updateProduct,
@@ -11,15 +12,6 @@ import {
   type ProductUnit,
 } from '@/lib/inventory';
 import type { CategoryRow, ProductWithStock } from '@/lib/types';
-
-// Naira (major-unit) input → kobo (bigint). Empty / invalid ⇒ 0.
-function toKobo(naira: string): number {
-  const n = parseFloat(naira);
-  return Number.isFinite(n) && n > 0 ? Math.round(n * 100) : 0;
-}
-function fromKobo(kobo: number | null | undefined): string {
-  return kobo && kobo > 0 ? (kobo / 100).toString() : '';
-}
 
 const SIZES = ['', 'big', 'medium', 'small'] as const;
 

--- a/web-pos/src/components/inventory/ReceiveStockDialog.tsx
+++ b/web-pos/src/components/inventory/ReceiveStockDialog.tsx
@@ -4,20 +4,13 @@ import { useMemo, useState } from 'react';
 
 import { useSession } from '@/components/providers/SessionProvider';
 import { useCurrency } from '@/hooks/useCurrency';
+import { fromKobo, toKobo } from '@/lib/currency';
 import {
   receiveStock,
   RECEIVE_PAYMENT_METHODS,
   type ReceivePaymentMethod,
 } from '@/lib/inventory';
 import type { ProductWithStock, SupplierRow } from '@/lib/types';
-
-function toKobo(naira: string): number {
-  const n = parseFloat(naira);
-  return Number.isFinite(n) && n > 0 ? Math.round(n * 100) : 0;
-}
-function fromKobo(kobo: number | null | undefined): string {
-  return kobo && kobo > 0 ? (kobo / 100).toString() : '';
-}
 
 interface DraftLine {
   productId: string;

--- a/web-pos/src/lib/checkout.ts
+++ b/web-pos/src/lib/checkout.ts
@@ -7,6 +7,7 @@
 
 import type { SupabaseClient } from '@supabase/supabase-js';
 
+import { friendlyRpcError, newId } from './rpc';
 import type { ProductWithStock } from './types';
 
 // The retail tier is the primary line price (per-tier switching is a later
@@ -109,38 +110,33 @@ interface OrderRow {
 
 // Turn a raw RPC error into an operator-facing message.
 function friendlyError(message: string): string {
-  if (message.includes('insufficient_stock')) {
-    return 'Not enough stock to complete this sale — another till may have just sold the same item. Refresh and try again.';
-  }
-  if (message.includes('permission_denied')) {
-    return 'You do not have permission to ring up a sale.';
-  }
-  if (message.includes('debt_limit_exceeded')) {
-    return 'This sale would push the customer past their debt limit. Take a payment, lower the amount owed, or raise their limit.';
-  }
-  if (message.includes('customer_wallet_missing')) {
-    return 'This customer has no wallet set up yet. Add them again on the mobile app, then retry.';
-  }
-  if (message.includes('credit_requires_customer')) {
-    return 'Attach a registered customer before selling on credit.';
-  }
-  if (message.includes('amount_paid_below_net')) {
-    return 'The amount paid is less than the total. Enter the full amount, or use Pay with Credit / Register as Credit Sale.';
-  }
-  if (message.includes('tenant_mismatch') || message.includes('no_business_for_caller')) {
-    return 'Your session is not linked to this business. Sign out and back in.';
-  }
-  return message;
+  return friendlyRpcError(message, [
+    [
+      'insufficient_stock',
+      'Not enough stock to complete this sale — another till may have just sold the same item. Refresh and try again.',
+    ],
+    ['permission_denied', 'You do not have permission to ring up a sale.'],
+    [
+      'debt_limit_exceeded',
+      'This sale would push the customer past their debt limit. Take a payment, lower the amount owed, or raise their limit.',
+    ],
+    [
+      'customer_wallet_missing',
+      'This customer has no wallet set up yet. Add them again on the mobile app, then retry.',
+    ],
+    ['credit_requires_customer', 'Attach a registered customer before selling on credit.'],
+    [
+      'amount_paid_below_net',
+      'The amount paid is less than the total. Enter the full amount, or use Pay with Credit / Register as Credit Sale.',
+    ],
+  ]);
 }
 
 export async function checkoutOrder(
   supabase: SupabaseClient,
   args: CheckoutArgs,
 ): Promise<CheckoutResult> {
-  const orderId =
-    typeof crypto !== 'undefined' && 'randomUUID' in crypto
-      ? crypto.randomUUID()
-      : `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  const orderId = newId();
 
   const { data, error } = await supabase.rpc('checkout_order', {
     p_business_id: args.businessId,

--- a/web-pos/src/lib/currency.ts
+++ b/web-pos/src/lib/currency.ts
@@ -84,3 +84,15 @@ export function formatKobo(
   if (kobo === null || kobo === undefined) return '—';
   return formatCurrency(kobo / 100, code);
 }
+
+// Parse a major-unit (e.g. naira) text input to kobo. Empty / non-positive ⇒ 0.
+export function toKobo(naira: string): number {
+  const n = parseFloat(naira);
+  return Number.isFinite(n) && n > 0 ? Math.round(n * 100) : 0;
+}
+
+// Render a kobo amount as an editable major-unit string (empty when 0/absent).
+// Inverse of toKobo for form inputs.
+export function fromKobo(kobo: number | null | undefined): string {
+  return kobo && kobo > 0 ? (kobo / 100).toString() : '';
+}

--- a/web-pos/src/lib/inventory.ts
+++ b/web-pos/src/lib/inventory.ts
@@ -6,6 +6,7 @@
 
 import type { SupabaseClient } from '@supabase/supabase-js';
 
+import { friendlyRpcError, newId } from './rpc';
 import type { CategoryRow, ProductRow, SupplierRow } from './types';
 
 // A product unit the catalogue understands (mirrors the cloud products.unit
@@ -31,39 +32,20 @@ export type ProductUnit = (typeof PRODUCT_UNITS)[number];
 export const RECEIVE_PAYMENT_METHODS = ['cash', 'transfer', 'pos', 'other'] as const;
 export type ReceivePaymentMethod = (typeof RECEIVE_PAYMENT_METHODS)[number];
 
-function newId(): string {
-  return typeof crypto !== 'undefined' && 'randomUUID' in crypto
-    ? crypto.randomUUID()
-    : `${Date.now()}-${Math.random().toString(16).slice(2)}`;
-}
-
-// Map an RPC error token to an operator-facing message (mirrors checkout.ts).
+// Map an RPC error token to an operator-facing message.
 function friendlyError(message: string): string {
-  if (message.includes('permission_denied')) {
-    return 'You do not have permission to do this. Ask a manager.';
-  }
-  if (message.includes('name_required')) {
-    return 'Enter a product name.';
-  }
-  if (message.includes('lines_required') || message.includes('line_quantity_must_be_positive')) {
-    return 'Add at least one line with a quantity of one or more.';
-  }
-  if (message.includes('opening_stock_must_be_non_negative')) {
-    return 'Opening stock cannot be negative.';
-  }
-  if (message.includes('product_not_found')) {
-    return 'That product no longer exists. Refresh and try again.';
-  }
-  if (message.includes('supplier_id_required')) {
-    return 'Choose a supplier for this delivery.';
-  }
-  if (message.includes('store_id_required')) {
-    return 'This account has no store set up yet.';
-  }
-  if (message.includes('tenant_mismatch') || message.includes('no_business_for_caller')) {
-    return 'Your session is not linked to this business. Sign out and back in.';
-  }
-  return message;
+  return friendlyRpcError(message, [
+    ['permission_denied', 'You do not have permission to do this. Ask a manager.'],
+    ['name_required', 'Enter a product name.'],
+    [
+      ['lines_required', 'line_quantity_must_be_positive'],
+      'Add at least one line with a quantity of one or more.',
+    ],
+    ['opening_stock_must_be_non_negative', 'Opening stock cannot be negative.'],
+    ['product_not_found', 'That product no longer exists. Refresh and try again.'],
+    ['supplier_id_required', 'Choose a supplier for this delivery.'],
+    ['store_id_required', 'This account has no store set up yet.'],
+  ]);
 }
 
 export interface AddProductArgs {

--- a/web-pos/src/lib/rpc.ts
+++ b/web-pos/src/lib/rpc.ts
@@ -1,0 +1,30 @@
+// Shared helpers for the online-write RPC client libs (checkout / inventory /
+// stock adjustments). The web has no outbox: each write calls a server-
+// authoritative RPC (ADR 0008) with a client-minted idempotency id, and maps the
+// RPC's raw error token to an operator-facing message.
+
+// A client-minted UUID for an RPC's idempotency key. Falls back to a
+// timestamp+random id where crypto.randomUUID is unavailable.
+export function newId(): string {
+  return typeof crypto !== 'undefined' && 'randomUUID' in crypto
+    ? crypto.randomUUID()
+    : `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
+
+// One rule for friendlyRpcError: if the raw error contains any of the token(s),
+// surface the friendly message. Domain rules are evaluated in order.
+export type RpcErrorCase = [string | string[], string];
+
+// Map a raw RPC error to an operator-facing message: domain cases first, then the
+// tenant-binding case every RPC can raise, else the raw message unchanged.
+export function friendlyRpcError(raw: string, cases: RpcErrorCase[] = []): string {
+  const message = raw ?? '';
+  for (const [tokens, friendly] of cases) {
+    const list = Array.isArray(tokens) ? tokens : [tokens];
+    if (list.some((t) => message.includes(t))) return friendly;
+  }
+  if (message.includes('tenant_mismatch') || message.includes('no_business_for_caller')) {
+    return 'Your session is not linked to this business. Sign out and back in.';
+  }
+  return message;
+}

--- a/web-pos/src/lib/stockAdjustments.ts
+++ b/web-pos/src/lib/stockAdjustments.ts
@@ -6,29 +6,15 @@
 
 import type { SupabaseClient } from '@supabase/supabase-js';
 
-function newId(): string {
-  return typeof crypto !== 'undefined' && 'randomUUID' in crypto
-    ? crypto.randomUUID()
-    : `${Date.now()}-${Math.random().toString(16).slice(2)}`;
-}
+import { friendlyRpcError, newId } from './rpc';
 
 function friendlyError(message: string): string {
-  if (message.includes('insufficient_stock')) {
-    return 'That would take stock below zero. Lower the amount removed.';
-  }
-  if (message.includes('permission_denied')) {
-    return 'You do not have permission to do this.';
-  }
-  if (message.includes('quantity_diff_must_be_nonzero')) {
-    return 'Enter a non-zero quantity.';
-  }
-  if (message.includes('request_not_found')) {
-    return 'That request no longer exists. Refresh the queue.';
-  }
-  if (message.includes('tenant_mismatch') || message.includes('no_business_for_caller')) {
-    return 'Your session is not linked to this business. Sign out and back in.';
-  }
-  return message;
+  return friendlyRpcError(message, [
+    ['insufficient_stock', 'That would take stock below zero. Lower the amount removed.'],
+    ['permission_denied', 'You do not have permission to do this.'],
+    ['quantity_diff_must_be_nonzero', 'Enter a non-zero quantity.'],
+    ['request_not_found', 'That request no longer exists. Refresh the queue.'],
+  ]);
 }
 
 export interface RequestAdjustmentResult {


### PR DESCRIPTION
Quality-only follow-up from the epic-#46 code review. No behaviour change.

- New `src/lib/rpc.ts`: `newId()` + `friendlyRpcError(message, cases)` (shared match loop + the common `tenant_mismatch` fallback). Removes the copy-pasted `newId` (inventory/stockAdjustments) and the inline id-gen in checkout.
- `toKobo`/`fromKobo` moved into `src/lib/currency.ts` beside `formatKobo`; the inventory dialogs import them.
- `checkout.ts` / `inventory.ts` / `stockAdjustments.ts` delegate their `friendlyError` to the shared helper — every surfaced message preserved.

Verified: `npx tsc --noEmit` + `next build` green.

Closes #68