### PR TITLE
feat(reports): closing-report reconciliation — stock flow-equation + integrity flag (#72)

### DIFF
--- a/BUILD_LOG.md
+++ b/BUILD_LOG.md
@@ -2,6 +2,39 @@
 
 ---
 
+## 2026-07-05 — Closing report: cash-flow summary (issue #72, slice 1)
+
+**What changed.** First slice of the closing-report enhancement (ADR 0014 §②):
+a **derived cash-flow summary** on the CEO Daily Reconciliation — the period's
+expected cash *movement* from recorded cash tenders, **not** a counted drawer
+(Hard Rule #8: no float, no Close Day, no cash balance).
+
+- **Sourcing.** `payment_transactions` is the unified physical-cash ledger; every
+  cash move writes one (`sale` / `wallet_topup` / `refund` / `expense`, each with
+  a `method`). Verified at the insert sites (`daos_orders`, `credit_ledger_service`,
+  `daos_expenses`). Supplier payments are the one cash-out **not** in it (only on
+  `supplier_ledger_entries`), so they're summed from there. Expenses are taken
+  from the `expense` payment rows — **not** also from the expenses table — so
+  nothing double-counts. `method` matched case-insensitively ('Cash'/'cash' drift).
+- **Business-wide.** `payment_transactions` has no `storeId`, so the card is
+  business-wide (like the existing outstanding-debt line) and clearly labelled.
+  Crate deposits (a refundable held liability) are excluded — the ask is
+  operating cash (sales + debts collected).
+- **New plumbing.** `OrdersDao.watchAllPaymentTransactions()` (no regen — table
+  already in its accessor) + `allPaymentTransactionsProvider`
+  (`businessScopedStream`; passes the provider-ban test). `ReconData` gains
+  `cashSalesKobo` / `cashDebtsCollectedKobo` / `cashRefundsKobo` /
+  `cashExpensesKobo` / `cashSupplierPaidKobo` + `cashInKobo` / `cashOutKobo` /
+  `netCashMovementKobo` getters.
+- **UI/CSV.** New CEO-only `_cashFlowCard` (Cash in → Cash out → Net cash
+  movement) between P&L and Business worth; CSV export gains the same rows.
+- **Tests.** 4 cash-flow getter cases added to `recon_data_test.dart` (10 total
+  green); `flutter analyze` clean; provider-ban + business-scoped-stream tests green.
+
+Remaining for #72: stock flow-equation card and the integrity flag.
+
+---
+
 ## 2026-07-05 — Daily Reconciliation P&L: subtract discounts (issue #70)
 
 **What changed.** The Daily Reconciliation booked sales revenue **gross** and

--- a/BUILD_LOG.md
+++ b/BUILD_LOG.md
@@ -2,6 +2,36 @@
 
 ---
 
+## 2026-07-05 — Closing report: integrity flag (issue #72, slice 3 — epic complete)
+
+**What changed.** Final slice of the closing-report enhancement (ADR 0014 §④):
+a CEO-only **integrity check** card that reconciles reported P&L profit against
+the independent physical stock count — **no new persistence**, derived entirely
+from recorded flows + the count.
+
+- **What it does.** A true "Δ net position over the period = reported profit"
+  identity can't close: there's no cash leg (Hard Rule #8) and no stored
+  period-start snapshot. So instead of persisting snapshots, the flag surfaces
+  the one thing the recorded flows did **not** book — the **stock-count variance**
+  (physical − expected, at cost, straight from slice 2's `stockVarianceKobo`).
+  Reported profit is built only from sales / COGS / discounts / expenses /
+  damages, so a count shortfall is a **recording error** (unbooked shrinkage /
+  theft / miscount), not a separate real loss, and it isn't reflected in the
+  reported profit. The card shows Reported net profit → Unexplained variance →
+  **Count-reconciled profit** (`netProfit + variance`), with a
+  reconciled/flagged verdict and a "take a count" nudge when no count exists.
+- **Plumbing.** `ReconData` gains `integrityAdjustedProfitKobo` +
+  `hasIntegrityGap` getters (no new fields — reuses the slice-2 variance). New
+  CEO-only `_integrityCard` (shield icon) after the stock audit, shown when
+  `hasStockFlow`; CSV export gains a "Count-reconciled profit" row.
+- **Tests.** 3 integrity getter cases added to `recon_data_test.dart` (17 total
+  green); `flutter analyze` clean.
+
+**Epic status:** all three closing-report checks now ship — cash-flow summary
+(slice 1), stock flow-equation (slice 2), integrity flag (slice 3). Closes #72.
+
+---
+
 ## 2026-07-05 — Closing report: stock flow-equation card (issue #72, slice 2)
 
 **What changed.** Second slice of the closing-report enhancement (ADR 0014 §①):

--- a/BUILD_LOG.md
+++ b/BUILD_LOG.md
@@ -2,6 +2,54 @@
 
 ---
 
+## 2026-07-05 — Closing report: stock flow-equation card (issue #72, slice 2)
+
+**What changed.** Second slice of the closing-report enhancement (ADR 0014 §①):
+a CEO-only **stock reconciliation flow-equation** card on the Daily
+Reconciliation — Opening + Goods received − COGS − Damages − Expired (± Other) =
+**Expected closing** (the perpetual system figure), then **Variance = Physical
+count − Expected**. Values the whole equation at **current per-product cost**.
+
+- **Cost basis (the hard input, resolved).** Opening stock *as of a past date*
+  is genuinely hard: cost is time-varying under FIFO (ADR 0005) and only current
+  stock is valued today. Rather than fake historical precision, every term is
+  valued at the product's **current** buying price, and opening / expected-closing
+  are reconstructed by **rewinding the recorded `stock_transactions` deltas from
+  the current on-hand figure** (`current − Σ deltas after period end` = closing;
+  `closing − Σ period deltas` = opening). Because opening is that rewind, the
+  equation **ties out to the system figure by construction** — stated basis, not
+  faked precision.
+- **Expired split from damages.** Record Damages and free-text removals both put
+  expiry in `stock_adjustments.reason` (`damage:expired` / "Expired"), reached
+  from the ledger row via `adjustmentId`. New `isExpiredReason` (contains
+  "expired") breaks Expired onto its own line; non-expired damage stays Damages.
+  The P&L "Damages (at cost)" line is deliberately **left unchanged** (still
+  folds expiry) — this split is scoped to the stock card.
+- **Classification.** From `stock_transactions` (store-scoped by `locationId`,
+  non-voided): `sale`/`return` → COGS (returns net against it); receipts (reason
+  "Stock received", both Receive Stock and Add Product opening) → Goods received;
+  `adjustment` reasons → Expired / Damages / receipt; everything else (transfers,
+  "Daily stock count adjustment", unclassified) → an **Other movements** residual
+  so nothing is silently folded into opening. Variance reuses the stock-count
+  surplus/shortage-at-cost figures (`surplus − shortage`), shown only when a
+  count exists.
+- **New plumbing.** `StockLedgerDao.watchAllTransactions()` (raw ledger rows, no
+  regen) + `allStockTransactionsProvider` (`businessScopedStream`; passes the
+  provider-ban test). `ReconData` gains `stockOpeningKobo` / `stockReceivedKobo` /
+  `stockCogsKobo` / `stockDamagesKobo` / `stockExpiredKobo` /
+  `stockOtherMovementsKobo` / `stockExpectedClosingKobo` fields +
+  `stockDerivedClosingKobo` / `stockVarianceKobo` / `hasStockFlow` getters.
+- **UI/CSV.** New CEO-only `_stockFlowCard` (scale-balanced icon) between the
+  shrinkage card and the stock audit, shown only when `hasStockFlow`; CSV export
+  gains the mirroring rows.
+- **Tests.** 4 flow-equation getter cases added to `recon_data_test.dart` (14
+  total green); `flutter analyze` clean; provider-ban + business-scoped-stream
+  tests green.
+
+Remaining for #72: the integrity flag (slice 3).
+
+---
+
 ## 2026-07-05 — Closing report: cash-flow summary (issue #72, slice 1)
 
 **What changed.** First slice of the closing-report enhancement (ADR 0014 §②):

--- a/CONTEXT/progress-tracker.md
+++ b/CONTEXT/progress-tracker.md
@@ -24,9 +24,15 @@ design in **ADR 0014**. Two issues off `main`:
     `OrdersDao.watchAllPaymentTransactions` + `allPaymentTransactionsProvider`;
     CEO-only card + CSV. `payment_transactions` = unified cash ledger; supplier cash
     from supplier_ledger; no double-count.
-  - ⏳ **Slice 2 — stock flow-equation card.** Decided: value the flow at **current
-    cost throughout** (ties out to current inventory-at-cost); expired broken out
-    from damages. Source from `stock_transactions` (has `movementType` + `locationId`).
+  - ✅ **Slice 2 — stock flow-equation card (this branch).** CEO-only stock
+    reconciliation: Opening + Goods received − COGS − Damages − Expired (± Other)
+    = Expected closing → Variance = Physical − Expected. Valued at **current cost
+    throughout**; opening/expected-closing reconstructed by **rewinding the
+    `stock_transactions` ledger from current on-hand** (ties out by construction,
+    handles historical period-end). Expired split from damages via
+    `adjustmentId → reason` (`isExpiredReason`). `StockLedgerDao.watchAllTransactions`
+    + `allStockTransactionsProvider`; 7 `stock*Kobo` fields + `stockVarianceKobo`
+    / `hasStockFlow` getters; `_stockFlowCard` + CSV. 14 recon tests green.
   - ⏳ **Slice 3 — integrity flag.** Flow-reconciliation, no new tables; flags
     P&L-profit vs measured-asset-change gap (stock-count variance as the signal).
 

--- a/CONTEXT/progress-tracker.md
+++ b/CONTEXT/progress-tracker.md
@@ -10,10 +10,10 @@ The human updates it when resolving open questions or making architectural decis
 
 152 sessions logged. Codebase is live and being verified on-device.
 
-### IN PROGRESS: Closing-report reconciliation (ADR 0014, 2026-07-05)
-Enhancing the Daily Reconciliation (§25.9) into a full closing report. Grilled;
+### SHIPPED: Closing-report reconciliation (ADR 0014, 2026-07-05)
+Enhanced the Daily Reconciliation (§25.9) into a full closing report. Grilled;
 design in **ADR 0014**. Two issues off `main`:
-- **#70 — P&L discount fix (SHIPPED → PR #71).** Report booked revenue gross and
+- **#70 — P&L discount fix (SHIPPED — PR #71 MERGED to `main`).** Report booked revenue gross and
   ignored `orders.discountKobo`, overstating profit. Added `ReconData.discountsKobo`
   + `netRevenueKobo`; P&L now Revenue → −Discounts → Net revenue → −COGS; margin on
   net revenue. Branch `fix/recon-pl-discounts`.
@@ -33,8 +33,12 @@ design in **ADR 0014**. Two issues off `main`:
     `adjustmentId → reason` (`isExpiredReason`). `StockLedgerDao.watchAllTransactions`
     + `allStockTransactionsProvider`; 7 `stock*Kobo` fields + `stockVarianceKobo`
     / `hasStockFlow` getters; `_stockFlowCard` + CSV. 14 recon tests green.
-  - ⏳ **Slice 3 — integrity flag.** Flow-reconciliation, no new tables; flags
-    P&L-profit vs measured-asset-change gap (stock-count variance as the signal).
+  - ✅ **Slice 3 — integrity flag (this branch).** CEO-only integrity check:
+    reconciles reported P&L profit against the physical count with **no new
+    persistence** — surfaces the stock-count variance the flows never booked
+    (`integrityAdjustedProfitKobo = netProfit + variance`; `hasIntegrityGap`),
+    framed as a recording error, not a real loss. `_integrityCard` + CSV row. 17
+    recon tests green. **Epic complete → closes #72.**
 
 
 

--- a/CONTEXT/progress-tracker.md
+++ b/CONTEXT/progress-tracker.md
@@ -10,6 +10,28 @@ The human updates it when resolving open questions or making architectural decis
 
 152 sessions logged. Codebase is live and being verified on-device.
 
+### IN PROGRESS: Closing-report reconciliation (ADR 0014, 2026-07-05)
+Enhancing the Daily Reconciliation (§25.9) into a full closing report. Grilled;
+design in **ADR 0014**. Two issues off `main`:
+- **#70 — P&L discount fix (SHIPPED → PR #71).** Report booked revenue gross and
+  ignored `orders.discountKobo`, overstating profit. Added `ReconData.discountsKobo`
+  + `netRevenueKobo`; P&L now Revenue → −Discounts → Net revenue → −COGS; margin on
+  net revenue. Branch `fix/recon-pl-discounts`.
+- **#72 — closing-report enhancement (branch `feat/closing-report-reconciliation`,
+  stacked on #70).**
+  - ✅ **Slice 1 — cash-flow summary (committed `676c310`).** Business-wide derived
+    cash *movement* from tender-tagged flows (no drawer count — Hard Rule #8).
+    `OrdersDao.watchAllPaymentTransactions` + `allPaymentTransactionsProvider`;
+    CEO-only card + CSV. `payment_transactions` = unified cash ledger; supplier cash
+    from supplier_ledger; no double-count.
+  - ⏳ **Slice 2 — stock flow-equation card.** Decided: value the flow at **current
+    cost throughout** (ties out to current inventory-at-cost); expired broken out
+    from damages. Source from `stock_transactions` (has `movementType` + `locationId`).
+  - ⏳ **Slice 3 — integrity flag.** Flow-reconciliation, no new tables; flags
+    P&L-profit vs measured-asset-change gap (stock-count variance as the signal).
+
+
+
 ### PLANNING: Web POS (online-first browser client) — grilled 2026-07-04, ADRs 0007–0012
 - **North star:** full parity — the *entire* app replicated for web — reached in
   phases. **Phase 1 = selling loop + inventory management + reports.** Later phases

--- a/docs/adr/0014-closing-report-reconciliation.md
+++ b/docs/adr/0014-closing-report-reconciliation.md
@@ -28,8 +28,10 @@ Decisions locked:
   `expenses.paymentMethod`, `supplier_ledger_entries.paymentMethod`
   (all `== 'cash'`, matched **case-insensitively** — the data has `'Cash'`/`'cash'`
   drift). The authoritative cash-in source is `payment_transactions`
-  (`type` in {sale, topup_cash, …}), not `orders.paymentType`, so partial cash
-  on a credit order is captured. No cash *balance* is ever asserted.
+  (`type` in {sale, wallet_topup, refund, expense}), not `orders.paymentType`, so
+  partial cash on a credit order is captured; cash supplier payments (the one
+  cash-out not in `payment_transactions`) are summed from `supplier_ledger_entries`
+  `payment_*`. No cash *balance* is ever asserted.
 
 - **Stock reconciliation is a cost-valued flow-equation card (a derivation),
   compared to the physical count.** Opening (at cost) + Goods received − COGS −
@@ -39,9 +41,20 @@ Decisions locked:
   reason). The literal spec equation (which also subtracts *shortages* from
   expected) is rejected: a shortage **is** the variance, so subtracting it would
   double-count. The one genuinely hard input is *opening stock at cost as of a
-  past date* — cost is time-varying under FIFO (ADR 0005) and today only current
-  stock at current cost is valued; the implementation approximates and states
-  its basis rather than pretending to historical-cost precision.
+  past date* — cost is time-varying under FIFO (ADR 0005). **Basis decided
+  as-built (current cost, ledger-rewound):** every term (opening, received,
+  COGS, damages, expired) is valued at the product's *current* per-product
+  buying price (`products.buyingPriceKobo`; uncosted units, cost ≤ 0, carry
+  zero value). Opening and Expected closing are reconstructed by **rewinding the
+  recorded `stock_transactions` deltas from the current on-hand figure** — so the
+  equation ties to the perpetual SYSTEM figure *by construction* rather than
+  pretending to historical-cost precision. Deltas are classified by
+  `movementType`/reason (sale → COGS, receipt reasons → Goods received,
+  `damage:`/`expired` reasons → Damages/Expired); transfers, count fixes, and
+  anything unclassified land in a signed **Other movements** residual so nothing
+  is silently folded into opening. Consequence: this card's COGS (current cost)
+  can diverge from the P&L COGS (per-line snapshotted FIFO cost) under a price
+  change — accepted as the stated current-cost basis.
 
 - **P&L books gross revenue and subtracts an explicit Discounts line.**
   `order_items.unitPriceKobo` is the **gross** list price; the order's real

--- a/lib/core/database/daos_inventory.dart
+++ b/lib/core/database/daos_inventory.dart
@@ -730,6 +730,18 @@ class StockLedgerDao extends DatabaseAccessor<AppDatabase>
         .watch();
   }
 
+  /// Every non-voided stock movement for the business (raw ledger rows, no
+  /// joins). Feeds the Daily Reconciliation stock flow-equation card (ADR
+  /// 0014): opening and expected-closing stock are reconstructed by rewinding
+  /// these deltas from the current on-hand figure, valued at current cost.
+  /// Store scope is applied in the report from each row's `locationId`.
+  Stream<List<StockTransactionData>> watchAllTransactions() {
+    return (select(stockTransactions)
+          ..where((s) => whereBusiness(s) & s.voidedAt.isNull())
+          ..orderBy([(s) => OrderingTerm.desc(s.createdAt)]))
+        .watch();
+  }
+
   // ── Filtered queries with joined product/user/store names ──────────
 
   JoinedSelectStatement<HasResultSet, dynamic> _buildFilteredQuery({

--- a/lib/core/database/daos_orders.dart
+++ b/lib/core/database/daos_orders.dart
@@ -25,6 +25,18 @@ class OrdersDao extends DatabaseAccessor<AppDatabase>
 
   // ── Reads ──────────────────────────────────────────────────────────────────
 
+  /// Every `payment_transactions` row for this business — the unified physical-
+  /// cash tender ledger (`type` in {sale, wallet_topup, refund, expense}, each
+  /// carrying its `method`). Newest first. Voided rows are kept; callers filter
+  /// on `voidedAt`. This table has no `storeId`, so the Daily Reconciliation
+  /// cash-flow summary that reads it (ADR 0014) is business-wide.
+  Stream<List<PaymentTransactionData>> watchAllPaymentTransactions() {
+    return (select(paymentTransactions)
+          ..where((p) => whereBusiness(p))
+          ..orderBy([(p) => OrderingTerm.desc(p.createdAt)]))
+        .watch();
+  }
+
   Future<OrderData?> findById(String id) {
     return (select(orders)
           ..where((o) => o.id.equals(id) & whereBusiness(o))

--- a/lib/core/providers/stream_providers.dart
+++ b/lib/core/providers/stream_providers.dart
@@ -1822,3 +1822,14 @@ final allSupplierLedgerEntriesProvider =
   (ref, db, businessId) => db.supplierLedgerDao.watchAllHistory(),
   whenAbsent: const [],
 );
+
+/// Every `payment_transactions` row (the unified physical-cash tender ledger)
+/// for this business, newest first. Feeds the Daily Reconciliation cash-flow
+/// summary (ADR 0014): cash IN (`sale`, `wallet_topup`) and cash OUT (`refund`,
+/// `expense`), each filtered on `method == 'cash'`. The table carries no
+/// `storeId`, so the cash summary is business-wide (like customer debt).
+final allPaymentTransactionsProvider =
+    businessScopedStream<List<PaymentTransactionData>>(
+  (ref, db, businessId) => db.ordersDao.watchAllPaymentTransactions(),
+  whenAbsent: const [],
+);

--- a/lib/core/providers/stream_providers.dart
+++ b/lib/core/providers/stream_providers.dart
@@ -1833,3 +1833,14 @@ final allPaymentTransactionsProvider =
   (ref, db, businessId) => db.ordersDao.watchAllPaymentTransactions(),
   whenAbsent: const [],
 );
+
+/// Every non-voided `stock_transactions` row (the append-only stock ledger) for
+/// this business. Feeds the Daily Reconciliation stock flow-equation card (ADR
+/// 0014): opening and expected-closing stock are reconstructed by rewinding
+/// these deltas from the current on-hand figure, valued at current cost. Store
+/// scope is applied in the report from each row's `locationId`.
+final allStockTransactionsProvider =
+    businessScopedStream<List<StockTransactionData>>(
+  (ref, db, businessId) => db.stockLedgerDao.watchAllTransactions(),
+  whenAbsent: const [],
+);

--- a/lib/features/dashboard/reconciliation/recon_data.dart
+++ b/lib/features/dashboard/reconciliation/recon_data.dart
@@ -253,6 +253,11 @@ class ReconData {
     required this.skus,
     required this.uncostedItems,
     required this.refundsKobo,
+    required this.cashSalesKobo,
+    required this.cashDebtsCollectedKobo,
+    required this.cashRefundsKobo,
+    required this.cashExpensesKobo,
+    required this.cashSupplierPaidKobo,
     required this.bestStaff,
     required this.bestStaffKobo,
     required this.expensesKobo,
@@ -297,6 +302,16 @@ class ReconData {
   final int skus;
   final int uncostedItems;
   final int refundsKobo;
+  // ── Cash-flow summary (ADR 0014, business-wide) ──────────────────────────
+  // Derived cash MOVEMENT for the period from tender-tagged flows (`method ==
+  // 'cash'`), NOT a drawer count (Hard Rule #8: no cash balance, no float, no
+  // Close Day). `payment_transactions` is the unified physical-cash ledger and
+  // has no storeId, so these are business-wide (like outstanding customer debt).
+  final int cashSalesKobo; // IN — payment_transactions type 'sale'
+  final int cashDebtsCollectedKobo; // IN — type 'wallet_topup' (debt paid in cash)
+  final int cashRefundsKobo; // OUT — type 'refund'
+  final int cashExpensesKobo; // OUT — type 'expense'
+  final int cashSupplierPaidKobo; // OUT — supplier_ledger payment_* (not in pay-txns)
   final String? bestStaff;
   final int bestStaffKobo;
   final int expensesKobo;
@@ -338,6 +353,15 @@ class ReconData {
   int get grossProfitKobo => netRevenueKobo - cogsKobo;
   int get netProfitKobo =>
       grossProfitKobo - expensesKobo - damageCostKobo - crateDamageDepositKobo;
+
+  // ── Cash-flow summary getters (ADR 0014) ─────────────────────────────────
+  int get cashInKobo => cashSalesKobo + cashDebtsCollectedKobo;
+  int get cashOutKobo =>
+      cashRefundsKobo + cashExpensesKobo + cashSupplierPaidKobo;
+  /// Expected net cash movement for the period (in − out). Not a cash balance —
+  /// there is no opening float to add it to (Hard Rule #8).
+  int get netCashMovementKobo => cashInKobo - cashOutKobo;
+  bool get hasCashActivity => cashInKobo != 0 || cashOutKobo != 0;
 
   /// Net result for the period (flow). Folds the inventory-on-hand asset and the
   /// supplier flows (goods received / paid to suppliers / refunds) that used to
@@ -398,6 +422,8 @@ ReconData computeReconData(
       ref.watch(allStockAdjustmentsProvider).valueOrNull ?? const [];
   final ledger =
       ref.watch(allSupplierLedgerEntriesProvider).valueOrNull ?? const [];
+  final payments =
+      ref.watch(allPaymentTransactionsProvider).valueOrNull ?? const [];
   final counts = ref.watch(allStockCountsProvider).valueOrNull ?? const [];
   // Inventory-on-hand must honour the active-store scope like every other
   // figure here (§12.1): pass the locked store so a single-store view doesn't
@@ -636,6 +662,44 @@ ReconData computeReconData(
     }
   }
 
+  // ── Cash-flow summary (ADR 0014; business-wide, tender-tagged) ───────────
+  // Expected cash MOVEMENT for the period from recorded cash tenders — NOT a
+  // drawer count (Hard Rule #8: no float, no counted cash). payment_transactions
+  // is the unified physical-cash ledger (sale / wallet_topup / refund / expense,
+  // each with a `method`) and has no storeId, so this card is business-wide.
+  // Crate deposits (a refundable held liability) are deliberately excluded — the
+  // ask is operating cash (sales + debts collected). `method` casing drifts
+  // ('Cash'/'cash'), so match case-insensitively.
+  var cashSalesKobo = 0;
+  var cashDebtsCollectedKobo = 0;
+  var cashRefundsKobo = 0;
+  var cashExpensesKobo = 0;
+  for (final p in payments) {
+    if (p.voidedAt != null) continue;
+    if (p.method.toLowerCase() != 'cash') continue;
+    if (!inSpan(p.createdAt)) continue;
+    if (p.type == 'sale') {
+      cashSalesKobo += p.amountKobo;
+    } else if (p.type == 'wallet_topup') {
+      cashDebtsCollectedKobo += p.amountKobo;
+    } else if (p.type == 'refund') {
+      cashRefundsKobo += p.amountKobo;
+    } else if (p.type == 'expense') {
+      cashExpensesKobo += p.amountKobo;
+    }
+  }
+  // Supplier payments made in cash — the one cash-out NOT in payment_transactions
+  // (recorded only on the supplier ledger). Business-wide, in span, to match the
+  // rest of the cash card.
+  var cashSupplierPaidKobo = 0;
+  for (final l in ledger) {
+    if (l.voidedAt != null || l.referenceType == 'void') continue;
+    if (!l.referenceType.startsWith('payment_')) continue;
+    if (!inSpan(l.activityDate)) continue;
+    if ((l.paymentMethod ?? '').toLowerCase() != 'cash') continue;
+    cashSupplierPaidKobo += l.amountKobo;
+  }
+
   // ── Outstanding customer debt (business-wide — wallets aren't per store) ──
   final totalOwedKobo = balances.values
       .where((b) => b < 0)
@@ -676,6 +740,11 @@ ReconData computeReconData(
     skus: skuSet.length,
     uncostedItems: uncostedItems,
     refundsKobo: refundsKobo,
+    cashSalesKobo: cashSalesKobo,
+    cashDebtsCollectedKobo: cashDebtsCollectedKobo,
+    cashRefundsKobo: cashRefundsKobo,
+    cashExpensesKobo: cashExpensesKobo,
+    cashSupplierPaidKobo: cashSupplierPaidKobo,
     bestStaff: bestStaff,
     bestStaffKobo: bestStaffKobo,
     expensesKobo: expensesKobo,

--- a/lib/features/dashboard/reconciliation/recon_data.dart
+++ b/lib/features/dashboard/reconciliation/recon_data.dart
@@ -435,6 +435,27 @@ class ReconData {
   /// count exists in the period ([hasStockCount]).
   int get stockVarianceKobo => surplusCostKobo - shortageCostKobo;
 
+  // ── Integrity flag (ADR 0014 slice 3) ────────────────────────────────────
+  // Reconciles reported P&L profit against the independent physical stock
+  // count, deriving the gap entirely from recorded flows + the count — no new
+  // persistence. A true "Δ net position = profit" identity can't close (no cash
+  // leg under Hard Rule #8, no stored period-start snapshot), so the flag
+  // instead surfaces the one thing the flows did NOT record: the stock-count
+  // variance. Reported profit is built only from sales / COGS / discounts /
+  // expenses / damages, so a count shortfall is a RECORDING error (unbooked
+  // shrinkage / theft / miscount) the profit figure never reflected — not a
+  // separate real loss.
+
+  /// Reported net profit reconciled against the physical count: P&L profit plus
+  /// the stock-count variance the flows never booked. Equals [netProfitKobo]
+  /// when the count matches the flows (a surplus lifts it, a shortage cuts it).
+  int get integrityAdjustedProfitKobo => netProfitKobo + stockVarianceKobo;
+
+  /// True when a physical count was taken and it does not match the recorded
+  /// flows — an unexplained gap worth flagging. Without a count there is nothing
+  /// independent to reconcile against, so this is false.
+  bool get hasIntegrityGap => hasStockCount && stockVarianceKobo != 0;
+
   /// Whether any stock movement or on-hand value exists to render the card.
   bool get hasStockFlow =>
       stockOpeningKobo != 0 ||

--- a/lib/features/dashboard/reconciliation/recon_data.dart
+++ b/lib/features/dashboard/reconciliation/recon_data.dart
@@ -112,6 +112,29 @@ bool isDamageReason(String reason) {
       r.startsWith('broken');
 }
 
+/// A damage/loss reason that specifically names expiry (spoilage past date).
+/// The ADR 0014 stock flow-equation card breaks **Expired** out of Damages as
+/// its own line. Record Damages stamps `damage:expired` (`stock_count_screen`);
+/// a Manager/CEO free-text removal stores "Expired". Both contain "expired", so
+/// match on that, case-insensitively. Callers pair this with [isDamageReason]:
+/// a non-expired damage is `isDamageReason(r) && !isExpiredReason(r)`.
+bool isExpiredReason(String reason) => reason.toLowerCase().contains('expired');
+
+/// A stock-increment reason that names a goods RECEIPT (stock coming in), for
+/// the ADR 0014 flow-equation "Goods received" line. Both Receive Stock and Add
+/// Product opening stock route through `adjustStock` with the reason "Stock
+/// received"; a few synonyms are accepted for robustness. Count reconciliations
+/// ("Daily stock count adjustment") and manual removals are deliberately NOT
+/// receipts — they fall to the "other movements" residual.
+bool isReceiptReason(String reason) {
+  final r = reason.toLowerCase();
+  return r.contains('received') ||
+      r.contains('receipt') ||
+      r.contains('restock') ||
+      r.contains('opening') ||
+      r.contains('initial');
+}
+
 /// §17.2 crate-aware damages — FULL crate lost. When a damaged tracked-bottle
 /// product also forfeits its refundable crate deposit because the full crate
 /// (item + its container) was lost, Record Damages appends this suffix to the
@@ -285,6 +308,13 @@ class ReconData {
     required this.inventoryOnHandKobo,
     required this.uncostedInventoryItems,
     required this.surplusCostKobo,
+    required this.stockOpeningKobo,
+    required this.stockReceivedKobo,
+    required this.stockCogsKobo,
+    required this.stockDamagesKobo,
+    required this.stockExpiredKobo,
+    required this.stockOtherMovementsKobo,
+    required this.stockExpectedClosingKobo,
     required this.topItems,
     required this.manufacturerEmpties,
   });
@@ -343,6 +373,27 @@ class ReconData {
   final int inventoryOnHandKobo;
   final int uncostedInventoryItems;
   final int surplusCostKobo;
+
+  // ── Stock flow-equation card (ADR 0014, at current cost) ─────────────────
+  // Opening@cost + Goods received − COGS − Damages − Expired (± Other) =
+  // Expected closing (the perpetual SYSTEM figure), then Variance = Physical
+  // count − Expected. Reconstructed from the `stock_transactions` ledger by
+  // rewinding recorded deltas from the current on-hand figure, so the equation
+  // ties out by construction (see [computeReconData]). Every term is valued at
+  // the product's CURRENT buying price — cost is time-varying under FIFO (ADR
+  // 0005) and only current stock is valued today, so this states a current-cost
+  // basis rather than pretending to historical-cost precision. CEO-only (§25.3).
+  final int stockOpeningKobo; // system stock at period start × current cost
+  final int stockReceivedKobo; // goods received in period × current cost
+  final int stockCogsKobo; // units sold in period × current cost
+  final int stockDamagesKobo; // non-expired damages in period × current cost
+  final int stockExpiredKobo; // expired removals in period × current cost
+  /// Signed residual: transfers, count reconciliations, and any adjustment not
+  /// classified as a sale / receipt / damage / expiry. Keeps the flow equation
+  /// tying to the system figure without silently folding these into opening.
+  final int stockOtherMovementsKobo;
+  final int stockExpectedClosingKobo; // system stock at period end × current cost
+
   final List<({String name, int qty})> topItems;
   final List<({String manufacturerName, int count, int valueKobo})> manufacturerEmpties;
 
@@ -362,6 +413,37 @@ class ReconData {
   /// there is no opening float to add it to (Hard Rule #8).
   int get netCashMovementKobo => cashInKobo - cashOutKobo;
   bool get hasCashActivity => cashInKobo != 0 || cashOutKobo != 0;
+
+  // ── Stock flow-equation getters (ADR 0014) ───────────────────────────────
+  /// Expected closing rebuilt from the flow lines the card renders. Equal to
+  /// [stockExpectedClosingKobo] by construction (opening is the rewind of the
+  /// period's deltas from the system closing), so displaying both proves the
+  /// equation ties out.
+  int get stockDerivedClosingKobo =>
+      stockOpeningKobo +
+      stockReceivedKobo -
+      stockCogsKobo -
+      stockDamagesKobo -
+      stockExpiredKobo +
+      stockOtherMovementsKobo;
+
+  /// Variance = Physical count − Expected closing, valued at current cost:
+  /// a surplus (physical over system) is positive, a shortage negative. This is
+  /// the count discrepancy the recorded flows did NOT explain — the independent
+  /// signal the closing report surfaces. Uses the same count figures as the
+  /// stock audit (`surplus`/`shortage` at cost). Meaningful only when a physical
+  /// count exists in the period ([hasStockCount]).
+  int get stockVarianceKobo => surplusCostKobo - shortageCostKobo;
+
+  /// Whether any stock movement or on-hand value exists to render the card.
+  bool get hasStockFlow =>
+      stockOpeningKobo != 0 ||
+      stockExpectedClosingKobo != 0 ||
+      stockReceivedKobo != 0 ||
+      stockCogsKobo != 0 ||
+      stockDamagesKobo != 0 ||
+      stockExpiredKobo != 0 ||
+      stockOtherMovementsKobo != 0;
 
   /// Net result for the period (flow). Folds the inventory-on-hand asset and the
   /// supplier flows (goods received / paid to suppliers / refunds) that used to
@@ -424,6 +506,8 @@ ReconData computeReconData(
       ref.watch(allSupplierLedgerEntriesProvider).valueOrNull ?? const [];
   final payments =
       ref.watch(allPaymentTransactionsProvider).valueOrNull ?? const [];
+  final stockTxns =
+      ref.watch(allStockTransactionsProvider).valueOrNull ?? const [];
   final counts = ref.watch(allStockCountsProvider).valueOrNull ?? const [];
   // Inventory-on-hand must honour the active-store scope like every other
   // figure here (§12.1): pass the locked store so a single-store view doesn't
@@ -537,6 +621,91 @@ ReconData computeReconData(
     } else {
       inventoryOnHandKobo += p.totalStock * p.product.buyingPriceKobo;
     }
+  }
+
+  // ── Stock flow-equation at current cost (ADR 0014) ───────────────────────
+  // Opening@cost + Goods received − COGS − Damages − Expired (± Other) =
+  // Expected closing (the perpetual SYSTEM figure), then Variance = Physical −
+  // Expected (the stock-count discrepancy). Opening and expected-closing are
+  // reconstructed by rewinding the recorded `stock_transactions` deltas from
+  // the current on-hand figure, so the equation ties to the system by
+  // construction. Every term is valued at the product's CURRENT buying price —
+  // cost is time-varying under FIFO (ADR 0005) and only current stock is valued
+  // today, so this states a current-cost basis rather than faking historical
+  // precision. Store scope is applied per row's `locationId` like every figure
+  // here. Receipts (Receive Stock / opening stock) and manual adjustments share
+  // movementType 'adjustment', so they're split by the linked reason; anything
+  // unclassified (transfers, count reconciliations) is kept in an "other
+  // movements" residual so nothing is silently folded into opening.
+  final reasonByAdjustmentId = {for (final a in adjustments) a.id: a.reason};
+  final currentUnits = {
+    for (final p in productsWS) p.product.id: p.totalStock,
+  };
+  final afterEndUnits = <String, int>{}; // deltas at/after period end (rewind)
+  final periodDelta = <String, int>{}; // net delta within the period
+  final receivedUnits = <String, int>{};
+  final soldUnits = <String, int>{};
+  final damagedUnits = <String, int>{};
+  final expiredUnits = <String, int>{};
+  final otherDelta = <String, int>{}; // signed residual within the period
+  void add(Map<String, int> m, String k, int v) => m[k] = (m[k] ?? 0) + v;
+  for (final t in stockTxns) {
+    if (t.voidedAt != null || !inScope(t.locationId)) continue;
+    final pid = t.productId;
+    final delta = t.quantityDelta;
+    if (endExclusive != null && !t.createdAt.isBefore(endExclusive)) {
+      add(afterEndUnits, pid, delta);
+    }
+    if (!inSpan(t.createdAt)) continue;
+    add(periodDelta, pid, delta);
+    final mt = t.movementType;
+    if (mt == 'sale' || mt == 'return') {
+      // A return (stock restored) nets against units sold.
+      add(soldUnits, pid, -delta);
+    } else if (mt == 'received' || mt == 'restock') {
+      add(receivedUnits, pid, delta);
+    } else if (mt == 'adjustment' || mt == 'adjusted') {
+      final reason = t.adjustmentId == null
+          ? ''
+          : (reasonByAdjustmentId[t.adjustmentId] ?? '');
+      if (isExpiredReason(reason)) {
+        add(expiredUnits, pid, -delta);
+      } else if (isDamageReason(reason)) {
+        add(damagedUnits, pid, -delta);
+      } else if (isReceiptReason(reason)) {
+        add(receivedUnits, pid, delta);
+      } else {
+        add(otherDelta, pid, delta);
+      }
+    } else {
+      // transfer_in / transfer_out / anything unclassified
+      add(otherDelta, pid, delta);
+    }
+  }
+  var stockOpeningKobo = 0;
+  var stockReceivedKobo = 0;
+  var stockCogsKobo = 0;
+  var stockDamagesKobo = 0;
+  var stockExpiredKobo = 0;
+  var stockOtherMovementsKobo = 0;
+  var stockExpectedClosingKobo = 0;
+  final flowPids = <String>{
+    ...currentUnits.keys,
+    ...periodDelta.keys,
+    ...afterEndUnits.keys,
+  };
+  for (final pid in flowPids) {
+    final cost = productById[pid]?.buyingPriceKobo ?? 0;
+    if (cost <= 0) continue; // uncosted units carry no value (P&L footnote)
+    final closing = (currentUnits[pid] ?? 0) - (afterEndUnits[pid] ?? 0);
+    final opening = closing - (periodDelta[pid] ?? 0);
+    stockOpeningKobo += opening * cost;
+    stockExpectedClosingKobo += closing * cost;
+    stockReceivedKobo += (receivedUnits[pid] ?? 0) * cost;
+    stockCogsKobo += (soldUnits[pid] ?? 0) * cost;
+    stockDamagesKobo += (damagedUnits[pid] ?? 0) * cost;
+    stockExpiredKobo += (expiredUnits[pid] ?? 0) * cost;
+    stockOtherMovementsKobo += (otherDelta[pid] ?? 0) * cost;
   }
 
   // ── Expenses (approved, in span, in scope) ───────────────────────────────
@@ -772,6 +941,13 @@ ReconData computeReconData(
     inventoryOnHandKobo: inventoryOnHandKobo,
     uncostedInventoryItems: uncostedInventoryItems,
     surplusCostKobo: surplusCostKobo,
+    stockOpeningKobo: stockOpeningKobo,
+    stockReceivedKobo: stockReceivedKobo,
+    stockCogsKobo: stockCogsKobo,
+    stockDamagesKobo: stockDamagesKobo,
+    stockExpiredKobo: stockExpiredKobo,
+    stockOtherMovementsKobo: stockOtherMovementsKobo,
+    stockExpectedClosingKobo: stockExpectedClosingKobo,
     topItems: topItems,
     manufacturerEmpties: manufacturerEmpties,
   );

--- a/lib/features/dashboard/screens/daily_reconciliation_detail_screen.dart
+++ b/lib/features/dashboard/screens/daily_reconciliation_detail_screen.dart
@@ -111,6 +111,10 @@ class DailyReconciliationDetailScreen extends ConsumerWidget {
           ],
           SizedBox(height: context.spacingM),
           _stockCard(context, theme, d),
+          if (isCeo && d.hasStockFlow) ...[
+            SizedBox(height: context.spacingM),
+            _integrityCard(context, theme, d),
+          ],
           if (!isCeo) ...[
             SizedBox(height: context.spacingM),
             _debtsExpensesCard(context, theme, d),
@@ -359,6 +363,77 @@ class DailyReconciliationDetailScreen extends ConsumerWidget {
           style: context.bodySmall.copyWith(color: theme.hintColor),
         ),
       ],
+    );
+  }
+
+  /// Integrity flag (ADR 0014 slice 3): reconciles reported P&L profit against
+  /// the independent physical stock count. Any gap is the stock-count variance
+  /// the recorded flows never booked — a recording error (shrinkage / theft /
+  /// miscount), not a separate loss, and NOT reflected in the reported profit.
+  /// No persistence — derived from flows + the count. CEO-only.
+  Widget _integrityCard(BuildContext context, ThemeData theme, ReconData d) {
+    final successColor = theme.extension<AppSemanticColors>()!.success;
+    final dangerColor = theme.colorScheme.error;
+    if (!d.hasStockCount) {
+      return _card(
+        context,
+        theme,
+        'Integrity check',
+        FontAwesomeIcons.shieldHalved.data,
+        theme.hintColor,
+        [
+          Text(
+            'No physical stock count in this period, so the recorded flows can\'t '
+            'be reconciled against a real count. Take a stock count to verify '
+            'nothing left unrecorded.',
+            style: context.bodySmall.copyWith(color: theme.hintColor),
+          ),
+        ],
+      );
+    }
+    final gap = d.stockVarianceKobo;
+    final reconciled = gap == 0;
+    final color = reconciled ? successColor : dangerColor;
+    return _card(
+      context,
+      theme,
+      'Integrity check',
+      FontAwesomeIcons.shieldHalved.data,
+      color,
+      [
+        _line(context, theme, 'Reported net profit',
+            formatCurrency(d.netProfitKobo / 100.0)),
+        _line(
+          context,
+          theme,
+          'Unexplained stock variance',
+          reconciled
+              ? formatCurrency(0)
+              : '${gap >= 0 ? '+ ' : '− '}${formatCurrency(gap.abs() / 100.0)}',
+          danger: !reconciled,
+        ),
+        _divider(theme),
+        _line(
+          context,
+          theme,
+          'Count-reconciled profit',
+          formatCurrency(d.integrityAdjustedProfitKobo / 100.0),
+          strong: true,
+          color: color,
+        ),
+        const SizedBox(height: 6),
+        Text(
+          reconciled
+              ? 'The physical count matches recorded sales, receipts, damages and '
+                    'expiries — the reported profit reconciles.'
+              : 'The physical count is off the recorded flows by '
+                    '${formatCurrency(gap.abs() / 100.0)}. This is a recording gap '
+                    '(unbooked shrinkage / theft or a miscount), not reflected in '
+                    'the reported profit above.',
+          style: context.bodySmall.copyWith(color: theme.hintColor),
+        ),
+      ],
+      danger: !reconciled,
     );
   }
 
@@ -832,6 +907,8 @@ class DailyReconciliationDetailScreen extends ConsumerWidget {
         ['Other stock movements (at cost)', money(d.stockOtherMovementsKobo)],
         ['Expected closing (at cost)', money(d.stockExpectedClosingKobo)],
         ['Stock variance (counted − expected)', money(d.stockVarianceKobo)],
+        // Integrity check — mirrors _integrityCard.
+        ['Count-reconciled profit', money(d.integrityAdjustedProfitKobo)],
         ['Stock shortages (units)', '${d.shortageUnits}'],
       ] else ...[
         ['Stock shortages (units)', '${d.shortageUnits}'],

--- a/lib/features/dashboard/screens/daily_reconciliation_detail_screen.dart
+++ b/lib/features/dashboard/screens/daily_reconciliation_detail_screen.dart
@@ -105,6 +105,10 @@ class DailyReconciliationDetailScreen extends ConsumerWidget {
           ],
           SizedBox(height: context.spacingM),
           _shrinkageCard(context, theme, d, retail: !isCeo),
+          if (isCeo && d.hasStockFlow) ...[
+            SizedBox(height: context.spacingM),
+            _stockFlowCard(context, theme, d),
+          ],
           SizedBox(height: context.spacingM),
           _stockCard(context, theme, d),
           if (!isCeo) ...[
@@ -288,6 +292,70 @@ class DailyReconciliationDetailScreen extends ConsumerWidget {
         Text(
           'Expected cash movement from recorded cash tenders — business-wide, '
           'not a counted drawer.',
+          style: context.bodySmall.copyWith(color: theme.hintColor),
+        ),
+      ],
+    );
+  }
+
+  /// Stock reconciliation as a cost-valued flow equation (ADR 0014): Opening +
+  /// Goods received − COGS − Damages − Expired (± Other) = Expected closing (the
+  /// perpetual system figure), then Variance = Physical count − Expected. Every
+  /// figure is at CURRENT per-product cost (the stated basis — cost is
+  /// time-varying under FIFO). CEO-only (cost wall §25.3).
+  Widget _stockFlowCard(BuildContext context, ThemeData theme, ReconData d) {
+    final successColor = theme.extension<AppSemanticColors>()!.success;
+    final dangerColor = theme.colorScheme.error;
+    final variance = d.stockVarianceKobo;
+    final hasVariance = d.hasStockCount && variance != 0;
+    final varianceColor = variance >= 0 ? successColor : dangerColor;
+    return _card(
+      context,
+      theme,
+      'Stock reconciliation (at cost)',
+      FontAwesomeIcons.scaleBalanced.data,
+      Colors.blueAccent,
+      [
+        _line(context, theme, 'Opening stock',
+            formatCurrency(d.stockOpeningKobo / 100.0)),
+        _line(context, theme, 'Goods received',
+            '+ ${formatCurrency(d.stockReceivedKobo / 100.0)}'),
+        _line(context, theme, 'Cost of goods sold',
+            '− ${formatCurrency(d.stockCogsKobo / 100.0)}'),
+        _line(context, theme, 'Damages',
+            '− ${formatCurrency(d.stockDamagesKobo / 100.0)}'),
+        _line(context, theme, 'Expired',
+            '− ${formatCurrency(d.stockExpiredKobo / 100.0)}'),
+        if (d.stockOtherMovementsKobo != 0)
+          _line(
+            context,
+            theme,
+            'Other movements',
+            '${d.stockOtherMovementsKobo >= 0 ? '+ ' : '− '}'
+                '${formatCurrency(d.stockOtherMovementsKobo.abs() / 100.0)}',
+          ),
+        _divider(theme),
+        _line(context, theme, 'Expected closing',
+            formatCurrency(d.stockExpectedClosingKobo / 100.0),
+            strong: true),
+        if (d.hasStockCount) ...[
+          _line(
+            context,
+            theme,
+            'Variance (counted − expected)',
+            '${variance >= 0 ? '+ ' : '− '}'
+                '${formatCurrency(variance.abs() / 100.0)}',
+            strong: true,
+            color: hasVariance ? varianceColor : null,
+          ),
+        ],
+        const SizedBox(height: 6),
+        Text(
+          d.hasStockCount
+              ? 'Valued at current cost. Variance is the counted-vs-expected gap '
+                    'the recorded flows didn\'t explain.'
+              : 'Valued at current cost. No stock count in this period, so there '
+                    'is no variance to reconcile against.',
           style: context.bodySmall.copyWith(color: theme.hintColor),
         ),
       ],
@@ -755,6 +823,15 @@ class DailyReconciliationDetailScreen extends ConsumerWidget {
         ['Expenses paid (cash)', money(d.cashExpensesKobo)],
         ['Paid to suppliers (cash)', money(d.cashSupplierPaidKobo)],
         ['Net cash movement', money(d.netCashMovementKobo)],
+        // Stock reconciliation (at cost) — mirrors _stockFlowCard.
+        ['Opening stock (at cost)', money(d.stockOpeningKobo)],
+        ['Goods received (at cost)', money(d.stockReceivedKobo)],
+        ['COGS (at current cost)', money(d.stockCogsKobo)],
+        ['Damages (stock, at cost)', money(d.stockDamagesKobo)],
+        ['Expired (at cost)', money(d.stockExpiredKobo)],
+        ['Other stock movements (at cost)', money(d.stockOtherMovementsKobo)],
+        ['Expected closing (at cost)', money(d.stockExpectedClosingKobo)],
+        ['Stock variance (counted − expected)', money(d.stockVarianceKobo)],
         ['Stock shortages (units)', '${d.shortageUnits}'],
       ] else ...[
         ['Stock shortages (units)', '${d.shortageUnits}'],

--- a/lib/features/dashboard/screens/daily_reconciliation_detail_screen.dart
+++ b/lib/features/dashboard/screens/daily_reconciliation_detail_screen.dart
@@ -99,6 +99,8 @@ class DailyReconciliationDetailScreen extends ConsumerWidget {
             SizedBox(height: context.spacingM),
             _plCard(context, theme, d),
             SizedBox(height: context.spacingM),
+            _cashFlowCard(context, theme, d),
+            SizedBox(height: context.spacingM),
             _businessWorthCard(context, theme, d),
           ],
           SizedBox(height: context.spacingM),
@@ -243,6 +245,51 @@ class DailyReconciliationDetailScreen extends ConsumerWidget {
             style: context.bodySmall.copyWith(color: theme.hintColor),
           ),
         ],
+      ],
+    );
+  }
+
+  /// Derived cash-flow summary (ADR 0014): the period's expected cash MOVEMENT
+  /// from recorded cash tenders — cash sales + debts collected in, refunds +
+  /// cash expenses + cash supplier payments out. **Business-wide** (the
+  /// payment_transactions ledger has no store) and **not a counted drawer**:
+  /// there is no opening float to add this to (Hard Rule #8). CEO-only.
+  Widget _cashFlowCard(BuildContext context, ThemeData theme, ReconData d) {
+    final successColor = theme.extension<AppSemanticColors>()!.success;
+    final dangerColor = theme.colorScheme.error;
+    final netColor = d.netCashMovementKobo >= 0 ? successColor : dangerColor;
+    return _card(
+      context,
+      theme,
+      'Cash flow (business-wide)',
+      FontAwesomeIcons.moneyBillWave.data,
+      netColor,
+      [
+        _line(context, theme, 'Cash sales',
+            '+ ${formatCurrency(d.cashSalesKobo / 100.0)}'),
+        _line(context, theme, 'Debts collected (cash)',
+            '+ ${formatCurrency(d.cashDebtsCollectedKobo / 100.0)}'),
+        _line(context, theme, 'Cash in',
+            formatCurrency(d.cashInKobo / 100.0), strong: true),
+        _divider(theme),
+        _line(context, theme, 'Refunds paid (cash)',
+            '− ${formatCurrency(d.cashRefundsKobo / 100.0)}'),
+        _line(context, theme, 'Expenses paid (cash)',
+            '− ${formatCurrency(d.cashExpensesKobo / 100.0)}'),
+        _line(context, theme, 'Paid to suppliers (cash)',
+            '− ${formatCurrency(d.cashSupplierPaidKobo / 100.0)}'),
+        _line(context, theme, 'Cash out',
+            formatCurrency(d.cashOutKobo / 100.0), strong: true),
+        _divider(theme),
+        _line(context, theme, 'Net cash movement',
+            formatCurrency(d.netCashMovementKobo / 100.0),
+            strong: true, color: netColor),
+        const SizedBox(height: 6),
+        Text(
+          'Expected cash movement from recorded cash tenders — business-wide, '
+          'not a counted drawer.',
+          style: context.bodySmall.copyWith(color: theme.hintColor),
+        ),
       ],
     );
   }
@@ -701,6 +748,13 @@ class DailyReconciliationDetailScreen extends ConsumerWidget {
         // Supplier account position: negative = we owe, positive = credit held.
         ['Supplier account balance (now)', money(d.supplierAccountBalanceKobo)],
         ['Business net position (now)', money(d.businessNetPositionKobo)],
+        // Cash flow (business-wide) — mirrors _cashFlowCard.
+        ['Cash sales', money(d.cashSalesKobo)],
+        ['Debts collected (cash)', money(d.cashDebtsCollectedKobo)],
+        ['Refunds paid (cash)', money(d.cashRefundsKobo)],
+        ['Expenses paid (cash)', money(d.cashExpensesKobo)],
+        ['Paid to suppliers (cash)', money(d.cashSupplierPaidKobo)],
+        ['Net cash movement', money(d.netCashMovementKobo)],
         ['Stock shortages (units)', '${d.shortageUnits}'],
       ] else ...[
         ['Stock shortages (units)', '${d.shortageUnits}'],

--- a/test/dashboard/recon_data_test.dart
+++ b/test/dashboard/recon_data_test.dart
@@ -12,6 +12,11 @@ ReconData recon({
   int expensesKobo = 0,
   int damageCostKobo = 0,
   int crateDamageDepositKobo = 0,
+  int cashSalesKobo = 0,
+  int cashDebtsCollectedKobo = 0,
+  int cashRefundsKobo = 0,
+  int cashExpensesKobo = 0,
+  int cashSupplierPaidKobo = 0,
 }) {
   return ReconData(
     totalRevenueKobo: costedRevenueKobo,
@@ -22,6 +27,11 @@ ReconData recon({
     skus: 0,
     uncostedItems: 0,
     refundsKobo: 0,
+    cashSalesKobo: cashSalesKobo,
+    cashDebtsCollectedKobo: cashDebtsCollectedKobo,
+    cashRefundsKobo: cashRefundsKobo,
+    cashExpensesKobo: cashExpensesKobo,
+    cashSupplierPaidKobo: cashSupplierPaidKobo,
     bestStaff: null,
     bestStaffKobo: 0,
     expensesKobo: expensesKobo,
@@ -107,6 +117,40 @@ void main() {
       // A fully-discounted period has no net revenue → no divide-by-zero.
       expect(recon(costedRevenueKobo: 5000, discountsKobo: 5000).grossMarginPct,
           '0.0');
+    });
+  });
+
+  group('ReconData cash-flow summary (issue #72, ADR 0014)', () {
+    test('cash in = cash sales + debts collected', () {
+      final d = recon(cashSalesKobo: 80000, cashDebtsCollectedKobo: 12000);
+      expect(d.cashInKobo, 92000);
+    });
+
+    test('cash out = refunds + cash expenses + cash supplier payments', () {
+      final d = recon(
+        cashRefundsKobo: 3000,
+        cashExpensesKobo: 7000,
+        cashSupplierPaidKobo: 20000,
+      );
+      expect(d.cashOutKobo, 30000);
+    });
+
+    test('net cash movement is in minus out (can be negative)', () {
+      final d = recon(
+        cashSalesKobo: 50000,
+        cashDebtsCollectedKobo: 10000,
+        cashRefundsKobo: 5000,
+        cashExpensesKobo: 15000,
+        cashSupplierPaidKobo: 60000,
+      );
+      // 60,000 in − 80,000 out = −20,000.
+      expect(d.netCashMovementKobo, -20000);
+    });
+
+    test('hasCashActivity is false only when nothing moved', () {
+      expect(recon().hasCashActivity, isFalse);
+      expect(recon(cashSalesKobo: 1).hasCashActivity, isTrue);
+      expect(recon(cashSupplierPaidKobo: 1).hasCashActivity, isTrue);
     });
   });
 }

--- a/test/dashboard/recon_data_test.dart
+++ b/test/dashboard/recon_data_test.dart
@@ -17,6 +17,7 @@ ReconData recon({
   int cashRefundsKobo = 0,
   int cashExpensesKobo = 0,
   int cashSupplierPaidKobo = 0,
+  bool hasStockCount = false,
   int shortageCostKobo = 0,
   int surplusCostKobo = 0,
   int stockOpeningKobo = 0,
@@ -49,7 +50,7 @@ ReconData recon({
     damageCostKobo: damageCostKobo,
     damageRetailKobo: 0,
     crateDamageDepositKobo: crateDamageDepositKobo,
-    hasStockCount: false,
+    hasStockCount: hasStockCount,
     productsCounted: 0,
     shortageCount: 0,
     shortageUnits: 0,
@@ -213,6 +214,48 @@ void main() {
       expect(recon(stockExpectedClosingKobo: 1).hasStockFlow, isTrue);
       expect(recon(stockReceivedKobo: 1).hasStockFlow, isTrue);
       expect(recon(stockExpiredKobo: 1).hasStockFlow, isTrue);
+    });
+  });
+
+  group('ReconData integrity flag (issue #72 slice 3, ADR 0014)', () {
+    test('count-reconciled profit is net profit plus the stock variance', () {
+      // Net profit 30,000; counted 4,000 short (shortage cost) → 26,000.
+      final d = recon(
+        costedRevenueKobo: 100000,
+        cogsKobo: 70000,
+        hasStockCount: true,
+        shortageCostKobo: 4000,
+      );
+      expect(d.netProfitKobo, 30000);
+      expect(d.stockVarianceKobo, -4000);
+      expect(d.integrityAdjustedProfitKobo, 26000);
+    });
+
+    test('a surplus lifts the reconciled profit above the reported profit', () {
+      final d = recon(
+        costedRevenueKobo: 50000,
+        cogsKobo: 30000,
+        hasStockCount: true,
+        surplusCostKobo: 1500,
+      );
+      // net profit 20,000 + surplus 1,500 = 21,500.
+      expect(d.integrityAdjustedProfitKobo, 21500);
+    });
+
+    test('hasIntegrityGap requires both a count and a non-zero variance', () {
+      // Variance present but no count taken → nothing to reconcile against.
+      expect(recon(shortageCostKobo: 5000).hasIntegrityGap, isFalse);
+      // Count taken and it ties out → reconciled, no gap.
+      expect(recon(hasStockCount: true).hasIntegrityGap, isFalse);
+      // Count taken and it diverges → flagged.
+      expect(
+        recon(hasStockCount: true, shortageCostKobo: 5000).hasIntegrityGap,
+        isTrue,
+      );
+      expect(
+        recon(hasStockCount: true, surplusCostKobo: 5000).hasIntegrityGap,
+        isTrue,
+      );
     });
   });
 }

--- a/test/dashboard/recon_data_test.dart
+++ b/test/dashboard/recon_data_test.dart
@@ -17,6 +17,15 @@ ReconData recon({
   int cashRefundsKobo = 0,
   int cashExpensesKobo = 0,
   int cashSupplierPaidKobo = 0,
+  int shortageCostKobo = 0,
+  int surplusCostKobo = 0,
+  int stockOpeningKobo = 0,
+  int stockReceivedKobo = 0,
+  int stockCogsKobo = 0,
+  int stockDamagesKobo = 0,
+  int stockExpiredKobo = 0,
+  int stockOtherMovementsKobo = 0,
+  int stockExpectedClosingKobo = 0,
 }) {
   return ReconData(
     totalRevenueKobo: costedRevenueKobo,
@@ -46,7 +55,7 @@ ReconData recon({
     shortageUnits: 0,
     surplusCount: 0,
     surplusUnits: 0,
-    shortageCostKobo: 0,
+    shortageCostKobo: shortageCostKobo,
     shortageRetailKobo: 0,
     shortages: const [],
     goodsReceivedKobo: 0,
@@ -58,7 +67,14 @@ ReconData recon({
     supplierPayableKobo: 0,
     inventoryOnHandKobo: 0,
     uncostedInventoryItems: 0,
-    surplusCostKobo: 0,
+    surplusCostKobo: surplusCostKobo,
+    stockOpeningKobo: stockOpeningKobo,
+    stockReceivedKobo: stockReceivedKobo,
+    stockCogsKobo: stockCogsKobo,
+    stockDamagesKobo: stockDamagesKobo,
+    stockExpiredKobo: stockExpiredKobo,
+    stockOtherMovementsKobo: stockOtherMovementsKobo,
+    stockExpectedClosingKobo: stockExpectedClosingKobo,
     topItems: const [],
     manufacturerEmpties: const [],
   );
@@ -151,6 +167,52 @@ void main() {
       expect(recon().hasCashActivity, isFalse);
       expect(recon(cashSalesKobo: 1).hasCashActivity, isTrue);
       expect(recon(cashSupplierPaidKobo: 1).hasCashActivity, isTrue);
+    });
+  });
+
+  group('ReconData stock flow-equation (issue #72 slice 2, ADR 0014)', () {
+    test('derived closing = opening + received − cogs − damages − expired', () {
+      // Opening 100,000 + received 40,000 − COGS 55,000 − damages 3,000 −
+      // expired 2,000 = 80,000, and no other movements.
+      final d = recon(
+        stockOpeningKobo: 100000,
+        stockReceivedKobo: 40000,
+        stockCogsKobo: 55000,
+        stockDamagesKobo: 3000,
+        stockExpiredKobo: 2000,
+        stockExpectedClosingKobo: 80000,
+      );
+      expect(d.stockDerivedClosingKobo, 80000);
+      // Ties out to the perpetual system figure fed in independently.
+      expect(d.stockDerivedClosingKobo, d.stockExpectedClosingKobo);
+    });
+
+    test('other movements (transfers / count fixes) fold into the equation', () {
+      // A +5,000 transfer-in shifts derived closing up by 5,000.
+      final d = recon(
+        stockOpeningKobo: 100000,
+        stockReceivedKobo: 0,
+        stockCogsKobo: 20000,
+        stockOtherMovementsKobo: 5000,
+        stockExpectedClosingKobo: 85000,
+      );
+      expect(d.stockDerivedClosingKobo, 85000);
+      expect(d.stockDerivedClosingKobo, d.stockExpectedClosingKobo);
+    });
+
+    test('variance is surplus minus shortage (physical − expected, at cost)', () {
+      // Counted 2,000 over in one product, 5,000 short in another → net −3,000.
+      final d = recon(surplusCostKobo: 2000, shortageCostKobo: 5000);
+      expect(d.stockVarianceKobo, -3000);
+      // A pure surplus is positive.
+      expect(recon(surplusCostKobo: 1500).stockVarianceKobo, 1500);
+    });
+
+    test('hasStockFlow is false only when every flow line is zero', () {
+      expect(recon().hasStockFlow, isFalse);
+      expect(recon(stockExpectedClosingKobo: 1).hasStockFlow, isTrue);
+      expect(recon(stockReceivedKobo: 1).hasStockFlow, isTrue);
+      expect(recon(stockExpiredKobo: 1).hasStockFlow, isTrue);
     });
   });
 }


### PR DESCRIPTION
Implements the closing-report enhancement designed in **ADR 0014**, completing the Daily Reconciliation (§25.9) into a three-check closing report. Builds on #70 (P&L discount fix, now merged). All new cost/profit surfaces are CEO-only (cost wall §25.3); no new synced tables; respects Hard Rule #8 (no cash account / drawer count).

## The three checks

1. **Cash-flow summary** (slice 1, already on this branch) — the period's expected cash *movement* from tender-tagged flows (cash sales + debts collected − cash refunds/expenses/supplier payments), business-wide, `method == 'cash'` matched case-insensitively. Not a drawer count.
2. **Stock flow-equation card (at cost)** (slice 2) — Opening + Goods received − COGS − Damages − **Expired** (± Other) = **Expected closing** (the perpetual system figure) → **Variance = Physical count − Expected**. Every term valued at **current per-product cost**; opening/expected-closing reconstructed by *rewinding the `stock_transactions` ledger from current on-hand*, so the equation ties out by construction and historical period-ends work. Expired is split from damages via the linked adjustment reason; transfers / count reconciliations fall to an "Other movements" residual.
3. **Integrity flag** (slice 3) — reconciles reported P&L profit against the independent physical count, with **no new persistence**. Surfaces the stock-count variance the flows never booked as a *recording error* (unbooked shrinkage/theft/miscount), shown as Reported net profit → Unexplained variance → Count-reconciled profit.

## Plumbing
- `StockLedgerDao.watchAllTransactions()` + `allStockTransactionsProvider` (`businessScopedStream`; passes the provider-ban test). No schema change / no migration.
- `ReconData` gains the `stock*Kobo` flow fields + `stockVarianceKobo` / `hasStockFlow` / `integrityAdjustedProfitKobo` / `hasIntegrityGap` getters.
- New CEO-only `_stockFlowCard` and `_integrityCard`; CSV export extended.

## Cost basis (documented trade-off)
Opening stock *as of a past date* is genuinely hard — cost is time-varying under FIFO (ADR 0005) and only current stock is valued today. Rather than fake historical precision, the whole equation is valued at current cost and stated as such (ADR 0014 §①).

## Tests
`test/dashboard/recon_data_test.dart` — 17 getter-level cases green (7 new across slices 2–3). `flutter analyze` clean; provider-ban + business-scoped-stream tests green.

Closes #72.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CEO-only closing report experience with business-wide cash-flow, stock (at-cost) reconciliation, and an integrity check to reconcile reported profit vs physical count.
  * Extended CEO CSV export to include the added cash/stock breakdowns, variance details, and integrity results.
  * Reconciliation data now streams live for up-to-date card values.
* **Bug Fixes**
  * Improved stock and cash reconciliation accuracy by using clarified valuation and flow inputs, plus more precise reason-based classification.
* **Documentation / Tests**
  * Updated the closing-report ADR and progress tracking; reconciliation logic is covered with new/expanded tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->