### PR TITLE
fix(reports): subtract discounts in Daily Reconciliation P&L (#70)

### DIFF
--- a/BUILD_LOG.md
+++ b/BUILD_LOG.md
@@ -2,6 +2,32 @@
 
 ---
 
+## 2026-07-05 — Daily Reconciliation P&L: subtract discounts (issue #70)
+
+**What changed.** The Daily Reconciliation booked sales revenue **gross** and
+never read `orders.discountKobo`, so **gross/net profit were overstated by the
+discounts given**. (`order_items.unitPriceKobo` is the gross list price; the
+order's real payable is `netAmountKobo = gross − discount`, per
+`order_commands.dart`.) Fixed per ADR 0014 §③.
+
+- **`recon_data.dart`.** New `ReconData.discountsKobo` (summed from
+  `orders.discountKobo` over counted sales, store- and span-scoped like refunds).
+  New `netRevenueKobo = costedRevenueKobo − discountsKobo`; `grossProfitKobo`
+  now `netRevenue − COGS`; `grossMarginPct` measured against **net** revenue
+  (with a divide-by-zero guard for a fully-discounted period).
+- **`daily_reconciliation_detail_screen.dart`.** P&L card shows Revenue →
+  − Discounts → Net revenue → − COGS → Gross profit (discount rows render only
+  when discounts > 0). CSV export gains the Discounts + Net-revenue rows.
+- **`test/dashboard/recon_data_test.dart`.** New — 6 cases over the P&L getters
+  (net revenue, gross profit, net profit, margin-on-net, zero-discount parity,
+  zero-net-revenue guard). All green; `flutter analyze` clean on the feature.
+
+CEO-only (cost wall §25.3) is unchanged. Scope is P&L discounts only — the stock
+flow-equation card, cash-flow summary, and integrity flag are the follow-up
+issue (ADR 0014).
+
+---
+
 ## 2026-07-05 — Currency input: preserve the caret on mid-string edits
 
 **What changed.** `CurrencyInputFormatter` no longer slams the caret to the end of

--- a/docs/adr/0014-closing-report-reconciliation.md
+++ b/docs/adr/0014-closing-report-reconciliation.md
@@ -1,0 +1,83 @@
+# The closing report reconciles from recorded flows, not a cash balance
+
+**Status:** accepted (2026-07-05)
+
+The Daily Reconciliation (§25.9, `recon_data.dart` + `daily_reconciliation_detail_screen.dart`)
+already ships a store-scoped, Day/Week/Month/Year report with Sales, a CEO
+Profit & Loss, a point-in-time "Business worth" net position, a perpetual stock
+audit, valued shrinkage, supplier flows, and crates. The ask is to complete it
+into a *closing report* with three linked checks — stock reconciliation, cash
+reconciliation, and P&L — plus a running business net position with an integrity
+flag. This ADR records how each is built given the constraints already in the
+codebase.
+
+The defining constraint is **Hard Rule #8**: the Funds Register was removed
+entirely (Session 96) — *no cash account, no Open Day / Close Day, no per-store
+money accounts; money is tracked as recorded sales, expenses, refunds, and
+supplier payments.* A literal cash reconciliation (opening float vs. physically
+counted drawer) *is* that removed model, so it is out of scope. Every decision
+below stays inside the recorded-flow world.
+
+Decisions locked:
+
+- **Cash reconciliation is a derived cash-flow *summary*, not a drawer count.**
+  It reports the period's expected cash *movement* from already-recorded,
+  tender-tagged flows — cash sales + debts collected − cash supplier payments −
+  cash expenses − cash refunds — with no opening float and no counted-cash
+  entry. Every source carries a tender: `payment_transactions.method`,
+  `expenses.paymentMethod`, `supplier_ledger_entries.paymentMethod`
+  (all `== 'cash'`, matched **case-insensitively** — the data has `'Cash'`/`'cash'`
+  drift). The authoritative cash-in source is `payment_transactions`
+  (`type` in {sale, topup_cash, …}), not `orders.paymentType`, so partial cash
+  on a credit order is captured. No cash *balance* is ever asserted.
+
+- **Stock reconciliation is a cost-valued flow-equation card (a derivation),
+  compared to the physical count.** Opening (at cost) + Goods received − COGS −
+  Damages − Expired = **Expected closing** (equal to the perpetual SYSTEM
+  figure), then **Variance = Physical count − Expected**. "Expired" is broken
+  out as its own line (today it is folded into damages via the `expired`
+  reason). The literal spec equation (which also subtracts *shortages* from
+  expected) is rejected: a shortage **is** the variance, so subtracting it would
+  double-count. The one genuinely hard input is *opening stock at cost as of a
+  past date* — cost is time-varying under FIFO (ADR 0005) and today only current
+  stock at current cost is valued; the implementation approximates and states
+  its basis rather than pretending to historical-cost precision.
+
+- **P&L books gross revenue and subtracts an explicit Discounts line.**
+  `order_items.unitPriceKobo` is the **gross** list price; the order's real
+  payable lives in `netAmountKobo`/`discountKobo` (`order_commands.dart`). The
+  report today sums `qty × unitPriceKobo` and never reads `discountKobo`, so
+  revenue and net profit are **overstated by the discount given** — a real
+  calculation bug in what already ships. Fix: Revenue (gross) − Discounts = Net
+  revenue → − COGS = Gross profit → − Expenses − Damages = Net profit. Shipped
+  as its own small PR ahead of the report work.
+
+- **The integrity flag reconciles from flows, adding no persistence.** A true
+  "Δ net position over the period = reported profit" identity cannot close: the
+  net position has no cash leg (Hard Rule #8) and no stored period-start snapshot
+  exists. Rather than persist snapshots, the flag derives the period's expected
+  asset change from recorded flows and the **physical stock count**, and flags
+  the gap against P&L profit. The independent signal it surfaces is stock-count
+  variance (shrinkage the flows didn't record) plus the now-corrected
+  discounts/refunds — i.e. a *recording error*, per the ask, not a real loss.
+
+- **The new cost/profit/cash-flow surfaces are CEO-only**, following the
+  existing cost wall (§25.3): Managers never see cost/COGS/margin/profit and
+  keep their retail-valued shrinkage + debts/expenses view.
+
+## Considered Options
+
+- **Reintroduce a lightweight opening-cash + counted-cash for the report only**
+  — rejected: it is the Open/Close-Day cash-account model Hard Rule #8 tombstoned
+  ("no reintroduction"); overturning it is a separate, deliberate architectural
+  reversal, not a report feature.
+- **Persist daily net-position snapshots for an exact running Δ** — deferred:
+  most faithful to "running net position," but adds a synced snapshot table +
+  backfill; the flow-reconciliation flag delivers the recording-error signal now
+  without new persistence. Revisit if snapshot-grade history is wanted.
+- **Book revenue net of discount with no discount line** — rejected: correct
+  bottom line but hides how much was discounted; the ask names discounts as an
+  explicit subtraction.
+- **Keep the perpetual count only / implement the literal equation** — rejected:
+  the first omits the opening→closing story asked for; the second double-counts
+  shortages so expected-vs-actual never ties out.

--- a/lib/features/dashboard/reconciliation/recon_data.dart
+++ b/lib/features/dashboard/reconciliation/recon_data.dart
@@ -248,6 +248,7 @@ class ReconData {
     required this.totalRevenueKobo,
     required this.costedRevenueKobo,
     required this.cogsKobo,
+    required this.discountsKobo,
     required this.itemsSold,
     required this.skus,
     required this.uncostedItems,
@@ -286,6 +287,12 @@ class ReconData {
   final int totalRevenueKobo;
   final int costedRevenueKobo;
   final int cogsKobo;
+  /// Period discounts given on counted sales (`orders.discountKobo`, summed in
+  /// scope + span). `order_items.unitPriceKobo` is the GROSS list price, so the
+  /// revenue sums above are gross of discount; this is subtracted in the P&L so
+  /// profit isn't overstated by the discount given (the order's real payable is
+  /// `netAmountKobo = gross − discount`). Contra-revenue, not an expense.
+  final int discountsKobo;
   final int itemsSold;
   final int skus;
   final int uncostedItems;
@@ -324,7 +331,11 @@ class ReconData {
   final List<({String name, int qty})> topItems;
   final List<({String manufacturerName, int count, int valueKobo})> manufacturerEmpties;
 
-  int get grossProfitKobo => costedRevenueKobo - cogsKobo;
+  /// Costed revenue net of discounts given — the real money earned on costed
+  /// lines. `costedRevenueKobo` is gross (Σ qty × gross unitPrice), so we
+  /// subtract the period's discounts to get what was actually charged.
+  int get netRevenueKobo => costedRevenueKobo - discountsKobo;
+  int get grossProfitKobo => netRevenueKobo - cogsKobo;
   int get netProfitKobo =>
       grossProfitKobo - expensesKobo - damageCostKobo - crateDamageDepositKobo;
 
@@ -352,10 +363,11 @@ class ReconData {
   /// Display this signed value — never relabel a credit as "owed".
   int get supplierAccountBalanceKobo => -supplierPayableKobo;
 
-  /// Gross margin as a 1-dp percentage string ("0.0" when there's no costed
-  /// revenue). Shared by the Statement card and the CSV export.
-  String get grossMarginPct => costedRevenueKobo > 0
-      ? (grossProfitKobo / costedRevenueKobo * 100).toStringAsFixed(1)
+  /// Gross margin as a 1-dp percentage string ("0.0" when there's no net
+  /// revenue). Measured against net revenue (after discounts), so the margin
+  /// reflects money actually earned. Shared by the P&L card and the CSV export.
+  String get grossMarginPct => netRevenueKobo > 0
+      ? (grossProfitKobo / netRevenueKobo * 100).toStringAsFixed(1)
       : '0.0';
 
   bool get isEmpty =>
@@ -419,6 +431,7 @@ ReconData computeReconData(
   var totalRevenueKobo = 0;
   var costedRevenueKobo = 0;
   var cogsKobo = 0;
+  var discountsKobo = 0;
   var itemsSold = 0;
   var uncostedItems = 0;
   var refundsKobo = 0;
@@ -436,6 +449,9 @@ ReconData computeReconData(
     if (!orderCountsAsSale(o.order.status) || !inSpan(o.order.createdAt)) {
       continue;
     }
+    // Order-level discount (contra-revenue). Scoped by the order's store to
+    // match refunds above; lines carry the same storeId in practice.
+    if (inScope(o.order.storeId)) discountsKobo += o.order.discountKobo;
     var orderRevenue = 0;
     for (final i in o.items) {
       if (!inScope(i.item.storeId)) continue;
@@ -655,6 +671,7 @@ ReconData computeReconData(
     totalRevenueKobo: totalRevenueKobo,
     costedRevenueKobo: costedRevenueKobo,
     cogsKobo: cogsKobo,
+    discountsKobo: discountsKobo,
     itemsSold: itemsSold,
     skus: skuSet.length,
     uncostedItems: uncostedItems,

--- a/lib/features/dashboard/screens/daily_reconciliation_detail_screen.dart
+++ b/lib/features/dashboard/screens/daily_reconciliation_detail_screen.dart
@@ -179,6 +179,20 @@ class DailyReconciliationDetailScreen extends ConsumerWidget {
           'Revenue',
           formatCurrency(d.costedRevenueKobo / 100.0),
         ),
+        if (d.discountsKobo > 0) ...[
+          _line(
+            context,
+            theme,
+            'Discounts',
+            '− ${formatCurrency(d.discountsKobo / 100.0)}',
+          ),
+          _line(
+            context,
+            theme,
+            'Net revenue',
+            formatCurrency(d.netRevenueKobo / 100.0),
+          ),
+        ],
         _line(
           context,
           theme,
@@ -676,7 +690,9 @@ class DailyReconciliationDetailScreen extends ConsumerWidget {
         ['Stock shortages (at cost)', money(d.shortageCostKobo)],
         ['Net result for period', money(d.periodNetResultKobo)],
         // Profit & Loss — mirrors _plCard.
-        ['Revenue (costed)', money(d.costedRevenueKobo)],
+        ['Revenue (costed, gross)', money(d.costedRevenueKobo)],
+        ['Discounts', money(d.discountsKobo)],
+        ['Net revenue (costed)', money(d.netRevenueKobo)],
         ['Cost of goods sold', money(d.cogsKobo)],
         ['Gross profit', money(d.grossProfitKobo)],
         ['Gross margin %', d.grossMarginPct],

--- a/test/dashboard/recon_data_test.dart
+++ b/test/dashboard/recon_data_test.dart
@@ -1,0 +1,112 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:reebaplus_pos/features/dashboard/reconciliation/recon_data.dart';
+
+/// Builds a [ReconData] with everything zeroed except the P&L inputs a test
+/// cares about — the getters under test only touch revenue / discounts / COGS /
+/// expenses / damages, so the rest can be neutral.
+ReconData recon({
+  int costedRevenueKobo = 0,
+  int cogsKobo = 0,
+  int discountsKobo = 0,
+  int expensesKobo = 0,
+  int damageCostKobo = 0,
+  int crateDamageDepositKobo = 0,
+}) {
+  return ReconData(
+    totalRevenueKobo: costedRevenueKobo,
+    costedRevenueKobo: costedRevenueKobo,
+    cogsKobo: cogsKobo,
+    discountsKobo: discountsKobo,
+    itemsSold: 0,
+    skus: 0,
+    uncostedItems: 0,
+    refundsKobo: 0,
+    bestStaff: null,
+    bestStaffKobo: 0,
+    expensesKobo: expensesKobo,
+    expensesCount: 0,
+    damageUnits: 0,
+    damageCostKobo: damageCostKobo,
+    damageRetailKobo: 0,
+    crateDamageDepositKobo: crateDamageDepositKobo,
+    hasStockCount: false,
+    productsCounted: 0,
+    shortageCount: 0,
+    shortageUnits: 0,
+    surplusCount: 0,
+    surplusUnits: 0,
+    shortageCostKobo: 0,
+    shortageRetailKobo: 0,
+    shortages: const [],
+    goodsReceivedKobo: 0,
+    supplierPaidKobo: 0,
+    totalOwedKobo: 0,
+    showCrates: false,
+    crateUnits: 0,
+    crateDepositKobo: 0,
+    supplierPayableKobo: 0,
+    inventoryOnHandKobo: 0,
+    uncostedInventoryItems: 0,
+    surplusCostKobo: 0,
+    topItems: const [],
+    manufacturerEmpties: const [],
+  );
+}
+
+void main() {
+  group('ReconData P&L — discounts are subtracted (issue #70)', () {
+    test('net revenue is gross costed revenue minus discounts', () {
+      final d = recon(costedRevenueKobo: 100000, discountsKobo: 15000);
+      expect(d.netRevenueKobo, 85000);
+    });
+
+    test('gross profit subtracts discounts before COGS', () {
+      // Gross revenue 100,000; discount 15,000; COGS 60,000.
+      final d = recon(
+        costedRevenueKobo: 100000,
+        discountsKobo: 15000,
+        cogsKobo: 60000,
+      );
+      // 100,000 − 15,000 − 60,000 = 25,000 (was 40,000 before the fix).
+      expect(d.grossProfitKobo, 25000);
+    });
+
+    test('net profit flows the discount through expenses and damages', () {
+      final d = recon(
+        costedRevenueKobo: 100000,
+        discountsKobo: 15000,
+        cogsKobo: 60000,
+        expensesKobo: 5000,
+        damageCostKobo: 2000,
+        crateDamageDepositKobo: 1000,
+      );
+      // grossProfit 25,000 − 5,000 − 2,000 − 1,000 = 17,000.
+      expect(d.netProfitKobo, 17000);
+    });
+
+    test('gross margin is measured against net revenue', () {
+      final d = recon(
+        costedRevenueKobo: 100000,
+        discountsKobo: 20000,
+        cogsKobo: 40000,
+      );
+      // net revenue 80,000; gross profit 40,000 → 50.0%.
+      expect(d.grossMarginPct, '50.0');
+    });
+
+    test('zero discounts leave the pre-fix behaviour intact', () {
+      final d = recon(costedRevenueKobo: 100000, cogsKobo: 60000);
+      expect(d.netRevenueKobo, 100000);
+      expect(d.grossProfitKobo, 40000);
+      expect(d.grossMarginPct, '40.0');
+    });
+
+    test('gross margin is "0.0" when there is no net revenue', () {
+      expect(recon().grossMarginPct, '0.0');
+      // A fully-discounted period has no net revenue → no divide-by-zero.
+      expect(recon(costedRevenueKobo: 5000, discountsKobo: 5000).grossMarginPct,
+          '0.0');
+    });
+  });
+}


### PR DESCRIPTION
## Summary
The Daily Reconciliation booked sales revenue **gross** and never read `orders.discountKobo`, so **gross and net profit were overstated by the discounts given** in the period.

- `order_items.unitPriceKobo` is the gross list price; the order's real payable is `netAmountKobo = gross − discount` (`order_commands.dart`).
- `recon_data.dart` summed `qty × unitPriceKobo` for revenue and ignored the discount entirely.

## Changes
- `recon_data.dart`: new `discountsKobo` (summed from counted sales, store/span-scoped like refunds); `netRevenueKobo = costedRevenue − discounts`; `grossProfit = netRevenue − COGS`; gross margin measured against **net** revenue (with a divide-by-zero guard).
- `daily_reconciliation_detail_screen.dart`: P&L card shows Revenue → − Discounts → Net revenue → − COGS → Gross profit (discount rows render only when discounts > 0); CSV export gains Discounts + Net-revenue rows.
- `test/dashboard/recon_data_test.dart`: 6 cases over the P&L getters. `flutter analyze` clean.
- `docs/adr/0014-closing-report-reconciliation.md`: records the grilled design for the follow-up closing-report enhancement (cash-flow summary, stock flow-equation card, integrity flag) — this PR is decision ③ of that ADR.

CEO-only (cost wall §25.3) unchanged.

Closes #70

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Daily reconciliation now accounts for discounts when calculating revenue, profit, and margins.
  * The Profit & Loss view and CSV export now show discounts and net revenue separately, with safer behavior when revenue is zero.
  * Reconciliation totals and margin figures have been corrected to better match reported sales figures.

* **Documentation**
  * Added guidance for the updated reconciliation and closing-report approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->