### PR TITLE
feat(industry): Industry registry foundation + industryOf() resolver (#77)

### DIFF
--- a/BUILD_LOG.md
+++ b/BUILD_LOG.md
@@ -2,6 +2,41 @@
 
 ---
 
+## 2026-07-06 — Industry registry foundation + `industryOf()` (issue #77, ADR 0015)
+
+**What changed.** The prefactor for PRD #76: introduce **one Industry registry**
+as the single source of truth for the app's industries, plus a total
+`industryOf()` resolver — with **no user-visible change**.
+
+- **`lib/core/industry/industry.dart` (new).** An `Industry` enum whose entries
+  carry the facts that used to be duplicated across two lists: canonical `label`,
+  `icon`, `comingSoon`, `crateEligible` (+ lowercase `aliases` for legacy DB
+  values). `Industry.catalogue` = every entry except the `generic` fallback, in
+  plan order — what the pickers render from.
+- **`industryOf(String? type)`.** Total normalizer: trims/lowercases and matches
+  a stored `businesses.type` against each entry's label or aliases; the legacy
+  `'Beer distributor'` DB canonical and any casing map to `beverage`;
+  unknown/empty/null → `generic` (never throws, never blanks the app). No new
+  column, no migration — consistent with the existing `isCrateBusiness` string
+  gate (ADR 0015).
+- **`isCrateBusiness` is now a shim** — `industryOf(type).crateEligible` — so
+  Bar/Beverage-only crate-eligibility is derived from the same registry
+  everywhere. `business_types.dart` becomes a thin derivation: `kBusinessTypes`
+  maps `Industry.catalogue` labels and re-exports `isCrateBusiness`; the private
+  `_businessTypes` record list in `ceo_sign_up_screen.dart` is deleted and the
+  picker renders from `Industry.catalogue`. No duplicated industry facts remain.
+
+**Files changed:**
+- `lib/core/industry/industry.dart` — the registry + `industryOf` + `isCrateBusiness`.
+- `lib/core/data/business_types.dart` — thin derivation/re-export over the registry.
+- `lib/features/auth/screens/ceo_sign_up_screen.dart` — removed `_businessTypes`; picker reads `Industry.catalogue`.
+- `test/industry/industry_registry_test.dart` — 12 seam tests (resolution, membership, crate-gate, golden pin).
+
+**Verification:**
+- `flutter analyze` → clean (No issues found).
+- `flutter test test/industry` → 12/12 green; ran `test/crates test/settings test/auth test/providers` → all green except one **pre-existing** flaky widget test (`who_is_working_screen_test.dart`, confirmed failing on pristine `main`, unrelated).
+- `flutter run` on `emulator-5554` → built, installed, and booted `com.reebaplus.pos` cleanly (crate gate resolves live at startup for the Beverage tenant).
+
 ## 2026-07-05 — Closing report: integrity flag (issue #72, slice 3 — epic complete)
 
 **What changed.** Final slice of the closing-report enhancement (ADR 0014 §④):

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -165,8 +165,9 @@ The trade a business operates in (Beverage distributor, Pharmacy, Phone &
 Gadgets, Frozen Foods & Grocery, …) — the single input that morphs the app's
 words, presets, and optional feature surfaces. Resolved from `businesses.type`
 by the total normalizer `industryOf(type)`; unknown/null → the `generic`
-Industry, never a crash. Nine ship, all selectable at onboarding and editable
-later (ADR 0015).
+Industry, never a crash. Across the epic all nine become selectable at
+onboarding and editable later; this foundation slice adds the registry without
+changing today's selectable set (ADR 0015).
 _Avoid_: reading `businesses.type` string directly to branch behaviour (use the
 resolved Industry); a new `industry_id` column (identity is the normalized type).
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -158,6 +158,37 @@ _Avoid_: server-arrival order as the FIFO key; prompting the user per corrected
 sale; treating an assignment as permanent (it is stable only until an earlier
 sale arrives).
 
+### Industry
+
+**Industry**:
+The trade a business operates in (Beverage distributor, Pharmacy, Phone &
+Gadgets, Frozen Foods & Grocery, …) — the single input that morphs the app's
+words, presets, and optional feature surfaces. Resolved from `businesses.type`
+by the total normalizer `industryOf(type)`; unknown/null → the `generic`
+Industry, never a crash. Nine ship, all selectable at onboarding and editable
+later (ADR 0015).
+_Avoid_: reading `businesses.type` string directly to branch behaviour (use the
+resolved Industry); a new `industry_id` column (identity is the normalized type).
+
+**Industry Profile**:
+The per-Industry configuration record in the one industry registry: display
+label, icon, its **Lexicon**, starter categories/units, and its feature flags.
+Layered over the *one* shared products/POS/inventory model — an Industry is
+configuration, not a separate data model or app (ADR 0015). The registry
+supersedes the old duplicated lists (`business_types.dart` +
+`_businessTypes` in `ceo_sign_up_screen.dart`).
+_Avoid_: per-industry screens/tables/flows forked from the shared model; a
+plugin architecture.
+
+**Lexicon**:
+The app-shipped, compile-time set of an Industry's domain nouns (item name, unit,
+category, …) — only the nouns that read wrong cross-industry; neutral words
+(Save/Price/Stock) are left literal. Beverage-only nouns (crate, empties) live
+only in the beverage profile so they cannot leak. Missing slots fall back to the
+`generic` Lexicon. Not CEO-editable, not synced (ADR 0015).
+_Avoid_: translating every string; a synced or owner-editable vocabulary;
+hardcoding "crate"/"bottle" in feature code.
+
 ### Scoping
 
 **Current Business Id**:

--- a/docs/adr/0015-multi-industry-onboarding.md
+++ b/docs/adr/0015-multi-industry-onboarding.md
@@ -1,0 +1,84 @@
+# Industry is a configuration profile over one shared model, resolved by a normalizer
+
+**Status:** accepted (2026-07-06)
+
+The app ships built for a Beverage distributor: onboarding shows seven industries
+but only Beverage distributor is selectable (`business_types.dart` +
+`ceo_sign_up_screen.dart` `_businessTypes`), and the interior speaks beverage —
+"crate", "bottle", "empties" — because those nouns are hardcoded across ~23
+feature files. The ask is to (1) unlock every industry and add two new ones
+(**Phone & Gadgets**, **Frozen Foods & Grocery** → nine total), (2) make the
+app's language, guidance, presets, form fields, and feature surfaces adapt to the
+chosen industry, and (3) add an optional product photo to the Add/Update Product
+forms for all industries. The deep per-industry tailoring is explicitly phased —
+"one industry after another" — so this ADR records the *foundation* those later
+slices build on, not each industry's flow.
+
+The defining constraint is the offline sync architecture: one Drift source of
+truth, one sync registry, one outbox, RLS keyed on `business_id`. Any design that
+multiplies the data model or screen set per industry multiplies migrations, RLS
+policies, and sync failure modes. The existing crate feature is the proof point:
+industry-conditioned behaviour already ships as a `bool` flag
+(`tracks_empty_crates`) + a string normalizer (`isCrateBusiness`) gate over the
+shared model — not a separate app. This ADR generalises that one pattern.
+
+Decisions locked (grilled 2026-07-06):
+
+- **Architecture = configuration over one shared model.** An industry is a
+  *profile* layered on the single products/POS/inventory/orders model, never a
+  per-industry data model or plugin runtime. Industry-specific tracking (crates,
+  expiry, IMEI/serial, cold-chain) is optional fields/flags gated by the profile.
+  A truly alien flow (restaurant table-service, pharmacy dispensing) becomes an
+  individually-flagged sub-flow inside the shared shell, not a fork.
+
+- **Identity = a total normalizer over `businesses.type`, no new column, no
+  migration.** `businesses.type` is unconstrained `text` on both client (Drift
+  `text().nullable()`) and cloud (plain `text`; the crate gate in migration `0137`
+  already normalizes `lower(trim(type)) IN (...)`). A single `Industry` enum is
+  keyed by `industryOf(String? type)`, mapping known display strings → a stable
+  slug and **anything unknown/null → a safe `generic` profile** (never a crash,
+  never a blank app). The two duplicated industry lists collapse into one
+  registry that carries display label + icon + profile. Rejected: a stable
+  `businesses.industry_id` column — it buys only cloud-side filterability at the
+  cost of a synced schema change + backfill, against the house rule (the reason
+  `isCrateBusiness` normalizes instead of migrating).
+
+- **Terminology = swap the key nouns only, app-shipped, generic fallback.** Only
+  the domain nouns that read wrong cross-industry change (item name, unit,
+  category; beverage-only nouns like crate/empties stay scoped to the beverage
+  profile so they cannot leak). Neutral words (Save/Price/Stock/Search) are left
+  literal. The words are compile-time constants in the registry — **not**
+  CEO-editable and **not** synced; the CEO picks an *industry*, not individual
+  words. Owner word-customization and broad per-industry copy (screen titles,
+  help text, receipts) are rejected for now as large surface for small gain;
+  either can be added later. Implementation must audit which hardcoded nouns are
+  genuinely industry-sensitive to avoid slot-sprawl.
+
+- **Feature morph = industry decides, with a few owner switches.** Each profile
+  lists its relevant extras; most turn on automatically, a small number stay an
+  owner opt-in where behaviour genuinely varies within an industry (mirroring the
+  `tracks_empty_crates` switch). Rejected: a long list of manual per-feature
+  toggles at setup.
+
+- **Rollout = unlock all nine now, tailor extras later.** Every industry becomes
+  selectable immediately on the shared feature set + its words + basic starter
+  categories/units; per-industry extras (IMEI capture, expiry alerts, cold-chain,
+  etc.) land afterwards, one industry per PR, and availability is never blocked on
+  them. Deferred out of this body of work: barcode/IMEI **scanning**, the deep
+  per-industry flows, and any price-tier redesign (tiers keep today's
+  Retailer/Wholesaler structure; only their *labels* change via the lexicon).
+
+- **Industry is editable after onboarding, data preserved.** Switching (already
+  possible via Settings → Business Info) changes the words and which optional
+  features show/hide; existing products and history are untouched — a hidden
+  industry-specific field keeps its data and simply stops rendering. Consistent
+  with the editable crate switch; rejected locking it (rigid, and extra work to
+  remove editability that exists today).
+
+- **Product photo = one per product, cloud-synced, on the detail/edit screen.**
+  Optional image on both Add and Update Product. It uploads to Supabase Storage
+  and shows on every device (surviving reinstall), reusing the `BusinessLogoService`
+  pattern (instant local-cache render + offline upload queue). Scoped to the
+  product detail/edit screen for now — **not** the POS grid and **not** receipts
+  (both easy to add later). Rejected: local-only images (useless on a shared
+  multi-device till) and a multi-photo gallery (a larger separate feature).

--- a/docs/design/multi-industry-onboarding-brief.md
+++ b/docs/design/multi-industry-onboarding-brief.md
@@ -1,0 +1,155 @@
+# Multi-Industry Onboarding & App Morphing — Grilling Brief
+
+> **Purpose.** Seed document for the `/ask-matt` main flow
+> (`/grill-with-docs` → `/to-prd` → `/to-issues`). It restructures and
+> elaborates the raw request into a shape the grilling can sharpen and the
+> PRD/issues can be split from. It is **not** the final spec — the open
+> questions in §7 are deliberately unresolved so the interview can settle them.
+
+---
+
+## 1. One-line ask
+
+Unlock **every** industry at onboarding (not just Beverage distributor), add two
+brand-new industries (**Phone & Gadgets**, **Frozen Foods & Grocery**), and make
+the app's **language, guidance, presets, form fields, and feature surfaces morph
+to fit the industry the CEO chose** — starting with an optional **product image**
+on the Add / Update Product forms for all industries.
+
+## 2. Why (problem statement)
+
+The app is currently hard-built for a Beverage distributor. Onboarding shows all
+seven master-plan industries but only **Beverage distributor** is selectable; the
+other six are greyed-out "coming soon." Worse, the whole interior of the app
+speaks **beverage** — "crates," "bottles," "empties," "manufacturers" — so even
+if we flipped the other industries on today, a Pharmacy or Boutique owner would
+be managing "crates of drinks." The product is not yet **industry-aware**; it is
+beverage-aware with disabled doors.
+
+We want the app to **become the industry it was set up for**: the words on the
+Add Product form, the category and unit suggestions, the guides and empty-state
+hints, and eventually which tabs/fields/flows exist, should all reflect the
+selected industry.
+
+## 3. The nine-industry catalogue
+
+Existing seven (from `lib/core/data/business_types.dart`, plan order):
+
+1. Restaurant
+2. Supermarket
+3. Bar *(crate-eligible)*
+4. Beverage distributor *(crate-eligible — the one currently live)*
+5. Pharmacy
+6. Building Materials
+7. Boutique
+
+Add two **new**:
+
+8. **Phone & Gadgets**
+9. **Frozen Foods & Grocery**
+
+All nine selectable at onboarding once this program ships (rollout strategy is an
+open question — see §7).
+
+## 4. Current state (code grounding — verified, not assumed)
+
+- **Industry list is duplicated.** Canonical display strings live in
+  `lib/core/data/business_types.dart` (`kBusinessTypes`); the CEO sign-up screen
+  keeps its **own** private `_businessTypes` record list
+  (`ceo_sign_up_screen.dart`) coupling each label to an `IconData` and a
+  `comingSoon` bool. Two sources of truth to reconcile.
+- **Stored value is a display string, with a legacy quirk.** `businesses.type`
+  stores a string (the DB canonical for the live one is `'Beer distributor'`,
+  mapped to the display label "Beverage distributor" at load/save). There is
+  **no stable industry-id enum column** today. Older tenants stored
+  non-canonical casings — hence `isCrateBusiness()` normalises case.
+- **Only one industry-driven gate exists.** `isCrateBusiness(type)` (Bar / Beer
+  distributor) **AND** the `businesses.tracks_empty_crates` opt-in flag together
+  gate every empty-crate surface. This is the *only* precedent for morphing a
+  feature surface by industry, and it is a good pattern to generalise.
+- **No terminology / lexicon abstraction exists.** "crate"/"bottle" wording is
+  hardcoded across ~23 feature files. Nothing centralises industry copy.
+- **Product image is half-built and local-only.** `products.imagePath` (a local
+  file path column) already exists; `update_product_sheet.dart` already picks a
+  local image via `image_picker`; **`add_product_screen.dart` has no image UI**;
+  and `imagePath` is **not** in the sync registry/push whitelist, so images do
+  **not** cross devices (same situation the business logo solved with
+  `BusinessLogoService` + a Supabase Storage bucket).
+- **Invariants that constrain the design** (`context/architecture.md`):
+  offline-first, Drift is source of truth, every cloud write goes through the
+  outbox, `*_kobo` columns are bigint, new synced tables need a `SyncedTable`
+  registry entry + the `current_user_business_ids()` RLS helper, permissions are
+  data not code, entry is never blocked on a pull.
+
+## 5. Proposed decomposition (epics → candidate issues)
+
+Ordered so the foundation lands before the morph. `/to-issues` will split these;
+this is a starting cut, not the final issue list.
+
+### Epic 0 — Industry model foundation *(blocking prerequisite)*
+- Introduce a single **`IndustryProfile` registry** keyed by a stable industry
+  **id** (retiring the duplicated list). Each profile carries: `id`,
+  `displayName`, `icon`, `lexicon` (the noun set — what one product is called,
+  what a "unit" is, what "inventory"/"supplier"/"category" are called),
+  default **categories**, default **units of measure**, **feature flags**
+  (`tracksEmptyCrates`, `tracksExpiry`, `tracksSerialOrImei`, `tracksColdChain`,
+  price-tier model, …), the **Add/Update Product field set**, and
+  **guidance/help copy**.
+- Decide the canonical identifier and the **migration** for existing tenants
+  (see §7).
+
+### Epic 1 — Enable all industries at onboarding
+- Remove `comingSoon`; add Phone & Gadgets + Frozen Foods & Grocery; icons +
+  ordering; keep the crate opt-in visible **only** for crate-eligible industries.
+
+### Epic 2 — Terminology morph (lexicon layer)
+- Expose the active business's lexicon via a provider; replace hardcoded strings
+  **starting with Add/Update Product**, then POS, inventory, guides, empty
+  states, suggestions. Beverage keeps its exact current wording (no regression).
+
+### Epic 3 — Optional product image (all industries, cross-device)
+- Add image picker to **Add Product**; unify with Update Product; sync images
+  cross-device (Supabase Storage bucket, mirror `BusinessLogoService`); local
+  cache for offline grid/receipt; surface in POS grid + receipt (open question:
+  where it shows).
+
+### Epic 4+ — Per-industry functional morph *(one industry per PR, sequential)*
+- **Phone & Gadgets:** per-unit serial/IMEI, warranty, no expiry/crate.
+- **Frozen Foods & Grocery:** expiry + cold-chain emphasis, weight/batch, no crate.
+- **Pharmacy:** batch + expiry, regulated categories (barcode deferred).
+- **Restaurant / Supermarket / Building Materials / Boutique:** their own field
+  sets, categories, and terminology.
+
+## 6. Constraints & invariants to respect
+- Offline-first; Drift source of truth; all cloud writes via the outbox.
+- New synced column/table ⇒ registry entry + `bigint` for money + the
+  `current_user_business_ids()` RLS pattern.
+- Product image must never block a save and must render offline (local cache).
+- No AI attribution in commits/PRs (repo rule); log verified fixes to BUILD_LOG.
+
+## 7. Open questions for the grilling (the "pictures" to resolve)
+1. **Canonical industry id:** keep the display string in `businesses.type`, or
+   add a stable `industry_id` enum column? What migration for existing tenants
+   (incl. the `'Beer distributor'` legacy casing)?
+2. **Lexicon depth:** just nouns, or full guidance/help/onboarding tips per
+   industry? Who authors the copy and in what tone?
+3. **Editable after onboarding?** `tracks_empty_crates` is editable in Settings —
+   should the *industry* be too? What happens to existing data if an industry is
+   switched?
+4. **Feature flags vs opt-ins:** which surfaces are strictly industry-driven vs a
+   per-business toggle (crate tracking is already decoupled from type)?
+5. **Product image specifics:** one image or many? Cloud sync now or local-first?
+   Storage bucket, size caps, cost? Show in POS grid, receipt, both?
+6. **New industries' defaults:** starter categories, units, and price-tier
+   semantics for Phone & Gadgets and Frozen Foods & Grocery.
+7. **Price tiers:** do non-beverage industries want Retailer/Wholesaler tiers, or
+   a different tiering (or none)?
+8. **Scanning:** barcode/IMEI scanning is currently deferred — in or out for the
+   new industries?
+9. **Rollout:** ship all nine at once, or feature-flag the newly enabled ones?
+
+## 8. Delivery approach
+Epic 0–1 (foundation + onboarding) first; Epic 2 (terminology) and Epic 3
+(image) can run in parallel once the profile registry exists; Epic 4+ ships
+**one industry per PR** so each is independently reviewable and grabbable. Each
+resulting issue must be independently implementable per `/to-issues`.

--- a/docs/design/multi-industry-onboarding-brief.md
+++ b/docs/design/multi-industry-onboarding-brief.md
@@ -148,6 +148,44 @@ this is a starting cut, not the final issue list.
    new industries?
 9. **Rollout:** ship all nine at once, or feature-flag the newly enabled ones?
 
+## 7a. Decisions locked during grilling (running log)
+
+1. **Architecture = configuration over one shared model (option A).** Industry is a
+   *profile* layered on the existing single products/POS/inventory model — not a
+   per-industry data model or plugin app. Generalises the existing crate pattern.
+2. **Industry identity = a total normalizer over `businesses.type` (option i).** No
+   new column, no migration (`businesses.type` is unconstrained `text` on both
+   client and cloud; cloud crate gate `0137` already normalizes the string). One
+   `Industry` enum keyed by `industryOf(type)`, unknown/null → a safe `generic`
+   profile. Collapses the two duplicated lists (`business_types.dart` +
+   `_businessTypes` in `ceo_sign_up_screen.dart`) into one registry.
+3. **Terminology = swap key nouns only, app-shipped, generic fallback.** Change
+   only the domain nouns that read wrong cross-industry (item name, unit, category;
+   drink-only words like crate/empties stay scoped to beverage). Neutral words
+   (Save/Price/Stock/Search) unchanged. Words ship as compile-time constants in the
+   registry — **not** CEO-editable, not synced. Owner customization is a possible
+   later add, explicitly out of scope now.
+4. **Rollout = unlock all 9 now, tailor extras later.** All industries selectable
+   immediately on the shared feature set + correct words + starter categories/units.
+   Industry-specific extras (IMEI, expiry alerts, etc.) added afterwards, one
+   industry per PR — availability is never blocked on them.
+5. **Feature morph = industry decides + a few owner switches.** Each profile lists
+   its extras; most auto-on, a few stay owner opt-ins where behaviour varies
+   (mirrors `tracks_empty_crates`). Not a wall of manual toggles.
+6. **Product photo = one per product, cloud-synced, detail/edit screen only.**
+   Optional on Add + Update Product; uploads to Supabase Storage, shows on every
+   device, reuses the `BusinessLogoService` pattern (local-cache render + offline
+   upload). NOT on the POS grid, NOT on receipts (both easy later). No gallery.
+7. **Industry editable after onboarding, data preserved.** Switching changes words
+   + optional-feature visibility only; product/history data untouched (hidden
+   fields keep their data). Consistent with the editable crate switch.
+8. **Scope boundary locked.** OUT now (deferred to per-industry PRs): barcode/IMEI
+   scanning, deep per-industry flows, price-tier redesign (tiers keep
+   Retailer/Wholesaler; only labels change via the lexicon). IN now: the registry
+   + 9 industries, the noun-swap, basic starter categories/units, the synced photo.
+
+Full rationale for each: **ADR 0015**. Glossary: `CONTEXT.md` → Industry section.
+
 ## 8. Delivery approach
 Epic 0–1 (foundation + onboarding) first; Epic 2 (terminology) and Epic 3
 (image) can run in parallel once the profile registry exists; Epic 4+ ships

--- a/lib/core/data/business_types.dart
+++ b/lib/core/data/business_types.dart
@@ -11,5 +11,5 @@ export 'package:reebaplus_pos/core/industry/industry.dart' show isCrateBusiness;
 /// cannot drift from the registry. DB stores the canonical 'Beer distributor'
 /// string for Beverage distributor tenants; the Business Info screen maps the
 /// display ↔ DB label at load/save time.
-List<String> get kBusinessTypes =>
+final List<String> kBusinessTypes =
     Industry.catalogue.map((i) => i.label).toList(growable: false);

--- a/lib/core/data/business_types.dart
+++ b/lib/core/data/business_types.dart
@@ -1,32 +1,15 @@
-/// The seven master-plan business types (§1.2), in plan order. Single source of
-/// truth for the *display label strings* used in settings and dropdowns.
-///
-/// DB stores the canonical 'Beer distributor' string for Beverage distributor
-/// tenants; Business Info screen maps the display ↔ DB label at load/save time.
-/// CEO Sign Up couples each label with an icon and a comingSoon flag in its own
-/// private `_businessTypes` record list (ceo_sign_up_screen.dart).
-const List<String> kBusinessTypes = [
-  'Restaurant',
-  'Supermarket',
-  'Bar',
-  'Beverage distributor',
-  'Pharmacy',
-  'Building Materials',
-  'Boutique',
-];
+import 'package:reebaplus_pos/core/industry/industry.dart';
 
-/// Whether [type] is a business that uses empty-crate features — Bar or Beer
-/// distributor/Beverage distributor only (master plan §16.10). The single gate
-/// for crate-feature visibility; reuse it everywhere instead of re-comparing
-/// the raw strings.
-///
-/// Case-insensitive and trimmed on purpose: businesses onboarded by older
-/// builds stored non-canonical casings (e.g. 'Beer Distributor' vs the
-/// canonical 'Beverage distributor' above), and an exact-match check silently hid
-/// the Empty Crates tab from those tenants. Normalising here keeps the gate
-/// correct for that legacy data without a risky migration of synced rows.
-bool isCrateBusiness(String? type) {
-  final t = type?.trim().toLowerCase();
-  return t == 'bar' || t == 'beer distributor' || t == 'beverage distributor';
-}
+/// Compatibility shim over the one Industry registry (ADR 0015, #77). The
+/// industry facts — labels, icons, coming-soon, crate-eligibility — now live
+/// only in [Industry]; this file derives the old public names from it so
+/// existing callers keep working without a second copy of the list.
+export 'package:reebaplus_pos/core/industry/industry.dart' show isCrateBusiness;
 
+/// The business-type display labels shown in settings/dropdowns, in plan order.
+/// Derived from [Industry.catalogue] — no longer a hand-maintained list, so it
+/// cannot drift from the registry. DB stores the canonical 'Beer distributor'
+/// string for Beverage distributor tenants; the Business Info screen maps the
+/// display ↔ DB label at load/save time.
+List<String> get kBusinessTypes =>
+    Industry.catalogue.map((i) => i.label).toList(growable: false);

--- a/lib/core/industry/industry.dart
+++ b/lib/core/industry/industry.dart
@@ -78,8 +78,8 @@ enum Industry {
 
   /// The industries offered in pickers, in plan order — every entry except
   /// [generic]. Onboarding and Settings render from this so the two lists can
-  /// never diverge from the registry.
-  static List<Industry> get catalogue =>
+  /// never diverge from the registry. Computed once (used inside `build`).
+  static final List<Industry> catalogue =
       values.where((i) => i != generic).toList(growable: false);
 }
 
@@ -90,8 +90,7 @@ enum Industry {
 Industry industryOf(String? type) {
   final t = type?.trim().toLowerCase();
   if (t == null || t.isEmpty) return Industry.generic;
-  for (final ind in Industry.values) {
-    if (ind == Industry.generic) continue;
+  for (final ind in Industry.catalogue) {
     if (ind.label.toLowerCase() == t || ind.aliases.contains(t)) return ind;
   }
   return Industry.generic;

--- a/lib/core/industry/industry.dart
+++ b/lib/core/industry/industry.dart
@@ -1,0 +1,110 @@
+import 'package:flutter/material.dart';
+
+/// A trade the app can be set up for — the single input that morphs the app's
+/// words, presets, and optional feature surfaces (CONTEXT.md → *Industry*).
+///
+/// This enum **is** the one Industry registry (ADR 0015): the single source of
+/// truth for each industry's display label, icon, coming-soon flag, and
+/// crate-eligibility. It supersedes the two lists these facts used to be split
+/// across — the `kBusinessTypes` display list and the private `_businessTypes`
+/// record list in CEO Sign Up — so the two can no longer drift.
+///
+/// An industry is a *configuration profile* over the one shared
+/// products/POS/inventory model, never a separate data model or app. Identity
+/// is resolved from the stored `businesses.type` string by [industryOf]; there
+/// is no `industry_id` column and no migration. Anything unknown or null
+/// resolves to [generic] — a safe fallback so a legacy or malformed type never
+/// crashes or blanks the app.
+///
+/// Later slices of PRD #76 hang more configuration off each entry (the Lexicon
+/// of domain nouns, starter categories/units, further feature flags); #77
+/// introduces only the facts that were already duplicated.
+enum Industry {
+  restaurant(label: 'Restaurant', icon: Icons.restaurant_rounded),
+  supermarket(label: 'Supermarket', icon: Icons.local_grocery_store_rounded),
+  bar(label: 'Bar', icon: Icons.local_bar_rounded, crateEligible: true),
+
+  /// The one industry live today. The DB stores the legacy canonical string
+  /// `'Beer distributor'` for these tenants (mapped to this display label at
+  /// load/save), so [aliases] carries it for resolution.
+  beverage(
+    label: 'Beverage distributor',
+    icon: Icons.sports_bar_rounded,
+    comingSoon: false,
+    crateEligible: true,
+    aliases: {'beer distributor'},
+  ),
+  pharmacy(label: 'Pharmacy', icon: Icons.local_pharmacy_rounded),
+  buildingMaterials(label: 'Building Materials', icon: Icons.foundation_rounded),
+  boutique(label: 'Boutique', icon: Icons.checkroom_rounded),
+
+  /// Safe fallback for an unknown, legacy, or null `businesses.type`. Never
+  /// offered in a picker (excluded from [catalogue]); it exists so [industryOf]
+  /// is total and the interior falls back to neutral words and no
+  /// industry-only features.
+  generic(
+    label: 'Business',
+    icon: Icons.storefront_rounded,
+    comingSoon: false,
+  );
+
+  const Industry({
+    required this.label,
+    required this.icon,
+    this.comingSoon = true,
+    this.crateEligible = false,
+    this.aliases = const <String>{},
+  });
+
+  /// Canonical display label (what onboarding writes to `businesses.type` and
+  /// what the type pickers show).
+  final String label;
+
+  /// Icon shown beside the label in the onboarding picker.
+  final IconData icon;
+
+  /// Whether this industry is greyed-out as "coming soon" at onboarding. #77
+  /// preserves today's set (only [beverage] selectable); #79 flips all off.
+  final bool comingSoon;
+
+  /// Whether this industry uses the empty-crate features (Bar / Beverage only).
+  /// The crate-visibility gate reads this via [isCrateBusiness]; combine it with
+  /// the `tracks_empty_crates` opt-in for the full surface gate.
+  final bool crateEligible;
+
+  /// Extra lowercase strings (besides the lowercased [label]) that resolve to
+  /// this industry — legacy DB canonicals and casings. See [industryOf].
+  final Set<String> aliases;
+
+  /// The industries offered in pickers, in plan order — every entry except
+  /// [generic]. Onboarding and Settings render from this so the two lists can
+  /// never diverge from the registry.
+  static List<Industry> get catalogue =>
+      values.where((i) => i != generic).toList(growable: false);
+}
+
+/// Resolves a stored `businesses.type` string to its [Industry]. Total: known
+/// display labels and legacy aliases map to their industry (case-insensitive,
+/// trimmed); anything unknown, empty, or null maps to [Industry.generic]. Never
+/// throws.
+Industry industryOf(String? type) {
+  final t = type?.trim().toLowerCase();
+  if (t == null || t.isEmpty) return Industry.generic;
+  for (final ind in Industry.values) {
+    if (ind == Industry.generic) continue;
+    if (ind.label.toLowerCase() == t || ind.aliases.contains(t)) return ind;
+  }
+  return Industry.generic;
+}
+
+/// Whether [type] is a business that uses empty-crate features — Bar or
+/// Beverage distributor only (master plan §16.10). Derived from the registry's
+/// [Industry.crateEligible] flag so "bar/beverage only" stays consistent
+/// everywhere, including the server gate. The single gate for crate-feature
+/// visibility; reuse it instead of re-comparing raw strings.
+///
+/// Case-insensitive and trimmed on purpose: businesses onboarded by older
+/// builds stored non-canonical casings (e.g. 'Beer Distributor'), which
+/// [industryOf] normalizes — keeping the gate correct for that legacy data
+/// without a risky migration of synced rows.
+bool isCrateBusiness(String? type) => industryOf(type).crateEligible;

--- a/lib/features/auth/screens/ceo_sign_up_screen.dart
+++ b/lib/features/auth/screens/ceo_sign_up_screen.dart
@@ -13,7 +13,7 @@ import 'package:reebaplus_pos/core/data/currencies.dart';
 import 'package:reebaplus_pos/core/providers/app_providers.dart';
 import 'package:reebaplus_pos/core/theme/app_decorations.dart';
 import 'package:reebaplus_pos/core/utils/notifications.dart';
-import 'package:reebaplus_pos/core/data/business_types.dart';
+import 'package:reebaplus_pos/core/industry/industry.dart';
 import 'package:reebaplus_pos/features/auth/onboarding/onboarding_draft.dart';
 import 'package:reebaplus_pos/features/auth/widgets/auth_form_kit.dart';
 import 'package:reebaplus_pos/features/auth/widgets/branded_auth_background.dart';
@@ -50,30 +50,9 @@ class CeoSignUpScreen extends ConsumerStatefulWidget {
 class _CeoSignUpScreenState extends ConsumerState<CeoSignUpScreen> {
   static const int _totalSteps = 9;
 
-  /// All seven master-plan business types (§1.2). Only 'Beverage distributor'
-  /// is selectable; the other six are visible but greyed-out as coming soon.
-  static const List<({String label, IconData icon, bool comingSoon})>
-  _businessTypes = [
-    (label: 'Restaurant', icon: Icons.restaurant_rounded, comingSoon: true),
-    (
-      label: 'Supermarket',
-      icon: Icons.local_grocery_store_rounded,
-      comingSoon: true,
-    ),
-    (label: 'Bar', icon: Icons.local_bar_rounded, comingSoon: true),
-    (
-      label: 'Beverage distributor',
-      icon: Icons.sports_bar_rounded,
-      comingSoon: false,
-    ),
-    (label: 'Pharmacy', icon: Icons.local_pharmacy_rounded, comingSoon: true),
-    (
-      label: 'Building Materials',
-      icon: Icons.foundation_rounded,
-      comingSoon: true,
-    ),
-    (label: 'Boutique', icon: Icons.checkroom_rounded, comingSoon: true),
-  ];
+  // The business-type picker is rendered from [Industry.catalogue] — the one
+  // Industry registry (ADR 0015). Each entry carries its own label, icon and
+  // coming-soon flag, so this screen no longer keeps a private duplicate list.
 
   // Obvious PINs to block (master plan §5.1). Mirrors create_pin_screen.dart.
   static const Set<String> _blockedPins = {
@@ -871,7 +850,7 @@ class _CeoSignUpScreenState extends ConsumerState<CeoSignUpScreen> {
       title: 'What type of business?',
       subtitle: 'Pick the one that fits best.',
       children: [
-        ..._businessTypes.map((t) {
+        ...Industry.catalogue.map((t) {
           final selected = _businessType == t.label;
           return Padding(
             padding: const EdgeInsets.only(bottom: 12),

--- a/test/industry/industry_registry_test.dart
+++ b/test/industry/industry_registry_test.dart
@@ -1,0 +1,185 @@
+// Industry registry seam (issue #77, ADR 0015). The registry is the single
+// source of truth for the app's industries — display label, icon, coming-soon
+// flag, crate-eligibility — and `industryOf()` is the total normalizer that
+// resolves a stored `businesses.type` string to one canonical [Industry].
+//
+// These tests exercise the module's public behaviour, never its internals:
+//   (a) resolution   — canonical labels, legacy casings, unknown/null → generic;
+//   (b) membership   — the catalogue holds exactly the expected industries, in
+//                      plan order, with no duplicates and the same coming-soon
+//                      set the app shipped (proves the #77 prefactor is
+//                      user-visible-behaviour-preserving);
+//   (c) crate-gate   — crate-eligibility stays Bar/Beverage-only and reproduces
+//                      the old hardcoded `isCrateBusiness` truth table exactly;
+//   (d) golden pin   — a frozen snapshot of every catalogue entry, so any drift
+//                      in a label/icon/flag surfaces here for deliberate review.
+//
+// Prior art: test/permissions/gate_registry_membership_test.dart (membership)
+// and test/sync/sync_registry_golden_test.dart (frozen golden).
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reebaplus_pos/core/industry/industry.dart';
+
+void main() {
+  // === (a) RESOLUTION — industryOf() is total ============================
+
+  group('industryOf resolution', () {
+    test('resolves every catalogue label to its own Industry', () {
+      for (final ind in Industry.catalogue) {
+        expect(industryOf(ind.label), ind,
+            reason: 'canonical label "${ind.label}" must round-trip');
+      }
+    });
+
+    test('resolution is case- and whitespace-insensitive', () {
+      expect(industryOf('  bar  '), Industry.bar);
+      expect(industryOf('PHARMACY'), Industry.pharmacy);
+      expect(industryOf('beverage distributor'), Industry.beverage);
+    });
+
+    test('maps the legacy "Beer distributor" DB value and casings to beverage',
+        () {
+      // The DB stores 'Beer distributor' for beverage tenants; older builds
+      // stored non-canonical casings. All must resolve to the beverage profile.
+      expect(industryOf('Beer distributor'), Industry.beverage);
+      expect(industryOf('Beer Distributor'), Industry.beverage);
+      expect(industryOf('beer distributor'), Industry.beverage);
+    });
+
+    test('unknown, empty, blank, and null all resolve to generic (no crash)',
+        () {
+      expect(industryOf(null), Industry.generic);
+      expect(industryOf(''), Industry.generic);
+      expect(industryOf('   '), Industry.generic);
+      expect(industryOf('Spaceship Repair'), Industry.generic);
+    });
+  });
+
+  // === (b) MEMBERSHIP — the catalogue is exactly today's seven ===========
+
+  group('registry membership', () {
+    test('catalogue is the seven master-plan industries in plan order', () {
+      expect(
+        Industry.catalogue.map((i) => i.label).toList(),
+        const [
+          'Restaurant',
+          'Supermarket',
+          'Bar',
+          'Beverage distributor',
+          'Pharmacy',
+          'Building Materials',
+          'Boutique',
+        ],
+      );
+    });
+
+    test('generic is the fallback and is never offered in the catalogue', () {
+      expect(Industry.catalogue, isNot(contains(Industry.generic)));
+    });
+
+    test('catalogue labels are unique', () {
+      final labels = Industry.catalogue.map((i) => i.label).toList();
+      expect(labels.toSet().length, labels.length,
+          reason: 'duplicate label in the catalogue: $labels');
+    });
+
+    test('only Beverage distributor is selectable today (rest coming soon)', () {
+      // #77 is a pure prefactor: the onboarding picker must show the same
+      // selectable/greyed set it shows today. #79 flips these all on.
+      final comingSoon = {
+        for (final i in Industry.catalogue) i.label: i.comingSoon,
+      };
+      expect(comingSoon, {
+        'Restaurant': true,
+        'Supermarket': true,
+        'Bar': true,
+        'Beverage distributor': false,
+        'Pharmacy': true,
+        'Building Materials': true,
+        'Boutique': true,
+      });
+    });
+  });
+
+  // === (c) CRATE-GATE — Bar/Beverage only, isCrateBusiness parity ========
+
+  group('crate-eligibility', () {
+    test('only Bar and Beverage are crate-eligible', () {
+      final eligible =
+          Industry.catalogue.where((i) => i.crateEligible).map((i) => i.label);
+      expect(eligible, unorderedEquals(['Bar', 'Beverage distributor']));
+      expect(Industry.generic.crateEligible, isFalse);
+    });
+
+    test('isCrateBusiness reproduces the old hardcoded truth table', () {
+      // Verbatim behaviour of the pre-registry gate: true for exactly
+      // {bar, beer distributor, beverage distributor} (case-insensitive).
+      const crateTrue = [
+        'Bar',
+        'bar',
+        'Beer distributor',
+        'Beer Distributor',
+        'beverage distributor',
+        'Beverage distributor',
+      ];
+      const crateFalse = [
+        'Restaurant',
+        'Supermarket',
+        'Pharmacy',
+        'Building Materials',
+        'Boutique',
+        'Phone & Gadgets',
+        'nonsense',
+        '',
+      ];
+      for (final t in crateTrue) {
+        expect(isCrateBusiness(t), isTrue, reason: '"$t" should be crate');
+      }
+      for (final t in crateFalse) {
+        expect(isCrateBusiness(t), isFalse, reason: '"$t" should not be crate');
+      }
+      expect(isCrateBusiness(null), isFalse);
+    });
+
+    test('isCrateBusiness is exactly the registry crate flag', () {
+      for (final t in [
+        'Bar',
+        'Beverage distributor',
+        'Beer distributor',
+        'Restaurant',
+        'unknown',
+        null,
+      ]) {
+        expect(isCrateBusiness(t), industryOf(t).crateEligible,
+            reason: 'the shim must equal the registry flag for "$t"');
+      }
+    });
+  });
+
+  // === (d) GOLDEN PIN — frozen snapshot of the catalogue =================
+
+  group('catalogue golden', () {
+    // FROZEN GOLDEN DATA — the exact facts each catalogue entry held when the
+    // registry was introduced. A diff here means an industry's label, icon,
+    // coming-soon or crate flag changed: update this golden in the SAME commit,
+    // deliberately. (label | icon codepoint | comingSoon | crateEligible)
+    const golden = <String>[
+      'Restaurant|0xf0108|true|false',
+      'Supermarket|0xf86e|true|false',
+      'Bar|0xf865|true|true',
+      'Beverage distributor|0xf01b8|false|true',
+      'Pharmacy|0xf877|true|false',
+      'Building Materials|0xf7a3|true|false',
+      'Boutique|0xf639|true|false',
+    ];
+
+    test('catalogue matches the frozen golden', () {
+      final actual = Industry.catalogue
+          .map((i) =>
+              '${i.label}|0x${i.icon.codePoint.toRadixString(16)}|'
+              '${i.comingSoon}|${i.crateEligible}')
+          .toList();
+      expect(actual, golden);
+    });
+  });
+}


### PR DESCRIPTION
Closes #77 — the foundation prefactor for PRD #76 (multi-industry onboarding & app morphing), per ADR 0015.

## What this does
Collapses the two duplicated industry lists into **one `Industry` registry** and adds a total `industryOf()` resolver — **with no user-visible change**.

- **`lib/core/industry/industry.dart` (new)** — an `Industry` enum that is the single source of truth for each industry's `label`, `icon`, `comingSoon` flag and `crateEligible` flag (+ lowercase `aliases` for legacy DB values). `Industry.catalogue` = every entry except the `generic` fallback, in plan order.
- **`industryOf(String? type)`** — total normalizer: trims/lowercases and matches a stored `businesses.type` against each entry's label or aliases; the legacy `'Beer distributor'` DB canonical and any casing → `beverage`; unknown/empty/null → a safe `generic` (never throws, never blanks the app). No new column, no migration (ADR 0015).
- **`isCrateBusiness` is now a shim** over `industryOf(type).crateEligible`, so Bar/Beverage-only crate-eligibility is derived from the registry everywhere.
- **De-duplication** — `business_types.dart` becomes a thin derivation (`kBusinessTypes` maps `Industry.catalogue` labels; re-exports `isCrateBusiness`); the private `_businessTypes` record list in `ceo_sign_up_screen.dart` is deleted and the picker renders from `Industry.catalogue`. No industry facts live in two places.

**Pure prefactor** — the onboarding picker shows the same selectable/greyed set (only Beverage distributor). The two new industries (Phone & Gadgets, Frozen Foods & Grocery) and unlock-all land in #79; the Lexicon in #80/#81; the product photo in #78.

## Tests
`test/industry/industry_registry_test.dart` — 12 seam tests covering resolution (canonical, legacy casing, unknown→generic, never-throws), membership (exactly the seven, plan order, no dupes, today's coming-soon set), crate-gate (Bar/Beverage only + `isCrateBusiness` truth-table parity), and a frozen golden pin. Mirrors the gate-registry membership + sync-registry golden prior art.

## Verification
- `flutter analyze` → clean.
- `flutter test test/industry` → 12/12; ran crates/settings/auth/providers suites → green (one pre-existing flaky widget test unrelated, confirmed failing on pristine `main`).
- `flutter run` on the Android emulator → built, installed, booted `com.reebaplus.pos` cleanly (crate gate resolves live at startup).

## Note for the reviewer/merger
This PR also carries the epic's design docs (ADR 0015, the grilling brief, and the CONTEXT.md *Industry / Industry Profile / Lexicon* glossary), which currently live only on the standalone `feat/multi-industry-onboarding` branch. They are folded in here so they land on `main` with the foundation they govern — that branch can be closed/deleted rather than merged separately.

A follow-up noted by review, deferred to #79 (where canonical-label writing is in scope): absorb the display↔DB `'Beer distributor'` mapping into the registry as a `dbCanonical` field so the three conversion sites derive rather than re-hardcode it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a centralized industry registry to power business-type selection and industry-specific app behavior.
  * Business type options now load from a shared catalog, keeping the signup screen aligned with the latest industry list.

* **Bug Fixes**
  * Improved business-type matching for stored values, including case/spacing differences and legacy labels.
  * Unknown, empty, or missing business types now safely fall back to a generic industry.

* **Tests**
  * Added coverage for industry resolution, catalog ordering, eligibility rules, and registry consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->