### PR TITLE
feat(reports): standardized daily closing — declutter + opt-in VAT

### DIFF
--- a/BUILD_LOG.md
+++ b/BUILD_LOG.md
@@ -2,6 +2,50 @@
 
 ---
 
+## 2026-07-06 — Standardized daily closing: declutter + opt-in VAT
+
+**Context.** The Daily Reconciliation detail screen had grown to **9 cards that
+repeated the same ~10 figures** (Inventory on hand ×2, COGS ×2, Damages ×4,
+Shortages ×4, Net profit ×2; `Total sales` = `Revenue` = `Cash sales`). User
+asked for one *standardized* closing, aggregatable by period, and — after
+grilling the spec against locked decisions — **cash reconciliation dropped
+entirely** (all cash is ultimately deposited to an account; no counted drawer,
+no float, no over/short → no `daily_closings` table), keeping Hard Rule #8
+intact. Branch `feat/standardized-daily-close` off `feat/closing-report-
+reconciliation` (the ADR 0014 base); web-pos WIP parked in `git stash@{0}`.
+
+**Phase A — declutter (pure Dart, no schema).** `daily_reconciliation_detail_
+screen.dart`: deleted the redundant "Net result for this period (flow)" card;
+**merged** Shrinkage + Stock audit + Stock reconciliation + Integrity into ONE
+`_stockReconciliationCard` (CEO = cost flow-equation → expected closing →
+variance → count-reconciled-profit line; Manager = retail shrinkage + count).
+CEO now sees **5** cards (Sales, P&L, Cash, Stock reconciliation, Position),
+Manager **3** (Sales, Stock & shrinkage, Debts & expenses). Refunds moved onto
+the Sales card. `recon_data.dart` model untouched (getters kept), so the 17
+existing tests pass unchanged.
+
+**Phase C — opt-in VAT (settings-backed, no migration).** VAT is **OFF by
+default** and stored in the synced `settings` key/value table (like
+`default_currency`) — so it needs **no schema/cloud migration**:
+`vat_enabled` (`'true'`/`'false'`) + `vat_rate_bps` (basis points, 750 = 7.5%).
+- `core/settings/vat_settings.dart` — keys, `VatConfig`, pure `computeVatKobo`,
+  `parseVatRateBps`.
+- `vatConfigProvider` (mirrors `currencyCodeProvider`, `businessScopedStream`).
+- `ReconData` gains `vatEnabled` / `vatRateBps` / `vatKobo` (+`vatRateLabel`);
+  `computeReconData` derives VAT = rate × (gross − discounts). **Pass-through —
+  it does NOT touch the P&L profit lines.** Sales card + CSV show a "VAT due
+  (7.5%)" line only when enabled.
+- Settings → Business Info: new **Tax** section — "Charge VAT" toggle (prefills
+  7.5% on first enable) + VAT rate (%) field; persists to the two settings keys.
+
+**Parked (explicit user request):** VAT on the cart/receipt at checkout (mobile
++ web) — a later slice; today VAT is the obligation surfaced on the closing only.
+
+**Verification.** `flutter analyze` clean project-wide. `recon_data_test.dart`
+(19, incl. 2 new VAT) + new `vat_settings_test.dart` (8) green; ban test +
+dashboard + settings suites (77) green. On-device walkthrough (decluttered
+cards, VAT toggle, VAT line) pending.
+
 ## 2026-07-05 — Closing report: integrity flag (issue #72, slice 3 — epic complete)
 
 **What changed.** Final slice of the closing-report enhancement (ADR 0014 §④):

--- a/CONTEXT/progress-tracker.md
+++ b/CONTEXT/progress-tracker.md
@@ -10,6 +10,30 @@ The human updates it when resolving open questions or making architectural decis
 
 152 sessions logged. Codebase is live and being verified on-device.
 
+### SHIPPED: Standardized daily closing — declutter + opt-in VAT (2026-07-06)
+Reworked the Daily Reconciliation detail screen (§25.9) into one standardized
+closing and added opt-in VAT. Branch `feat/standardized-daily-close` (off
+`feat/closing-report-reconciliation`; web-pos WIP in `git stash@{0}`).
+- **Cash reconciliation dropped** (user: all cash is deposited to an account) —
+  no counted drawer / float / over-short, no `daily_closings` table; Hard Rule #8
+  stands. The close stays fully **derived + period-aggregatable** (existing
+  Day/Week/Month/Year grouping + store→business rollup satisfies "per store
+  first, then business-wide").
+- **Declutter (Phase A, no schema).** 9 duplicative cards → **5** for CEO
+  (Sales, P&L, Cash, Stock reconciliation, Position), **3** for Manager. Deleted
+  "Net result (flow)"; merged Shrinkage + Stock audit + Stock reconciliation +
+  Integrity into one `_stockReconciliationCard`. `recon_data.dart` model kept
+  (17 tests unchanged).
+- **VAT (Phase C, settings-backed, no migration).** OFF by default; synced
+  `settings` keys `vat_enabled` + `vat_rate_bps` (bps, 750 = 7.5%).
+  `vat_settings.dart` (pure `computeVatKobo`) + `vatConfigProvider` +
+  `ReconData.vatKobo` (derived on gross − discounts; **pass-through, not in the
+  P&L profit**). Sales card + CSV show "VAT due (7.5%)" when enabled; Settings →
+  Business Info → **Tax** toggle + rate field.
+- **Parked (user request):** VAT on cart/receipt at checkout (mobile + web).
+- `flutter analyze` clean; recon (19) + `vat_settings_test` (8) + dashboard/
+  settings/ban (77) green. On-device walkthrough pending.
+
 ### SHIPPED: Closing-report reconciliation (ADR 0014, 2026-07-05)
 Enhanced the Daily Reconciliation (§25.9) into a full closing report. Grilled;
 design in **ADR 0014**. Two issues off `main`:

--- a/lib/core/providers/stream_providers.dart
+++ b/lib/core/providers/stream_providers.dart
@@ -14,6 +14,7 @@ import 'package:reebaplus_pos/core/data/currencies.dart';
 import 'package:reebaplus_pos/core/database/app_database.dart';
 import 'package:reebaplus_pos/core/providers/app_providers.dart';
 import 'package:reebaplus_pos/core/providers/business_scoped_stream.dart';
+import 'package:reebaplus_pos/core/settings/vat_settings.dart';
 import 'package:reebaplus_pos/core/theme/theme_notifier.dart';
 import 'package:reebaplus_pos/core/utils/business_time.dart';
 import 'package:reebaplus_pos/core/utils/date_period.dart';
@@ -1211,6 +1212,25 @@ final currencySymbolProvider = Provider<String>((ref) {
   final code = ref.watch(currencyCodeProvider).valueOrNull ?? kDefaultCurrency;
   return currencySymbolForCode(code);
 });
+
+/// The business's VAT configuration (opt-in, OFF by default), streamed from the
+/// synced `vat_enabled` / `vat_rate_bps` settings keys — same mechanism as
+/// [currencyCodeProvider], so a CEO toggling VAT in Settings propagates across
+/// devices with no migration. A row is only "enabled" when the flag is `'true'`
+/// AND the rate is positive, so an enabled-but-unconfigured business shows no
+/// VAT. Consumed by the standardized daily closing (Phase 1 surfaces VAT due on
+/// net sales; the checkout/receipt VAT leg is a later slice).
+final vatConfigProvider = businessScopedStream<VatConfig>(
+  (ref, db, businessId) => db.settingsDao.watch(kVatEnabledKey).asyncMap((
+    enabledRaw,
+  ) async {
+    final enabled = enabledRaw?.trim().toLowerCase() == 'true';
+    if (!enabled) return VatConfig.off;
+    final rateBps = parseVatRateBps(await db.settingsDao.get(kVatRateBpsKey));
+    return VatConfig(enabled: rateBps > 0, rateBps: rateBps);
+  }),
+  whenAbsent: VatConfig.off,
+);
 
 /// Global permissions catalog. Identical on every device and every
 /// business — seeded by migration, never written at runtime.

--- a/lib/core/services/crash_reporter.dart
+++ b/lib/core/services/crash_reporter.dart
@@ -7,7 +7,7 @@ import 'package:reebaplus_pos/core/database/app_database.dart';
 /// App version recorded with each crash. Mirrors `version:` in pubspec.yaml —
 /// bump both together. (There is no package_info dependency; keeping this a
 /// constant avoids adding one just for diagnostics.)
-const String kAppVersion = '1.0.0+1';
+const String kAppVersion = '1.0.6+6';
 
 /// App-wide crash safety net (master plan §33 — Reliability and Crash
 /// Handling). Installs the global error handlers and records caught/uncaught

--- a/lib/core/settings/business_info_screen.dart
+++ b/lib/core/settings/business_info_screen.dart
@@ -11,6 +11,7 @@ import 'package:reebaplus_pos/core/permissions/permissions.dart';
 import 'package:reebaplus_pos/core/providers/app_providers.dart';
 import 'package:reebaplus_pos/core/result.dart';
 import 'package:reebaplus_pos/core/settings/settings_widgets.dart';
+import 'package:reebaplus_pos/core/settings/vat_settings.dart';
 import 'package:reebaplus_pos/core/theme/app_decorations.dart';
 import 'package:reebaplus_pos/core/utils/notifications.dart';
 import 'package:reebaplus_pos/core/utils/responsive.dart';
@@ -34,6 +35,10 @@ class _BusinessInfoScreenState extends ConsumerState<BusinessInfoScreen> {
   String? _type;
   bool _tracksEmptyCrates = true;
   String _currency = kDefaultCurrency;
+  // VAT is opt-in and OFF by default (not every business is authorised to
+  // charge it). Rate is entered as a percentage and stored as basis points.
+  bool _vatEnabled = false;
+  final _vatRateController = TextEditingController();
   bool _loading = true;
   bool _saving = false;
 
@@ -61,6 +66,7 @@ class _BusinessInfoScreenState extends ConsumerState<BusinessInfoScreen> {
   void dispose() {
     _nameController.dispose();
     _phoneController.dispose();
+    _vatRateController.dispose();
     super.dispose();
   }
 
@@ -73,6 +79,8 @@ class _BusinessInfoScreenState extends ConsumerState<BusinessInfoScreen> {
           )..where((t) => t.id.equals(bizId))).getSingleOrNull()
         : (await db.select(db.businesses).get()).firstOrNull;
     final currency = await db.settingsDao.get('default_currency');
+    final vatEnabledRaw = await db.settingsDao.get(kVatEnabledKey);
+    final vatBps = parseVatRateBps(await db.settingsDao.get(kVatRateBpsKey));
 
     // Attempt to resolve a cached local logo path.
     String? logoPath;
@@ -103,6 +111,10 @@ class _BusinessInfoScreenState extends ConsumerState<BusinessInfoScreen> {
         ...kCountryCurrency.values,
         _currency,
       }.toList()..sort();
+      _vatEnabled = vatEnabledRaw?.trim().toLowerCase() == 'true';
+      _vatRateController.text = vatBps > 0
+          ? VatConfig(enabled: true, rateBps: vatBps).ratePercentLabel
+          : '';
       _logoLocalPath = logoPath;
       _loading = false;
     });
@@ -202,9 +214,18 @@ class _BusinessInfoScreenState extends ConsumerState<BusinessInfoScreen> {
             : newLogoUrl ?? const Object(), // sentinel = leave unchanged
       );
       await db.settingsDao.set('default_currency', _currency);
+      // VAT (opt-in). Persist the flag always; write the rate (as basis points)
+      // only when enabled, defaulting a blank/zero entry so the closing shows no
+      // phantom VAT.
+      await db.settingsDao.set(kVatEnabledKey, _vatEnabled ? 'true' : 'false');
+      if (_vatEnabled) {
+        final pct = double.tryParse(_vatRateController.text.trim()) ?? 0;
+        final bps = pct <= 0 ? 0 : (pct * 100).round();
+        await db.settingsDao.set(kVatRateBpsKey, bps.toString());
+      }
       await db.activityLogDao.log(
         action: 'settings.business_info.update',
-        description: 'Updated business info (name, type, currency)',
+        description: 'Updated business info (name, type, currency, VAT)',
         staffId: db.currentUserId,
       );
       if (!mounted) return;
@@ -345,6 +366,65 @@ class _BusinessInfoScreenState extends ConsumerState<BusinessInfoScreen> {
                           onChanged: (v) =>
                               setState(() => _currency = v ?? _currency),
                         ),
+                      ],
+                    ),
+                  ),
+                  const SizedBox(height: 24),
+                  const SettingsSectionTitle('Tax'),
+                  const SizedBox(height: 16),
+                  GlassyCard(
+                    padding: const EdgeInsets.all(16),
+                    radius: 16,
+                    child: Column(
+                      children: [
+                        SwitchListTile(
+                          value: _vatEnabled,
+                          onChanged: (v) => setState(() {
+                            _vatEnabled = v;
+                            // Prefill the standard rate the first time it's
+                            // enabled with a blank field.
+                            if (v && _vatRateController.text.trim().isEmpty) {
+                              _vatRateController.text = const VatConfig(
+                                enabled: true,
+                                rateBps: kDefaultVatRateBps,
+                              ).ratePercentLabel;
+                            }
+                          }),
+                          activeThumbColor:
+                              Theme.of(context).colorScheme.primary,
+                          activeTrackColor: Theme.of(
+                            context,
+                          ).colorScheme.primary.withValues(alpha: 0.35),
+                          title: Text(
+                            'Charge VAT',
+                            style: Theme.of(context).textTheme.titleMedium,
+                          ),
+                          subtitle: Text(
+                            'Only enable if your business is registered to '
+                            'charge VAT. It appears on the daily closing.',
+                            style: Theme.of(context).textTheme.bodySmall,
+                          ),
+                          contentPadding: EdgeInsets.zero,
+                        ),
+                        if (_vatEnabled) ...[
+                          const SizedBox(height: 8),
+                          TextField(
+                            controller: _vatRateController,
+                            keyboardType: const TextInputType.numberWithOptions(
+                              decimal: true,
+                            ),
+                            inputFormatters: [
+                              FilteringTextInputFormatter.allow(
+                                RegExp(r'^\d*\.?\d*'),
+                              ),
+                            ],
+                            decoration: AppDecorations.authInputDecoration(
+                              context,
+                              label: 'VAT rate (%)',
+                              prefixIcon: Icons.percent_rounded,
+                            ),
+                          ),
+                        ],
                       ],
                     ),
                   ),

--- a/lib/core/settings/vat_settings.dart
+++ b/lib/core/settings/vat_settings.dart
@@ -1,0 +1,58 @@
+/// VAT (value-added tax) is an **opt-in, per-business** setting: not every
+/// business is registered/authorised to charge it, so it is OFF by default and
+/// only surfaces once the CEO enables it in Settings → Business Info.
+///
+/// Storage is the synced `settings` key/value table (like `default_currency`),
+/// so enabling it needs no schema migration and propagates across devices:
+///   • `vat_enabled`  — `'true'` / `'false'` (absent ⇒ disabled)
+///   • `vat_rate_bps` — the rate in **basis points** (`750` = 7.5%), absent ⇒ 0
+///
+/// Phase 1 (this change) surfaces the VAT **due on the period's net sales** in
+/// the standardized daily closing only. Adding VAT to the cart/receipt at
+/// checkout is deliberately parked for a later slice.
+library;
+
+const String kVatEnabledKey = 'vat_enabled';
+const String kVatRateBpsKey = 'vat_rate_bps';
+
+/// Nigeria's standard VAT rate (7.5%), a sensible default when a business first
+/// enables VAT and hasn't typed a rate yet.
+const int kDefaultVatRateBps = 750;
+
+/// Parsed VAT configuration for a business. [enabled] gates every VAT surface;
+/// [rateBps] is the rate in basis points (750 = 7.5%). A row that is enabled
+/// with a zero/blank rate yields no VAT (guarded by callers via [computeVatKobo]).
+class VatConfig {
+  const VatConfig({required this.enabled, required this.rateBps});
+
+  final bool enabled;
+  final int rateBps;
+
+  static const VatConfig off = VatConfig(enabled: false, rateBps: 0);
+
+  /// The rate as a display percentage string, trimming a trailing `.0`
+  /// (`750` → `"7.5"`, `2000` → `"20"`).
+  String get ratePercentLabel {
+    final pct = rateBps / 100.0;
+    return pct == pct.roundToDouble()
+        ? pct.toStringAsFixed(0)
+        : pct.toStringAsFixed(2).replaceFirst(RegExp(r'0+$'), '');
+  }
+}
+
+/// VAT (in kobo) charged on a [baseKobo] amount (net sales) at [rateBps] basis
+/// points, rounded half-away-from-zero to the nearest kobo — the same rounding
+/// the rest of the money math uses. Returns 0 for a non-positive base or rate,
+/// so an enabled-but-unconfigured business shows no phantom VAT.
+int computeVatKobo(int baseKobo, int rateBps) {
+  if (baseKobo <= 0 || rateBps <= 0) return 0;
+  return (baseKobo * rateBps / 10000).round();
+}
+
+/// Parse the stored `vat_rate_bps` string into basis points, tolerating a blank
+/// or malformed value (⇒ 0). Accepts an integer bps string (`'750'`).
+int parseVatRateBps(String? raw) {
+  if (raw == null) return 0;
+  final v = int.tryParse(raw.trim());
+  return (v == null || v < 0) ? 0 : v;
+}

--- a/lib/features/dashboard/reconciliation/recon_data.dart
+++ b/lib/features/dashboard/reconciliation/recon_data.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
 import 'package:reebaplus_pos/core/providers/app_providers.dart';
 import 'package:reebaplus_pos/core/providers/stream_providers.dart';
+import 'package:reebaplus_pos/core/settings/vat_settings.dart';
 import 'package:reebaplus_pos/shared/models/order_status.dart';
 
 /// Shared aggregation engine for the Daily Reconciliation (§25.9).
@@ -272,6 +273,9 @@ class ReconData {
     required this.costedRevenueKobo,
     required this.cogsKobo,
     required this.discountsKobo,
+    required this.vatEnabled,
+    required this.vatRateBps,
+    required this.vatKobo,
     required this.itemsSold,
     required this.skus,
     required this.uncostedItems,
@@ -328,6 +332,18 @@ class ReconData {
   /// profit isn't overstated by the discount given (the order's real payable is
   /// `netAmountKobo = gross − discount`). Contra-revenue, not an expense.
   final int discountsKobo;
+
+  // ── VAT (opt-in, per-business — OFF by default) ──────────────────────────
+  // Surfaced only when the business has enabled VAT in Settings (§10.1). Phase 1
+  // reports the VAT **due on the period's net sales** (gross − discounts) at the
+  // configured rate — it is a pass-through liability, NOT revenue or an expense,
+  // so it does not enter the P&L profit math. Adding VAT to the cart/receipt at
+  // checkout is a later slice; until then this is the obligation on recorded
+  // sales, computed by [computeVatKobo].
+  final bool vatEnabled;
+  final int vatRateBps; // basis points (750 = 7.5%)
+  final int vatKobo; // VAT due on net sales this period (0 when disabled)
+
   final int itemsSold;
   final int skus;
   final int uncostedItems;
@@ -396,6 +412,10 @@ class ReconData {
 
   final List<({String name, int qty})> topItems;
   final List<({String manufacturerName, int count, int valueKobo})> manufacturerEmpties;
+
+  /// The configured VAT rate as a display percentage ("7.5"), for card labels.
+  String get vatRateLabel =>
+      VatConfig(enabled: vatEnabled, rateBps: vatRateBps).ratePercentLabel;
 
   /// Costed revenue net of discounts given — the real money earned on costed
   /// lines. `costedRevenueKobo` is gross (Σ qty × gross unitPrice), so we
@@ -482,12 +502,13 @@ class ReconData {
       shortageCostKobo;
   int get businessNetPositionKobo => inventoryOnHandKobo + totalOwedKobo + crateDepositKobo - supplierPayableKobo;
 
-  /// Supplier account position (§21): all payments minus all goods
-  /// received, point-in-time. The inverse of [supplierPayableKobo] and identical
-  /// to `SupplierLedgerDao.getBalanceKobo` (SUM of signed entries).
-  ///   • positive (green) → credit we hold WITH the supplier (we've paid ahead);
-  ///   • negative (red)   → amount WE owe the supplier.
-  /// Display this signed value — never relabel a credit as "owed".
+  /// Supplier account position (§21): all payments made to suppliers minus all
+  /// goods received, point-in-time. The inverse of [supplierPayableKobo] and
+  /// identical to `SupplierLedgerDao.getBalanceKobo` (SUM of signed entries).
+  ///   • positive (green) → money we paid the supplier IN ADVANCE (a
+  ///     prepayment) — NOT money we hold on their behalf;
+  ///   • negative (red)   → a debt WE owe the supplier for unpaid goods.
+  /// Display this signed value — never relabel an advance payment as "owed".
   int get supplierAccountBalanceKobo => -supplierPayableKobo;
 
   /// Gross margin as a 1-dp percentage string ("0.0" when there's no net
@@ -551,6 +572,7 @@ ReconData computeReconData(
   final crateDamages =
       ref.watch(allCrateDamagesProvider).valueOrNull ?? const [];
   final users = ref.watch(usersByBusinessProvider).valueOrNull ?? const {};
+  final vat = ref.watch(vatConfigProvider).valueOrNull ?? VatConfig.off;
 
   final productById = {for (final p in productsWS) p.product.id: p.product};
   final inScope = reconStoreFilter(ref);
@@ -632,6 +654,14 @@ ReconData computeReconData(
       .toList()
     ..sort((a, b) => b.qty.compareTo(a.qty));
   final topItems = topItemsList.take(3).toList();
+
+  // ── VAT due on net sales (only when the business has enabled VAT) ─────────
+  // Base = gross sales − discounts (scope-consistent with the sums above). A
+  // pass-through liability computed on recorded sales; it does not affect the
+  // P&L profit lines.
+  final vatKobo = vat.enabled
+      ? computeVatKobo(totalRevenueKobo - discountsKobo, vat.rateBps)
+      : 0;
 
   // ── Inventory on hand at cost (point-in-time) ────────────────────────────
   var inventoryOnHandKobo = 0;
@@ -926,6 +956,9 @@ ReconData computeReconData(
     costedRevenueKobo: costedRevenueKobo,
     cogsKobo: cogsKobo,
     discountsKobo: discountsKobo,
+    vatEnabled: vat.enabled,
+    vatRateBps: vat.rateBps,
+    vatKobo: vatKobo,
     itemsSold: itemsSold,
     skus: skuSet.length,
     uncostedItems: uncostedItems,

--- a/lib/features/dashboard/screens/daily_reconciliation_detail_screen.dart
+++ b/lib/features/dashboard/screens/daily_reconciliation_detail_screen.dart
@@ -90,30 +90,18 @@ class DailyReconciliationDetailScreen extends ConsumerWidget {
           context.spacingM,
         ).copyWith(bottom: context.spacingM + context.deviceBottomPadding),
         children: [
-          if (isCeo) ...[
-            _netResultCard(context, theme, d),
-            SizedBox(height: context.spacingM),
-          ],
           _salesCard(context, theme, d),
           if (isCeo) ...[
             SizedBox(height: context.spacingM),
             _plCard(context, theme, d),
             SizedBox(height: context.spacingM),
             _cashFlowCard(context, theme, d),
+          ],
+          SizedBox(height: context.spacingM),
+          _stockReconciliationCard(context, theme, d, isCeo: isCeo),
+          if (isCeo) ...[
             SizedBox(height: context.spacingM),
             _businessWorthCard(context, theme, d),
-          ],
-          SizedBox(height: context.spacingM),
-          _shrinkageCard(context, theme, d, retail: !isCeo),
-          if (isCeo && d.hasStockFlow) ...[
-            SizedBox(height: context.spacingM),
-            _stockFlowCard(context, theme, d),
-          ],
-          SizedBox(height: context.spacingM),
-          _stockCard(context, theme, d),
-          if (isCeo && d.hasStockFlow) ...[
-            SizedBox(height: context.spacingM),
-            _integrityCard(context, theme, d),
           ],
           if (!isCeo) ...[
             SizedBox(height: context.spacingM),
@@ -151,6 +139,20 @@ class DailyReconciliationDetailScreen extends ConsumerWidget {
           formatCurrency(d.totalRevenueKobo / 100.0),
           strong: true,
         ),
+        if (d.refundsKobo > 0)
+          _line(
+            context,
+            theme,
+            'Refunds',
+            '− ${formatCurrency(d.refundsKobo / 100.0)}',
+          ),
+        if (d.vatEnabled)
+          _line(
+            context,
+            theme,
+            'VAT due (${d.vatRateLabel}%)',
+            formatCurrency(d.vatKobo / 100.0),
+          ),
         _line(
           context,
           theme,
@@ -302,14 +304,100 @@ class DailyReconciliationDetailScreen extends ConsumerWidget {
     );
   }
 
-  /// Stock reconciliation as a cost-valued flow equation (ADR 0014): Opening +
-  /// Goods received − COGS − Damages − Expired (± Other) = Expected closing (the
-  /// perpetual system figure), then Variance = Physical count − Expected. Every
-  /// figure is at CURRENT per-product cost (the stated basis — cost is
-  /// time-varying under FIFO). CEO-only (cost wall §25.3).
-  Widget _stockFlowCard(BuildContext context, ThemeData theme, ReconData d) {
+  /// The single stock section of the closing — replaces the former separate
+  /// Shrinkage, Stock audit, Stock reconciliation and Integrity cards, which
+  /// each re-showed the same shortage / damage / COGS figures. For the CEO it is
+  /// a cost-valued flow equation (Opening + Goods received − COGS − Damages −
+  /// Expired ± Other = Expected closing) reconciled to the physical count, then
+  /// the count-reconciled profit. For a Manager (cost wall §25.3) it is a
+  /// retail-valued shrinkage + count view with no cost/COGS/flow.
+  Widget _stockReconciliationCard(
+    BuildContext context,
+    ThemeData theme,
+    ReconData d, {
+    required bool isCeo,
+  }) {
     final successColor = theme.extension<AppSemanticColors>()!.success;
     final dangerColor = theme.colorScheme.error;
+    final hasShortage = d.shortageUnits > 0;
+
+    // Physical-count detail, shared by both roles.
+    List<Widget> countSection() => [
+      _line(context, theme, 'Products counted', fmtNumber(d.productsCounted)),
+      _line(
+        context,
+        theme,
+        'Short',
+        '${fmtNumber(d.shortageCount)} products · ${fmtNumber(d.shortageUnits)} units',
+        danger: hasShortage,
+      ),
+      _line(
+        context,
+        theme,
+        'Surplus',
+        '${fmtNumber(d.surplusCount)} products · ${fmtNumber(d.surplusUnits)} units',
+      ),
+      if (d.shortages.isNotEmpty) ...[
+        const SizedBox(height: 6),
+        Text(
+          'Shortages',
+          style: context.bodySmall.copyWith(fontWeight: FontWeight.w700),
+        ),
+        for (final s in d.shortages)
+          _line(
+            context,
+            theme,
+            s.name,
+            '${s.diff} (had ${s.system}, counted ${s.actual})',
+            danger: true,
+          ),
+      ],
+    ];
+
+    if (!isCeo) {
+      // Manager: retail-valued shrinkage + count. No cost, COGS or flow.
+      final shrinkVal = d.shortageRetailKobo + d.damageRetailKobo;
+      return _card(
+        context,
+        theme,
+        'Stock & shrinkage',
+        FontAwesomeIcons.boxesStacked.data,
+        Colors.blueAccent,
+        [
+          _line(
+            context,
+            theme,
+            'Stock shortages',
+            '${fmtNumber(d.shortageUnits)} unit(s) · ${formatCurrency(d.shortageRetailKobo / 100.0)}',
+            danger: hasShortage,
+          ),
+          _line(
+            context,
+            theme,
+            'Damages recorded',
+            '${fmtNumber(d.damageUnits)} unit(s) · ${formatCurrency(d.damageRetailKobo / 100.0)}',
+          ),
+          _divider(theme),
+          _line(
+            context,
+            theme,
+            'Sellable value unaccounted',
+            formatCurrency(shrinkVal / 100.0),
+            strong: true,
+          ),
+          const SizedBox(height: 6),
+          Text(
+            'Valued at selling price — an accountability figure, not the '
+            'company\'s cost of the loss.',
+            style: context.bodySmall.copyWith(color: theme.hintColor),
+          ),
+          if (d.hasStockCount) ...[_divider(theme), ...countSection()],
+        ],
+        danger: hasShortage,
+      );
+    }
+
+    // CEO: cost-valued flow equation reconciled to the count.
     final variance = d.stockVarianceKobo;
     final hasVariance = d.hasStockCount && variance != 0;
     final varianceColor = variance >= 0 ? successColor : dangerColor;
@@ -320,150 +408,72 @@ class DailyReconciliationDetailScreen extends ConsumerWidget {
       FontAwesomeIcons.scaleBalanced.data,
       Colors.blueAccent,
       [
-        _line(context, theme, 'Opening stock',
-            formatCurrency(d.stockOpeningKobo / 100.0)),
-        _line(context, theme, 'Goods received',
-            '+ ${formatCurrency(d.stockReceivedKobo / 100.0)}'),
-        _line(context, theme, 'Cost of goods sold',
-            '− ${formatCurrency(d.stockCogsKobo / 100.0)}'),
-        _line(context, theme, 'Damages',
-            '− ${formatCurrency(d.stockDamagesKobo / 100.0)}'),
-        _line(context, theme, 'Expired',
-            '− ${formatCurrency(d.stockExpiredKobo / 100.0)}'),
-        if (d.stockOtherMovementsKobo != 0)
-          _line(
-            context,
-            theme,
-            'Other movements',
-            '${d.stockOtherMovementsKobo >= 0 ? '+ ' : '− '}'
-                '${formatCurrency(d.stockOtherMovementsKobo.abs() / 100.0)}',
-          ),
-        _divider(theme),
-        _line(context, theme, 'Expected closing',
-            formatCurrency(d.stockExpectedClosingKobo / 100.0),
-            strong: true),
-        if (d.hasStockCount) ...[
-          _line(
-            context,
-            theme,
-            'Variance (counted − expected)',
-            '${variance >= 0 ? '+ ' : '− '}'
-                '${formatCurrency(variance.abs() / 100.0)}',
-            strong: true,
-            color: hasVariance ? varianceColor : null,
-          ),
+        if (d.hasStockFlow) ...[
+          _line(context, theme, 'Opening stock',
+              formatCurrency(d.stockOpeningKobo / 100.0)),
+          _line(context, theme, 'Goods received',
+              '+ ${formatCurrency(d.stockReceivedKobo / 100.0)}'),
+          _line(context, theme, 'Cost of goods sold',
+              '− ${formatCurrency(d.stockCogsKobo / 100.0)}'),
+          _line(context, theme, 'Damages',
+              '− ${formatCurrency(d.stockDamagesKobo / 100.0)}'),
+          _line(context, theme, 'Expired',
+              '− ${formatCurrency(d.stockExpiredKobo / 100.0)}'),
+          if (d.stockOtherMovementsKobo != 0)
+            _line(
+              context,
+              theme,
+              'Other movements',
+              '${d.stockOtherMovementsKobo >= 0 ? '+ ' : '− '}'
+                  '${formatCurrency(d.stockOtherMovementsKobo.abs() / 100.0)}',
+            ),
+          _divider(theme),
+          _line(context, theme, 'Expected closing',
+              formatCurrency(d.stockExpectedClosingKobo / 100.0),
+              strong: true),
+          if (d.hasStockCount)
+            _line(
+              context,
+              theme,
+              'Variance (counted − expected)',
+              '${variance >= 0 ? '+ ' : '− '}'
+                  '${formatCurrency(variance.abs() / 100.0)}',
+              strong: true,
+              color: hasVariance ? varianceColor : null,
+            ),
         ],
-        const SizedBox(height: 6),
-        Text(
-          d.hasStockCount
-              ? 'Valued at current cost. Variance is the counted-vs-expected gap '
-                    'the recorded flows didn\'t explain.'
-              : 'Valued at current cost. No stock count in this period, so there '
-                    'is no variance to reconcile against.',
-          style: context.bodySmall.copyWith(color: theme.hintColor),
-        ),
-      ],
-    );
-  }
-
-  /// Integrity flag (ADR 0014 slice 3): reconciles reported P&L profit against
-  /// the independent physical stock count. Any gap is the stock-count variance
-  /// the recorded flows never booked — a recording error (shrinkage / theft /
-  /// miscount), not a separate loss, and NOT reflected in the reported profit.
-  /// No persistence — derived from flows + the count. CEO-only.
-  Widget _integrityCard(BuildContext context, ThemeData theme, ReconData d) {
-    final successColor = theme.extension<AppSemanticColors>()!.success;
-    final dangerColor = theme.colorScheme.error;
-    if (!d.hasStockCount) {
-      return _card(
-        context,
-        theme,
-        'Integrity check',
-        FontAwesomeIcons.shieldHalved.data,
-        theme.hintColor,
-        [
+        if (d.hasStockCount) ...[
+          _divider(theme),
+          ...countSection(),
+          _divider(theme),
+          _line(
+            context,
+            theme,
+            'Count-reconciled profit',
+            formatCurrency(d.integrityAdjustedProfitKobo / 100.0),
+            strong: true,
+            color: hasVariance ? dangerColor : successColor,
+          ),
+          const SizedBox(height: 6),
           Text(
-            'No physical stock count in this period, so the recorded flows can\'t '
-            'be reconciled against a real count. Take a stock count to verify '
-            'nothing left unrecorded.',
+            hasVariance
+                ? 'The physical count is off the recorded flows by '
+                      '${formatCurrency(variance.abs() / 100.0)} — an unbooked '
+                      'shrinkage or miscount, not reflected in reported profit.'
+                : 'The physical count matches recorded sales, receipts, damages '
+                      'and expiries — reported profit reconciles.',
+            style: context.bodySmall.copyWith(color: theme.hintColor),
+          ),
+        ] else ...[
+          const SizedBox(height: 6),
+          Text(
+            'Valued at current cost. No stock count in this period, so there is '
+            'no variance to reconcile against.',
             style: context.bodySmall.copyWith(color: theme.hintColor),
           ),
         ],
-      );
-    }
-    final gap = d.stockVarianceKobo;
-    final reconciled = gap == 0;
-    final color = reconciled ? successColor : dangerColor;
-    return _card(
-      context,
-      theme,
-      'Integrity check',
-      FontAwesomeIcons.shieldHalved.data,
-      color,
-      [
-        _line(context, theme, 'Reported net profit',
-            formatCurrency(d.netProfitKobo / 100.0)),
-        _line(
-          context,
-          theme,
-          'Unexplained stock variance',
-          reconciled
-              ? formatCurrency(0)
-              : '${gap >= 0 ? '+ ' : '− '}${formatCurrency(gap.abs() / 100.0)}',
-          danger: !reconciled,
-        ),
-        _divider(theme),
-        _line(
-          context,
-          theme,
-          'Count-reconciled profit',
-          formatCurrency(d.integrityAdjustedProfitKobo / 100.0),
-          strong: true,
-          color: color,
-        ),
-        const SizedBox(height: 6),
-        Text(
-          reconciled
-              ? 'The physical count matches recorded sales, receipts, damages and '
-                    'expiries — the reported profit reconciles.'
-              : 'The physical count is off the recorded flows by '
-                    '${formatCurrency(gap.abs() / 100.0)}. This is a recording gap '
-                    '(unbooked shrinkage / theft or a miscount), not reflected in '
-                    'the reported profit above.',
-          style: context.bodySmall.copyWith(color: theme.hintColor),
-        ),
       ],
-      danger: !reconciled,
-    );
-  }
-
-  /// Period flow: the inventory-on-hand asset plus supplier flows, netted of the
-  /// period's expenses and losses. Renders [ReconData.periodNetResultKobo]
-  /// line-for-line so the breakdown sums to the bold total.
-  Widget _netResultCard(BuildContext context, ThemeData theme, ReconData d) {
-    final successColor = theme.extension<AppSemanticColors>()!.success;
-    final dangerColor = theme.colorScheme.error;
-    final periodNetColor = d.periodNetResultKobo >= 0 ? successColor : dangerColor;
-
-    return _card(
-      context,
-      theme,
-      'Net result for this period (flow)',
-      FontAwesomeIcons.moneyBillTrendUp.data,
-      periodNetColor,
-      [
-        _line(context, theme, 'Inventory on hand (at cost)', '+ ${formatCurrency(d.inventoryOnHandKobo / 100.0)}'),
-        _line(context, theme, 'Goods received', '+ ${formatCurrency(d.goodsReceivedKobo / 100.0)}'),
-        _line(context, theme, 'Paid to suppliers', '− ${formatCurrency(d.supplierPaidKobo / 100.0)}'),
-        _line(context, theme, 'Refunds', '− ${formatCurrency(d.refundsKobo / 100.0)}'),
-        _line(context, theme, 'Expenses', '− ${formatCurrency(d.expensesKobo / 100.0)}'),
-        _line(context, theme, 'Damages (at cost)', '− ${formatCurrency(d.damageCostKobo / 100.0)}'),
-        if (d.crateDamageDepositKobo > 0)
-          _line(context, theme, 'Crate deposit loss', '− ${formatCurrency(d.crateDamageDepositKobo / 100.0)}'),
-        _line(context, theme, 'Stock shortages (at cost)', '− ${formatCurrency(d.shortageCostKobo / 100.0)}'),
-        _divider(theme),
-        _line(context, theme, 'Net result for period', formatCurrency(d.periodNetResultKobo / 100.0), strong: true, color: periodNetColor),
-      ],
+      danger: hasVariance,
     );
   }
 
@@ -485,12 +495,14 @@ class DailyReconciliationDetailScreen extends ConsumerWidget {
         if (d.showCrates)
           _line(context, theme, 'Empty crates held (now)', '+ ${formatCurrency(d.crateDepositKobo / 100.0)}'),
         _line(context, theme, 'Outstanding customer debt (at risk)', '+ ${formatCurrency(d.totalOwedKobo / 100.0)}', color: d.totalOwedKobo > 0 ? dangerColor : null),
-        // Supplier account position: a negative balance means we owe them
-        // (− red); a positive balance is credit we hold with them (+ green).
+        // Supplier account position — tracks payments made to suppliers vs
+        // goods received. Negative (red) = a debt we owe them for unpaid goods;
+        // positive (green) = money we paid them in advance (a prepayment), not
+        // money we hold on their behalf.
         if (d.supplierAccountBalanceKobo < 0)
           _line(context, theme, 'Owed to suppliers (now)', '− ${formatCurrency(d.supplierAccountBalanceKobo.abs() / 100.0)}', color: dangerColor)
         else
-          _line(context, theme, 'Supplier credit held (now)', '+ ${formatCurrency(d.supplierAccountBalanceKobo / 100.0)}', color: d.supplierAccountBalanceKobo > 0 ? successColor : null),
+          _line(context, theme, 'Paid in advance to suppliers (now)', '+ ${formatCurrency(d.supplierAccountBalanceKobo / 100.0)}', color: d.supplierAccountBalanceKobo > 0 ? successColor : null),
         _divider(theme),
         _line(context, theme, 'Business net position (now)', formatCurrency(d.businessNetPositionKobo / 100.0), strong: true, color: positionColor),
         if (d.uncostedInventoryItems > 0) ...[
@@ -503,111 +515,6 @@ class DailyReconciliationDetailScreen extends ConsumerWidget {
         const SizedBox(height: 6),
         Text('Point-in-time net position. Not a cash balance.', style: context.bodySmall.copyWith(color: theme.hintColor)),
       ],
-    );
-  }
-
-  Widget _shrinkageCard(
-    BuildContext context,
-    ThemeData theme,
-    ReconData d, {
-    required bool retail,
-  }) {
-    final shortageVal = retail ? d.shortageRetailKobo : d.shortageCostKobo;
-    final damageVal = retail ? d.damageRetailKobo : d.damageCostKobo;
-    final danger = d.shortageUnits > 0;
-    return _card(
-      context,
-      theme,
-      retail ? 'Sellable value unaccounted' : 'Stock shrinkage (at cost)',
-      FontAwesomeIcons.triangleExclamation.data,
-      Colors.redAccent,
-      [
-        _line(
-          context,
-          theme,
-          'Stock shortages',
-          '${fmtNumber(d.shortageUnits)} unit(s) · ${formatCurrency(shortageVal / 100.0)}',
-          danger: danger,
-        ),
-        _line(
-          context,
-          theme,
-          'Damages recorded',
-          '${fmtNumber(d.damageUnits)} unit(s) · ${formatCurrency(damageVal / 100.0)}',
-        ),
-        _divider(theme),
-        _line(
-          context,
-          theme,
-          'Total',
-          formatCurrency((shortageVal + damageVal) / 100.0),
-          strong: true,
-        ),
-        if (retail) ...[
-          const SizedBox(height: 6),
-          Text(
-            'Valued at selling price — an accountability figure, not the '
-            'company\'s cost of the loss.',
-            style: context.bodySmall.copyWith(color: theme.hintColor),
-          ),
-        ],
-      ],
-      danger: danger,
-    );
-  }
-
-  Widget _stockCard(BuildContext context, ThemeData theme, ReconData d) {
-    final hasShortage = d.shortageUnits > 0;
-    return _card(
-      context,
-      theme,
-      'Stock audit',
-      FontAwesomeIcons.boxesStacked.data,
-      Colors.blueAccent,
-      [
-        if (!d.hasStockCount)
-          Text(
-            'No stock count taken in this period.',
-            style: context.bodySmall.copyWith(color: theme.hintColor),
-          )
-        else ...[
-          _line(
-            context,
-            theme,
-            'Products counted',
-            fmtNumber(d.productsCounted),
-          ),
-          _line(
-            context,
-            theme,
-            'Short',
-            '${fmtNumber(d.shortageCount)} products · ${fmtNumber(d.shortageUnits)} units',
-            danger: hasShortage,
-          ),
-          _line(
-            context,
-            theme,
-            'Surplus',
-            '${fmtNumber(d.surplusCount)} products · ${fmtNumber(d.surplusUnits)} units',
-          ),
-          if (d.shortages.isNotEmpty) ...[
-            const SizedBox(height: 6),
-            Text(
-              'Shortages',
-              style: context.bodySmall.copyWith(fontWeight: FontWeight.w700),
-            ),
-            for (final s in d.shortages)
-              _line(
-                context,
-                theme,
-                s.name,
-                '${s.diff} (had ${s.system}, counted ${s.actual})',
-                danger: true,
-              ),
-          ],
-        ],
-      ],
-      danger: hasShortage,
     );
   }
 
@@ -867,6 +774,7 @@ class DailyReconciliationDetailScreen extends ConsumerWidget {
       ['Items sold', '${d.itemsSold}'],
       ['Products (SKUs) sold', '${d.skus}'],
       ['Total sales', money(d.totalRevenueKobo)],
+      if (d.vatEnabled) ['VAT due (${d.vatRateLabel}%)', money(d.vatKobo)],
       if (isCeo) ...[
         // Net result for this period (flow) — mirrors _netResultCard.
         ['Inventory on hand (at cost)', money(d.inventoryOnHandKobo)],
@@ -888,7 +796,8 @@ class DailyReconciliationDetailScreen extends ConsumerWidget {
         ['Gross margin %', d.grossMarginPct],
         ['Net profit', money(d.netProfitKobo)],
         // Business worth right now (point-in-time) — mirrors _businessWorthCard.
-        // Supplier account position: negative = we owe, positive = credit held.
+        // Supplier account position: negative = a debt we owe for unpaid goods,
+        // positive = money we paid the supplier in advance (a prepayment).
         ['Supplier account balance (now)', money(d.supplierAccountBalanceKobo)],
         ['Business net position (now)', money(d.businessNetPositionKobo)],
         // Cash flow (business-wide) — mirrors _cashFlowCard.

--- a/lib/features/dashboard/screens/daily_reconciliation_detail_screen.dart
+++ b/lib/features/dashboard/screens/daily_reconciliation_detail_screen.dart
@@ -400,7 +400,6 @@ class DailyReconciliationDetailScreen extends ConsumerWidget {
     // CEO: cost-valued flow equation reconciled to the count.
     final variance = d.stockVarianceKobo;
     final hasVariance = d.hasStockCount && variance != 0;
-    final varianceColor = variance >= 0 ? successColor : dangerColor;
     return _card(
       context,
       theme,
@@ -439,7 +438,7 @@ class DailyReconciliationDetailScreen extends ConsumerWidget {
               '${variance >= 0 ? '+ ' : '− '}'
                   '${formatCurrency(variance.abs() / 100.0)}',
               strong: true,
-              color: hasVariance ? varianceColor : null,
+              color: hasVariance ? dangerColor : null,
             ),
         ],
         if (d.hasStockCount) ...[

--- a/lib/features/dashboard/screens/supplier_accounts_report_screen.dart
+++ b/lib/features/dashboard/screens/supplier_accounts_report_screen.dart
@@ -204,10 +204,12 @@ class _SupplierReportRow extends StatelessWidget {
   Widget build(BuildContext context) {
     final owed = row.balanceKobo < 0;
     final balColor = owed ? danger : (row.balanceKobo > 0 ? success : subtext);
+    // Positive = we paid the supplier in advance (a prepayment), not credit we
+    // hold on their behalf; negative = a debt we owe for unpaid goods.
     final balLabel = owed
         ? 'Owed ${formatCurrency(row.balanceKobo.abs() / 100)}'
         : (row.balanceKobo > 0
-              ? 'Credit ${formatCurrency(row.balanceKobo / 100)}'
+              ? 'Prepaid ${formatCurrency(row.balanceKobo / 100)}'
               : 'Settled');
 
     return GlassyCard(

--- a/lib/features/inventory/screens/supplier_detail_screen.dart
+++ b/lib/features/inventory/screens/supplier_detail_screen.dart
@@ -392,9 +392,11 @@ class _SupplierDetailScreenState extends ConsumerState<SupplierDetailScreen> {
   Widget _buildBalanceCard(BuildContext context, ThemeData theme, int balanceKobo, String scopeLabel) {
     final owed = balanceKobo < 0;
     final color = owed ? danger : (balanceKobo > 0 ? success : _text);
+    // Positive = we paid the supplier in advance (a prepayment), not credit we
+    // hold on their behalf; negative = a debt we owe for unpaid goods.
     final label = owed
         ? 'Amount owed to supplier'
-        : (balanceKobo > 0 ? 'Credit balance' : 'Settled');
+        : (balanceKobo > 0 ? 'Paid in advance' : 'Settled');
 
     return _GlassyCard(
       margin: EdgeInsets.symmetric(horizontal: context.getRSize(20)).copyWith(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.0.5+5
+version: 1.0.6+6
 
 environment:
   sdk: ^3.10.7

--- a/test/dashboard/recon_data_test.dart
+++ b/test/dashboard/recon_data_test.dart
@@ -7,8 +7,12 @@ import 'package:reebaplus_pos/features/dashboard/reconciliation/recon_data.dart'
 /// expenses / damages, so the rest can be neutral.
 ReconData recon({
   int costedRevenueKobo = 0,
+  int totalRevenueKobo = -1, // -1 ⇒ mirror costedRevenueKobo (back-compat)
   int cogsKobo = 0,
   int discountsKobo = 0,
+  bool vatEnabled = false,
+  int vatRateBps = 0,
+  int vatKobo = 0,
   int expensesKobo = 0,
   int damageCostKobo = 0,
   int crateDamageDepositKobo = 0,
@@ -29,10 +33,13 @@ ReconData recon({
   int stockExpectedClosingKobo = 0,
 }) {
   return ReconData(
-    totalRevenueKobo: costedRevenueKobo,
+    totalRevenueKobo: totalRevenueKobo < 0 ? costedRevenueKobo : totalRevenueKobo,
     costedRevenueKobo: costedRevenueKobo,
     cogsKobo: cogsKobo,
     discountsKobo: discountsKobo,
+    vatEnabled: vatEnabled,
+    vatRateBps: vatRateBps,
+    vatKobo: vatKobo,
     itemsSold: 0,
     skus: 0,
     uncostedItems: 0,
@@ -134,6 +141,27 @@ void main() {
       // A fully-discounted period has no net revenue → no divide-by-zero.
       expect(recon(costedRevenueKobo: 5000, discountsKobo: 5000).grossMarginPct,
           '0.0');
+    });
+  });
+
+  group('ReconData VAT (opt-in, per-business)', () {
+    test('vatRateLabel renders the configured rate as a percent', () {
+      final d = recon(vatEnabled: true, vatRateBps: 750, vatKobo: 1000);
+      expect(d.vatRateLabel, '7.5');
+    });
+
+    test('VAT is a pass-through — it does not enter the profit lines', () {
+      // Same P&L inputs, VAT on vs off → identical gross/net profit.
+      final off = recon(costedRevenueKobo: 100000, cogsKobo: 60000);
+      final on = recon(
+        costedRevenueKobo: 100000,
+        cogsKobo: 60000,
+        vatEnabled: true,
+        vatRateBps: 750,
+        vatKobo: 7500,
+      );
+      expect(on.grossProfitKobo, off.grossProfitKobo);
+      expect(on.netProfitKobo, off.netProfitKobo);
     });
   });
 

--- a/test/settings/vat_settings_test.dart
+++ b/test/settings/vat_settings_test.dart
@@ -1,0 +1,51 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reebaplus_pos/core/settings/vat_settings.dart';
+
+void main() {
+  group('computeVatKobo', () {
+    test('7.5% of ₦175,000 (17,500,000 kobo) = ₦13,125', () {
+      // 17_500_000 * 750 / 10000 = 1_312_500 kobo = ₦13,125.
+      expect(computeVatKobo(17500000, 750), 1312500);
+    });
+
+    test('rounds half-away-from-zero to the nearest kobo', () {
+      // 100 * 750 / 10000 = 7.5 → 8.
+      expect(computeVatKobo(100, 750), 8);
+    });
+
+    test('zero rate yields no VAT even on a positive base', () {
+      expect(computeVatKobo(50000, 0), 0);
+    });
+
+    test('non-positive base yields no VAT', () {
+      expect(computeVatKobo(0, 750), 0);
+      expect(computeVatKobo(-100, 750), 0);
+    });
+  });
+
+  group('parseVatRateBps', () {
+    test('parses a plain integer bps string', () {
+      expect(parseVatRateBps('750'), 750);
+    });
+
+    test('blank, null or malformed → 0', () {
+      expect(parseVatRateBps(null), 0);
+      expect(parseVatRateBps(''), 0);
+      expect(parseVatRateBps('abc'), 0);
+      expect(parseVatRateBps('-5'), 0);
+    });
+  });
+
+  group('VatConfig', () {
+    test('off is disabled with a zero rate', () {
+      expect(VatConfig.off.enabled, isFalse);
+      expect(VatConfig.off.rateBps, 0);
+    });
+
+    test('ratePercentLabel trims a trailing .0', () {
+      expect(const VatConfig(enabled: true, rateBps: 750).ratePercentLabel, '7.5');
+      expect(const VatConfig(enabled: true, rateBps: 2000).ratePercentLabel, '20');
+      expect(const VatConfig(enabled: true, rateBps: 500).ratePercentLabel, '5');
+    });
+  });
+}


### PR DESCRIPTION
Closes #74. Continuation of the closing-report epic (ADR 0014); **based on `feat/closing-report-reconciliation` (PR #73)**, not main — retarget to main once #73 merges.

## What changed

**1. Declutter → standardized closing.** The detail screen went from **9 cards repeating ~10 figures** (Damages ×4, Shortages ×4, COGS ×2, Inventory ×2, Net profit ×2) to **5 for CEO** (Sales · P&L · Cash · Stock reconciliation · Position) and **3 for Manager**, each figure appearing once:
- Deleted the redundant "Net result (flow)" card.
- Merged Shrinkage + Stock audit + Stock reconciliation + Integrity into one `_stockReconciliationCard`.
- Moved Refunds onto the Sales card. `recon_data.dart` model getters kept → existing tests unchanged.

**2. Opt-in VAT (OFF by default).** Stored in the synced `settings` table (`vat_enabled`, `vat_rate_bps`) — **no schema/cloud migration**. New `vat_settings.dart` (pure `computeVatKobo`) + `vatConfigProvider` + `ReconData.vatKobo` (derived on gross − discounts; **pass-through — not in the P&L profit**). Sales card + CSV show "VAT due (X%)" when enabled; Settings → Business Info gains a **Tax** toggle + rate field. **VAT on the cart/receipt at checkout is parked for a later slice.**

**3. Supplier balance wording.** A positive supplier balance now reads as **money paid in advance** (a prepayment), not "credit held" on their behalf — fixed on the closing Position card and the two supplier-account screens.

## Out of scope (decided with product)
- **Cash reconciliation** (counted drawer / opening float / over-short) — all cash is deposited to an account, so Hard Rule #8 stands and no `daily_closings` persistence is added.

## Verification
- `flutter analyze` clean project-wide.
- `recon_data_test` (19, +2 VAT) + new `vat_settings_test` (8) green; dashboard/settings/ban suites (77) green.
- On-device walkthrough (decluttered cards, VAT toggle, VAT line) **pending**.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional VAT support in business settings, including a charge VAT toggle and rate input.
  * Reworked the daily reconciliation detail view to show a cleaner, consolidated summary and updated CSV exports with VAT due when enabled.

* **Bug Fixes**
  * Improved supplier balance wording across reports and detail screens to better reflect prepaid vs. owed amounts.

* **Chores**
  * Updated the app version to 1.0.6+6.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->