### PR TITLE
feat(inventory): optional synced product photo (#78)

### DIFF
--- a/BUILD_LOG.md
+++ b/BUILD_LOG.md
@@ -2,6 +2,63 @@
 
 ---
 
+## 2026-07-07 — Optional synced product photo (issue #78, PRD #76)
+
+**What changed.** Owners can attach an optional photo to a product on Add /
+Update Product; it uploads to Supabase Storage, its URL syncs onto the product
+so every device shows it, a local cache renders it instantly and offline, and
+skipping it never blocks a save.
+
+- **Data layer.** Drift **v58 → v59**: `products.image_url` (nullable text) with
+  an idempotent `from < 59` onUpgrade addColumn. Cloud migration **0143** —
+  additive `ALTER TABLE products ADD COLUMN image_url`; `products` is a
+  pass-through push table, so the column rides the normal outbox → upsert → pull
+  path with no RPC/whitelist change (dodges the overload trap). `CatalogDao.
+  setProductImageUrl` is a minimal partial upsert used after upload + by the
+  offline flush.
+- **Service + storage.** `ProductImageService` mirrors `BusinessLogoService`:
+  pick+resize, upload to the **product-images** bucket at
+  `<businessId>/<productId>.png`, local file cache, and a SharedPreferences
+  pending set so a photo saved offline is auto-uploaded when connectivity
+  returns (via a new `SupabaseSyncService.onReconnected` hook wired in
+  app_providers, business-scoped so the patch stays correct on multi-business
+  devices). Cloud migration **0144** creates the public bucket + business-scoped
+  storage RLS (writes gated on `current_user_business_ids()` via the first path
+  segment). **Note:** the `business-logos` bucket was never created on this
+  project — the logo cloud-upload has been a silent no-op; `product-images` is
+  created here fresh.
+- **UI.** `ProductPhotoField` — a shared, responsive, theme-aware picker widget
+  mirroring `_LogoSection`'s design-system idiom (`context.getRSize` /
+  `getRFontSize`, theme colours, no hardcoded values), used on Add Product. The
+  Update Product sheet and the Product detail screen route their existing
+  pickers through `ProductImageService` and resolve a renderable path via
+  `ensureCached` so a cross-device photo shows and renders offline. The legacy
+  local `imagePath` is preserved for offline render. Photo stays **off** the POS
+  grid and receipts; one photo per product.
+
+**Files changed:** `lib/core/database/app_database.dart` (+`.g.dart`),
+`daos_catalog.dart`, `lib/core/services/product_image_service.dart` (new),
+`lib/core/services/supabase_sync_service.dart`, `lib/core/providers/app_providers.dart`,
+`lib/features/inventory/widgets/product_photo_field.dart` (new),
+`add_product_screen.dart`, `update_product_sheet.dart`, `product_detail_screen.dart`,
+`supabase/migrations/0143_product_image_url.sql` + `0144_product_images_bucket.sql` (new),
+`test/sync/product_image_url_sync_test.dart` (new).
+
+**Migration ordering note.** 0142 belongs to the unmerged web-pos #56 branch
+(cloud-only); 0143/0144 are collision-free but leave a 0142 gap on main until #56
+lands. 0143 + 0144 were applied to the cloud via MCP `apply_migration` (the
+project's recorded migration versions already diverge — 0140/0141 are timestamped
+on the cloud — so a blind `db push` was avoided).
+
+**Verification.**
+- `flutter analyze` → clean project-wide.
+- `flutter test test/sync test/inventory test/crates test/database` → green (incl.
+  the new `product_image_url_sync_test`).
+- `flutter run` on `emulator-5554` → built + booted `com.reebaplus.pos`; log shows
+  `onUpgrade: v58 → v59` on the populated device DB with **no runtime errors**.
+- Cloud verified: `products.image_url` column present, `product-images` bucket
+  public with 4 storage policies.
+
 ## 2026-07-06 — Standardized daily closing: declutter + opt-in VAT
 
 **Context.** The Daily Reconciliation detail screen had grown to **9 cards that

--- a/BUILD_LOG.md
+++ b/BUILD_LOG.md
@@ -14,8 +14,8 @@ skipping it never blocks a save.
   additive `ALTER TABLE products ADD COLUMN image_url`; `products` is a
   pass-through push table, so the column rides the normal outbox → upsert → pull
   path with no RPC/whitelist change (dodges the overload trap). `CatalogDao.
-  setProductImageUrl` is a minimal partial upsert used after upload + by the
-  offline flush.
+  setProductImageUrl` persists the URL on the local row and enqueues the FULL
+  product row (coalesce-safe) after upload + by the offline flush.
 - **Service + storage.** `ProductImageService` mirrors `BusinessLogoService`:
   pick+resize, upload to the **product-images** bucket at
   `<businessId>/<productId>.png`, local file cache, and a SharedPreferences

--- a/BUILD_LOG.md
+++ b/BUILD_LOG.md
@@ -59,6 +59,16 @@ on the cloud — so a blind `db push` was avoided).
 - Cloud verified: `products.image_url` column present, `product-images` bucket
   public with 4 storage policies.
 
+**Code-review fixes (two-axis review).** (1) **Coalesce-safety:** the outbox keeps
+one pending row per `(action_type, id)`, so a partial `{id, image_url}` upsert
+queued right after an `updateProductDetails` upsert replaced it and dropped the
+concurrent name/price edits — `setProductImageUrl` now enqueues the FULL row
+(`_enqueueFullProduct`); regression test added. (2) **POS-grid exclusion:** the
+flows had written the cache path to `products.image_path`, which the POS grid
+renders — #78 photos now live in `image_url` + the local cache only
+(`updateProductDetails.imagePath` is a sentinel-defaulted param). (3)
+`ProductPhotoField` uses `textTheme` styles; removed dead `localPathIfExists`.
+
 ## 2026-07-06 — Standardized daily closing: declutter + opt-in VAT
 
 **Context.** The Daily Reconciliation detail screen had grown to **9 cards that

--- a/CONTEXT/progress-tracker.md
+++ b/CONTEXT/progress-tracker.md
@@ -10,6 +10,18 @@ The human updates it when resolving open questions or making architectural decis
 
 152 sessions logged. Codebase is live and being verified on-device.
 
+### IN REVIEW: Optional synced product photo (issue #78, PRD #76 / ADR 0015)
+Branch `feat/product-photo-sync` (off main; independent slice of the
+multi-industry epic — no blocker). Owners attach an optional product photo on
+Add/Update Product; it uploads to the **product-images** Storage bucket, its URL
+syncs onto the product (`products.image_url`, Drift v59 + cloud 0143), a local
+cache renders it offline, and a reconnect flush uploads photos saved offline.
+`ProductImageService` mirrors `BusinessLogoService`; `ProductPhotoField` is the
+shared responsive/theme-aware picker. Off the POS grid + receipts; one per
+product. analyze clean, seam + migration tests green, boots on emulator
+(`onUpgrade v58→v59` clean); cloud column + bucket + RLS verified. Migration
+0142 (web-pos #56, unmerged) leaves a gap before 0143 — reconcile order at merge.
+
 ### SHIPPED: Standardized daily closing — declutter + opt-in VAT (2026-07-06)
 Reworked the Daily Reconciliation detail screen (§25.9) into one standardized
 closing and added opt-in VAT. Branch `feat/standardized-daily-close` (off

--- a/lib/core/database/app_database.dart
+++ b/lib/core/database/app_database.dart
@@ -394,6 +394,11 @@ class Products extends Table {
   // businesses that don't track expiry simply leave it null.
   DateTimeColumn get expiryDate => dateTime().nullable()();
   TextColumn get imagePath => text().nullable()();
+  // Optional cloud image URL for the product photo (schema v59, #78 / PRD #76).
+  // Synced cross-device via the normal outbox/pull path (products is a
+  // pass-through push table) so every device shows the same picture; the local
+  // [imagePath] continues to serve offline render. Null = no photo.
+  TextColumn get imageUrl => text().nullable()();
   IntColumn get version => integer().withDefault(const Constant(1))();
   DateTimeColumn get createdAt => dateTime().withDefault(currentDateAndTime)();
   DateTimeColumn get lastUpdatedAt =>
@@ -1830,7 +1835,7 @@ class AppDatabase extends _$AppDatabase {
   String? get currentAuthUserId => authUserIdResolver();
 
   @override
-  int get schemaVersion => 58;
+  int get schemaVersion => 59;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -3932,6 +3937,21 @@ class AppDatabase extends _$AppDatabase {
               [id, bid, pid, sid, qty, qty, r.read<int>('cost'), rec, rec, rec],
             );
           }
+        }
+      }
+      if (from < 59) {
+        // v59 (#78, PRD #76): products.image_url — the optional cloud image URL
+        // for a product's photo, synced cross-device (the local `image_path`
+        // continues to serve offline render). Nullable; photo-less products stay
+        // null. Mirrors supabase/migrations/0143_product_image_url.sql. Idempotency
+        // guard for a DB stepped back to < 59 by the revert-then-re-upgrade tests
+        // (same pattern as v57).
+        final has = await customSelect(
+          "SELECT 1 FROM pragma_table_info('products') "
+          "WHERE name = 'image_url'",
+        ).get();
+        if (has.isEmpty) {
+          await m.addColumn(products, products.imageUrl);
         }
       }
     },

--- a/lib/core/database/app_database.g.dart
+++ b/lib/core/database/app_database.g.dart
@@ -7598,6 +7598,17 @@ class $ProductsTable extends Products
     type: DriftSqlType.string,
     requiredDuringInsert: false,
   );
+  static const VerificationMeta _imageUrlMeta = const VerificationMeta(
+    'imageUrl',
+  );
+  @override
+  late final GeneratedColumn<String> imageUrl = GeneratedColumn<String>(
+    'image_url',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
   static const VerificationMeta _versionMeta = const VerificationMeta(
     'version',
   );
@@ -7666,6 +7677,7 @@ class $ProductsTable extends Products
     barcode,
     expiryDate,
     imagePath,
+    imageUrl,
     version,
     createdAt,
     lastUpdatedAt,
@@ -7902,6 +7914,12 @@ class $ProductsTable extends Products
         imagePath.isAcceptableOrUnknown(data['image_path']!, _imagePathMeta),
       );
     }
+    if (data.containsKey('image_url')) {
+      context.handle(
+        _imageUrlMeta,
+        imageUrl.isAcceptableOrUnknown(data['image_url']!, _imageUrlMeta),
+      );
+    }
     if (data.containsKey('version')) {
       context.handle(
         _versionMeta,
@@ -8048,6 +8066,10 @@ class $ProductsTable extends Products
         DriftSqlType.string,
         data['${effectivePrefix}image_path'],
       ),
+      imageUrl: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}image_url'],
+      ),
       version: attachedDatabase.typeMapping.read(
         DriftSqlType.int,
         data['${effectivePrefix}version'],
@@ -8099,6 +8121,7 @@ class ProductData extends DataClass implements Insertable<ProductData> {
   final String? barcode;
   final DateTime? expiryDate;
   final String? imagePath;
+  final String? imageUrl;
   final int version;
   final DateTime createdAt;
   final DateTime lastUpdatedAt;
@@ -8132,6 +8155,7 @@ class ProductData extends DataClass implements Insertable<ProductData> {
     this.barcode,
     this.expiryDate,
     this.imagePath,
+    this.imageUrl,
     required this.version,
     required this.createdAt,
     required this.lastUpdatedAt,
@@ -8192,6 +8216,9 @@ class ProductData extends DataClass implements Insertable<ProductData> {
     if (!nullToAbsent || imagePath != null) {
       map['image_path'] = Variable<String>(imagePath);
     }
+    if (!nullToAbsent || imageUrl != null) {
+      map['image_url'] = Variable<String>(imageUrl);
+    }
     map['version'] = Variable<int>(version);
     map['created_at'] = Variable<DateTime>(createdAt);
     map['last_updated_at'] = Variable<DateTime>(lastUpdatedAt);
@@ -8249,6 +8276,9 @@ class ProductData extends DataClass implements Insertable<ProductData> {
       imagePath: imagePath == null && nullToAbsent
           ? const Value.absent()
           : Value(imagePath),
+      imageUrl: imageUrl == null && nullToAbsent
+          ? const Value.absent()
+          : Value(imageUrl),
       version: Value(version),
       createdAt: Value(createdAt),
       lastUpdatedAt: Value(lastUpdatedAt),
@@ -8296,6 +8326,7 @@ class ProductData extends DataClass implements Insertable<ProductData> {
       barcode: serializer.fromJson<String?>(json['barcode']),
       expiryDate: serializer.fromJson<DateTime?>(json['expiryDate']),
       imagePath: serializer.fromJson<String?>(json['imagePath']),
+      imageUrl: serializer.fromJson<String?>(json['imageUrl']),
       version: serializer.fromJson<int>(json['version']),
       createdAt: serializer.fromJson<DateTime>(json['createdAt']),
       lastUpdatedAt: serializer.fromJson<DateTime>(json['lastUpdatedAt']),
@@ -8334,6 +8365,7 @@ class ProductData extends DataClass implements Insertable<ProductData> {
       'barcode': serializer.toJson<String?>(barcode),
       'expiryDate': serializer.toJson<DateTime?>(expiryDate),
       'imagePath': serializer.toJson<String?>(imagePath),
+      'imageUrl': serializer.toJson<String?>(imageUrl),
       'version': serializer.toJson<int>(version),
       'createdAt': serializer.toJson<DateTime>(createdAt),
       'lastUpdatedAt': serializer.toJson<DateTime>(lastUpdatedAt),
@@ -8370,6 +8402,7 @@ class ProductData extends DataClass implements Insertable<ProductData> {
     Value<String?> barcode = const Value.absent(),
     Value<DateTime?> expiryDate = const Value.absent(),
     Value<String?> imagePath = const Value.absent(),
+    Value<String?> imageUrl = const Value.absent(),
     int? version,
     DateTime? createdAt,
     DateTime? lastUpdatedAt,
@@ -8409,6 +8442,7 @@ class ProductData extends DataClass implements Insertable<ProductData> {
     barcode: barcode.present ? barcode.value : this.barcode,
     expiryDate: expiryDate.present ? expiryDate.value : this.expiryDate,
     imagePath: imagePath.present ? imagePath.value : this.imagePath,
+    imageUrl: imageUrl.present ? imageUrl.value : this.imageUrl,
     version: version ?? this.version,
     createdAt: createdAt ?? this.createdAt,
     lastUpdatedAt: lastUpdatedAt ?? this.lastUpdatedAt,
@@ -8482,6 +8516,7 @@ class ProductData extends DataClass implements Insertable<ProductData> {
           ? data.expiryDate.value
           : this.expiryDate,
       imagePath: data.imagePath.present ? data.imagePath.value : this.imagePath,
+      imageUrl: data.imageUrl.present ? data.imageUrl.value : this.imageUrl,
       version: data.version.present ? data.version.value : this.version,
       createdAt: data.createdAt.present ? data.createdAt.value : this.createdAt,
       lastUpdatedAt: data.lastUpdatedAt.present
@@ -8522,6 +8557,7 @@ class ProductData extends DataClass implements Insertable<ProductData> {
           ..write('barcode: $barcode, ')
           ..write('expiryDate: $expiryDate, ')
           ..write('imagePath: $imagePath, ')
+          ..write('imageUrl: $imageUrl, ')
           ..write('version: $version, ')
           ..write('createdAt: $createdAt, ')
           ..write('lastUpdatedAt: $lastUpdatedAt')
@@ -8560,6 +8596,7 @@ class ProductData extends DataClass implements Insertable<ProductData> {
     barcode,
     expiryDate,
     imagePath,
+    imageUrl,
     version,
     createdAt,
     lastUpdatedAt,
@@ -8597,6 +8634,7 @@ class ProductData extends DataClass implements Insertable<ProductData> {
           other.barcode == this.barcode &&
           other.expiryDate == this.expiryDate &&
           other.imagePath == this.imagePath &&
+          other.imageUrl == this.imageUrl &&
           other.version == this.version &&
           other.createdAt == this.createdAt &&
           other.lastUpdatedAt == this.lastUpdatedAt);
@@ -8632,6 +8670,7 @@ class ProductsCompanion extends UpdateCompanion<ProductData> {
   final Value<String?> barcode;
   final Value<DateTime?> expiryDate;
   final Value<String?> imagePath;
+  final Value<String?> imageUrl;
   final Value<int> version;
   final Value<DateTime> createdAt;
   final Value<DateTime> lastUpdatedAt;
@@ -8666,6 +8705,7 @@ class ProductsCompanion extends UpdateCompanion<ProductData> {
     this.barcode = const Value.absent(),
     this.expiryDate = const Value.absent(),
     this.imagePath = const Value.absent(),
+    this.imageUrl = const Value.absent(),
     this.version = const Value.absent(),
     this.createdAt = const Value.absent(),
     this.lastUpdatedAt = const Value.absent(),
@@ -8701,6 +8741,7 @@ class ProductsCompanion extends UpdateCompanion<ProductData> {
     this.barcode = const Value.absent(),
     this.expiryDate = const Value.absent(),
     this.imagePath = const Value.absent(),
+    this.imageUrl = const Value.absent(),
     this.version = const Value.absent(),
     this.createdAt = const Value.absent(),
     this.lastUpdatedAt = const Value.absent(),
@@ -8737,6 +8778,7 @@ class ProductsCompanion extends UpdateCompanion<ProductData> {
     Expression<String>? barcode,
     Expression<DateTime>? expiryDate,
     Expression<String>? imagePath,
+    Expression<String>? imageUrl,
     Expression<int>? version,
     Expression<DateTime>? createdAt,
     Expression<DateTime>? lastUpdatedAt,
@@ -8776,6 +8818,7 @@ class ProductsCompanion extends UpdateCompanion<ProductData> {
       if (barcode != null) 'barcode': barcode,
       if (expiryDate != null) 'expiry_date': expiryDate,
       if (imagePath != null) 'image_path': imagePath,
+      if (imageUrl != null) 'image_url': imageUrl,
       if (version != null) 'version': version,
       if (createdAt != null) 'created_at': createdAt,
       if (lastUpdatedAt != null) 'last_updated_at': lastUpdatedAt,
@@ -8813,6 +8856,7 @@ class ProductsCompanion extends UpdateCompanion<ProductData> {
     Value<String?>? barcode,
     Value<DateTime?>? expiryDate,
     Value<String?>? imagePath,
+    Value<String?>? imageUrl,
     Value<int>? version,
     Value<DateTime>? createdAt,
     Value<DateTime>? lastUpdatedAt,
@@ -8848,6 +8892,7 @@ class ProductsCompanion extends UpdateCompanion<ProductData> {
       barcode: barcode ?? this.barcode,
       expiryDate: expiryDate ?? this.expiryDate,
       imagePath: imagePath ?? this.imagePath,
+      imageUrl: imageUrl ?? this.imageUrl,
       version: version ?? this.version,
       createdAt: createdAt ?? this.createdAt,
       lastUpdatedAt: lastUpdatedAt ?? this.lastUpdatedAt,
@@ -8947,6 +8992,9 @@ class ProductsCompanion extends UpdateCompanion<ProductData> {
     if (imagePath.present) {
       map['image_path'] = Variable<String>(imagePath.value);
     }
+    if (imageUrl.present) {
+      map['image_url'] = Variable<String>(imageUrl.value);
+    }
     if (version.present) {
       map['version'] = Variable<int>(version.value);
     }
@@ -8994,6 +9042,7 @@ class ProductsCompanion extends UpdateCompanion<ProductData> {
           ..write('barcode: $barcode, ')
           ..write('expiryDate: $expiryDate, ')
           ..write('imagePath: $imagePath, ')
+          ..write('imageUrl: $imageUrl, ')
           ..write('version: $version, ')
           ..write('createdAt: $createdAt, ')
           ..write('lastUpdatedAt: $lastUpdatedAt, ')
@@ -54897,6 +54946,7 @@ typedef $$ProductsTableCreateCompanionBuilder =
       Value<String?> barcode,
       Value<DateTime?> expiryDate,
       Value<String?> imagePath,
+      Value<String?> imageUrl,
       Value<int> version,
       Value<DateTime> createdAt,
       Value<DateTime> lastUpdatedAt,
@@ -54933,6 +54983,7 @@ typedef $$ProductsTableUpdateCompanionBuilder =
       Value<String?> barcode,
       Value<DateTime?> expiryDate,
       Value<String?> imagePath,
+      Value<String?> imageUrl,
       Value<int> version,
       Value<DateTime> createdAt,
       Value<DateTime> lastUpdatedAt,
@@ -55357,6 +55408,11 @@ class $$ProductsTableFilterComposer
 
   ColumnFilters<String> get imagePath => $composableBuilder(
     column: $table.imagePath,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get imageUrl => $composableBuilder(
+    column: $table.imageUrl,
     builder: (column) => ColumnFilters(column),
   );
 
@@ -55846,6 +55902,11 @@ class $$ProductsTableOrderingComposer
     builder: (column) => ColumnOrderings(column),
   );
 
+  ColumnOrderings<String> get imageUrl => $composableBuilder(
+    column: $table.imageUrl,
+    builder: (column) => ColumnOrderings(column),
+  );
+
   ColumnOrderings<int> get version => $composableBuilder(
     column: $table.version,
     builder: (column) => ColumnOrderings(column),
@@ -56085,6 +56146,9 @@ class $$ProductsTableAnnotationComposer
 
   GeneratedColumn<String> get imagePath =>
       $composableBuilder(column: $table.imagePath, builder: (column) => column);
+
+  GeneratedColumn<String> get imageUrl =>
+      $composableBuilder(column: $table.imageUrl, builder: (column) => column);
 
   GeneratedColumn<int> get version =>
       $composableBuilder(column: $table.version, builder: (column) => column);
@@ -56513,6 +56577,7 @@ class $$ProductsTableTableManager
                 Value<String?> barcode = const Value.absent(),
                 Value<DateTime?> expiryDate = const Value.absent(),
                 Value<String?> imagePath = const Value.absent(),
+                Value<String?> imageUrl = const Value.absent(),
                 Value<int> version = const Value.absent(),
                 Value<DateTime> createdAt = const Value.absent(),
                 Value<DateTime> lastUpdatedAt = const Value.absent(),
@@ -56547,6 +56612,7 @@ class $$ProductsTableTableManager
                 barcode: barcode,
                 expiryDate: expiryDate,
                 imagePath: imagePath,
+                imageUrl: imageUrl,
                 version: version,
                 createdAt: createdAt,
                 lastUpdatedAt: lastUpdatedAt,
@@ -56583,6 +56649,7 @@ class $$ProductsTableTableManager
                 Value<String?> barcode = const Value.absent(),
                 Value<DateTime?> expiryDate = const Value.absent(),
                 Value<String?> imagePath = const Value.absent(),
+                Value<String?> imageUrl = const Value.absent(),
                 Value<int> version = const Value.absent(),
                 Value<DateTime> createdAt = const Value.absent(),
                 Value<DateTime> lastUpdatedAt = const Value.absent(),
@@ -56617,6 +56684,7 @@ class $$ProductsTableTableManager
                 barcode: barcode,
                 expiryDate: expiryDate,
                 imagePath: imagePath,
+                imageUrl: imageUrl,
                 version: version,
                 createdAt: createdAt,
                 lastUpdatedAt: lastUpdatedAt,

--- a/lib/core/database/daos_catalog.dart
+++ b/lib/core/database/daos_catalog.dart
@@ -424,6 +424,24 @@ class CatalogDao extends DatabaseAccessor<AppDatabase>
     await db.syncDao.enqueueUpsert('products', comp);
   }
 
+  /// Writes the cloud [imageUrl] (or null to clear) onto [productId] and
+  /// enqueues the products upsert so the photo converges cross-device (#78).
+  /// Called after a successful image upload — on Add/Update Product, and by the
+  /// offline retry flush once connectivity returns. A minimal partial upsert:
+  /// it touches only `image_url` + the sync cursor, leaving every other column
+  /// untouched (the local `image_path` offline render is unaffected).
+  Future<void> setProductImageUrl(String productId, String? imageUrl) async {
+    final comp = ProductsCompanion(
+      id: Value(productId),
+      imageUrl: Value(imageUrl),
+      lastUpdatedAt: Value(DateTime.now()),
+    );
+    await (update(
+      products,
+    )..where((t) => t.id.equals(productId) & whereBusiness(t))).write(comp);
+    await db.syncDao.enqueueUpsert('products', comp);
+  }
+
   Future<void> updateProductPrices(
     String productId, {
     required int buyingPriceKobo,

--- a/lib/core/database/daos_catalog.dart
+++ b/lib/core/database/daos_catalog.dart
@@ -363,7 +363,10 @@ class CatalogDao extends DatabaseAccessor<AppDatabase>
     bool? trackEmpties,
     bool? allowFractionalSales,
     int? lowStockThreshold,
-    String? imagePath,
+    // Sentinel-defaulted: omit to leave the legacy local image_path untouched.
+    // #78 photos live in image_url + the ProductImageService cache, never here,
+    // so the POS grid (which renders image_path) stays photo-free.
+    Object? imagePath = _unset,
     int? monthlyTargetUnits,
     // Optional cosmetic / metadata fields. Wrapped with present-check
     // sentinels so the caller can leave any of them out and the column
@@ -400,7 +403,9 @@ class CatalogDao extends DatabaseAccessor<AppDatabase>
       monthlyTargetUnits: monthlyTargetUnits == null
           ? const Value.absent()
           : Value(monthlyTargetUnits),
-      imagePath: Value(imagePath),
+      imagePath: identical(imagePath, _unset)
+          ? const Value.absent()
+          : Value(imagePath as String?),
       subtitle: identical(subtitle, _unset)
           ? const Value.absent()
           : Value(subtitle as String?),
@@ -425,21 +430,26 @@ class CatalogDao extends DatabaseAccessor<AppDatabase>
   }
 
   /// Writes the cloud [imageUrl] (or null to clear) onto [productId] and
-  /// enqueues the products upsert so the photo converges cross-device (#78).
-  /// Called after a successful image upload — on Add/Update Product, and by the
-  /// offline retry flush once connectivity returns. A minimal partial upsert:
-  /// it touches only `image_url` + the sync cursor, leaving every other column
-  /// untouched (the local `image_path` offline render is unaffected).
+  /// enqueues the product for sync so the photo converges cross-device (#78).
+  /// Called after a successful image upload — on Add/Update Product, the detail
+  /// screen, and by the offline retry flush once connectivity returns.
+  ///
+  /// Enqueues the FULL row (via [_enqueueFullProduct]) rather than a partial
+  /// `{image_url}` upsert: the outbox coalesces one pending row per
+  /// `(action_type, id)`, so a partial upsert queued right after a full
+  /// `updateProductDetails` upsert would REPLACE it and silently drop the
+  /// concurrent name/price edits. Re-reading and pushing every column keeps
+  /// those edits (and satisfies the cloud's NOT NULL columns).
   Future<void> setProductImageUrl(String productId, String? imageUrl) async {
-    final comp = ProductsCompanion(
-      id: Value(productId),
-      imageUrl: Value(imageUrl),
-      lastUpdatedAt: Value(DateTime.now()),
+    await (update(products)
+          ..where((t) => t.id.equals(productId) & whereBusiness(t)))
+        .write(
+      ProductsCompanion(
+        imageUrl: Value(imageUrl),
+        lastUpdatedAt: Value(DateTime.now()),
+      ),
     );
-    await (update(
-      products,
-    )..where((t) => t.id.equals(productId) & whereBusiness(t))).write(comp);
-    await db.syncDao.enqueueUpsert('products', comp);
+    await _enqueueFullProduct(productId);
   }
 
   Future<void> updateProductPrices(

--- a/lib/core/providers/app_providers.dart
+++ b/lib/core/providers/app_providers.dart
@@ -5,6 +5,8 @@
 /// here with proper dependency injection.
 library;
 
+import 'dart:async';
+
 import 'package:drift/drift.dart' show innerJoin;
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -15,6 +17,7 @@ import 'package:reebaplus_pos/core/database/app_database.dart';
 import 'package:reebaplus_pos/core/providers/business_scoped_stream.dart';
 import 'package:reebaplus_pos/core/services/biometric_service.dart';
 import 'package:reebaplus_pos/core/services/business_logo_service.dart';
+import 'package:reebaplus_pos/core/services/product_image_service.dart';
 import 'package:reebaplus_pos/core/theme/theme_notifier.dart';
 import 'package:reebaplus_pos/features/customers/data/models/customer.dart';
 import 'package:reebaplus_pos/features/customers/data/services/customer_service.dart';
@@ -355,11 +358,25 @@ final reorderAlertServiceProvider = Provider<ReorderAlertService>((ref) {
 });
 
 final supabaseSyncServiceProvider = Provider<SupabaseSyncService>((ref) {
-  return SupabaseSyncService(
+  final service = SupabaseSyncService(
     ref.read(databaseProvider),
     SupabaseCloudTransport(ref.read(supabaseClientProvider)),
     ref.read(secureStorageProvider),
   );
+  // On connectivity recovery, upload any product photos saved offline and write
+  // their public URLs onto the product rows (which then sync cross-device). #78.
+  service.onReconnected = () {
+    final db = ref.read(databaseProvider);
+    final businessId = db.businessIdResolver.call();
+    if (businessId == null) return;
+    unawaited(
+      ref.read(productImageServiceProvider).flushPending(
+            businessId,
+            (productId, url) => db.catalogDao.setProductImageUrl(productId, url),
+          ),
+    );
+  };
+  return service;
 });
 
 // ── Sync diagnostics ────────────────────────────────────────────────────────
@@ -511,6 +528,23 @@ final currentBusinessLogoPathProvider =
         businessId: business.id,
         logoUrl: business.logoUrl,
       );
+    });
+
+// ── Product Image (#78) ─────────────────────────────────────────────────────
+
+final productImageServiceProvider = Provider<ProductImageService>((ref) {
+  return ProductImageService(ref.read(supabaseClientProvider));
+});
+
+/// The local file path to a product's photo, or null when none is set or the
+/// cache is still being populated. Family keyed by the product's id + cloud
+/// URL: [ProductImageService.ensureCached] serves the local file when present,
+/// otherwise downloads from Storage once (so photos survive a reinstall and
+/// appear on every device), and returns null offline with no cache.
+final productImagePathProvider = FutureProvider.autoDispose
+    .family<String?, ({String productId, String? imageUrl})>((ref, arg) async {
+      final svc = ref.read(productImageServiceProvider);
+      return svc.ensureCached(productId: arg.productId, imageUrl: arg.imageUrl);
     });
 
 /// Lifts the `SupabaseSyncService.pullStatus` ValueNotifier into Riverpod

--- a/lib/core/providers/app_providers.dart
+++ b/lib/core/providers/app_providers.dart
@@ -367,7 +367,7 @@ final supabaseSyncServiceProvider = Provider<SupabaseSyncService>((ref) {
   // their public URLs onto the product rows (which then sync cross-device). #78.
   service.onReconnected = () {
     final db = ref.read(databaseProvider);
-    final businessId = db.businessIdResolver.call();
+    final businessId = db.currentBusinessId;
     if (businessId == null) return;
     unawaited(
       ref.read(productImageServiceProvider).flushPending(

--- a/lib/core/providers/app_providers.dart
+++ b/lib/core/providers/app_providers.dart
@@ -536,17 +536,6 @@ final productImageServiceProvider = Provider<ProductImageService>((ref) {
   return ProductImageService(ref.read(supabaseClientProvider));
 });
 
-/// The local file path to a product's photo, or null when none is set or the
-/// cache is still being populated. Family keyed by the product's id + cloud
-/// URL: [ProductImageService.ensureCached] serves the local file when present,
-/// otherwise downloads from Storage once (so photos survive a reinstall and
-/// appear on every device), and returns null offline with no cache.
-final productImagePathProvider = FutureProvider.autoDispose
-    .family<String?, ({String productId, String? imageUrl})>((ref, arg) async {
-      final svc = ref.read(productImageServiceProvider);
-      return svc.ensureCached(productId: arg.productId, imageUrl: arg.imageUrl);
-    });
-
 /// Lifts the `SupabaseSyncService.pullStatus` ValueNotifier into Riverpod
 /// so the MainLayout catch-up banner (and SyncIssues) can `ref.watch` it.
 /// Mirrors the pattern used for the `isOnline` ValueNotifier (read directly

--- a/lib/core/services/product_image_service.dart
+++ b/lib/core/services/product_image_service.dart
@@ -189,12 +189,6 @@ class ProductImageService {
   /// whether the file exists.
   Future<String> localPathFor(String productId) => _localPath(productId);
 
-  /// Returns the local file path if the cached file exists, otherwise null.
-  Future<String?> localPathIfExists(String productId) async {
-    final path = await _localPath(productId);
-    return File(path).existsSync() ? path : null;
-  }
-
   /// Returns the local file path, downloading from [imageUrl] once if the local
   /// cache is absent. Returns null if neither the local cache nor the URL
   /// yields an image (e.g. offline with no cache).

--- a/lib/core/services/product_image_service.dart
+++ b/lib/core/services/product_image_service.dart
@@ -1,0 +1,267 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:image/image.dart' as img;
+import 'package:image_picker/image_picker.dart';
+import 'package:path_provider/path_provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import 'package:reebaplus_pos/core/result.dart';
+
+/// Sanctioned direct-Supabase exception (#78, PRD #76): product photos go to
+/// Supabase Storage (not the outbox) because Storage objects are not tenant
+/// rows and have no Drift equivalent — same carve-out as [BusinessLogoService],
+/// documented in architecture.md. Only the resulting public URL rides sync
+/// (products.image_url); the bytes live in Storage + a local file cache.
+///
+/// Public bucket: `product-images`
+///   - Object path: `<businessId>/<productId>.png` — the first folder segment
+///     is the owning business, so the storage RLS can gate writes on
+///     `current_user_business_ids()` (see migration 0144).
+///   - Read policy: public (getPublicUrl renders cross-device; offline render
+///     comes from the local cache below).
+///   - Write policy: authenticated members of the business.
+class ProductImageService {
+  ProductImageService(this._client);
+
+  final SupabaseClient _client;
+
+  static const _bucket = 'product-images';
+  // Products get a larger cap than the 512px logo — staff recognise items by
+  // the photo, and the POS/inventory still never render it (detail screen only).
+  static const _maxDimension = 800;
+
+  /// Device-local set of `<businessId>|<productId>` whose local cache is written
+  /// but whose Storage upload hasn't succeeded yet (saved offline). Flushed on
+  /// reconnect by [flushPending]. Survives restart (SharedPreferences).
+  static const _pendingKey = 'pending_product_image_uploads';
+
+  // ── Pick + resize ──────────────────────────────────────────────────────────
+
+  /// Opens the image picker (gallery), decodes, resizes to ≤800×800 PNG.
+  /// Returns [Result.err] if the user cancels or the image can't be decoded.
+  Future<Result<Uint8List, AppError>> pickAndProcess({
+    ImageSource source = ImageSource.gallery,
+  }) async {
+    try {
+      final picker = ImagePicker();
+      final picked = await picker.pickImage(source: source, imageQuality: 90);
+      if (picked == null) return Result.err(AppError.cancelled());
+
+      final rawBytes = await picked.readAsBytes();
+      final decoded = img.decodeImage(rawBytes);
+      if (decoded == null) {
+        return Result.err(AppError.io('Could not decode image.'));
+      }
+
+      final resized = _resize(decoded);
+      final pngBytes = Uint8List.fromList(img.encodePng(resized));
+      return Result.ok(pngBytes);
+    } catch (e) {
+      return Result.err(AppError.unknown(e));
+    }
+  }
+
+  img.Image _resize(img.Image src) {
+    if (src.width <= _maxDimension && src.height <= _maxDimension) return src;
+    final ratio = src.width > src.height
+        ? _maxDimension / src.width
+        : _maxDimension / src.height;
+    return img.copyResize(
+      src,
+      width: (src.width * ratio).round(),
+      height: (src.height * ratio).round(),
+      interpolation: img.Interpolation.linear,
+    );
+  }
+
+  // ── Save (local + cloud) ───────────────────────────────────────────────────
+
+  /// Writes [bytes] to the local cache immediately (so the photo renders even
+  /// offline), then uploads to Storage and returns the public URL. The caller
+  /// writes that URL onto the product row (which syncs). On upload failure the
+  /// local cache is still written and [Result.err] is returned, so the caller
+  /// can mark the product for a later retry.
+  Future<Result<String, AppError>> save({
+    required String businessId,
+    required String productId,
+    required Uint8List bytes,
+  }) async {
+    // (a) Local cache first — always succeeds, gives instant + offline render.
+    try {
+      final path = await _localPath(productId);
+      await File(path).parent.create(recursive: true);
+      await File(path).writeAsBytes(bytes, flush: true);
+    } catch (e) {
+      return Result.err(AppError.io('Could not cache image locally.'));
+    }
+
+    // (b) Upload to Storage. On failure (offline), the local cache still
+    // renders and the product is marked pending so [flushPending] retries it
+    // when connectivity returns.
+    try {
+      final url = await _upload(businessId, productId, bytes);
+      await _unmarkPending(productId);
+      return Result.ok(url);
+    } on StorageException catch (e) {
+      await _markPending(businessId, productId);
+      return Result.err(AppError.network('Storage upload failed: ${e.message}'));
+    } catch (e) {
+      await _markPending(businessId, productId);
+      return Result.err(AppError.unknown(e));
+    }
+  }
+
+  Future<String> _upload(
+    String businessId,
+    String productId,
+    Uint8List bytes,
+  ) async {
+    final objectPath = _objectPath(businessId, productId);
+    await _client.storage.from(_bucket).uploadBinary(
+          objectPath,
+          bytes,
+          fileOptions: const FileOptions(upsert: true, contentType: 'image/png'),
+        );
+    return _client.storage.from(_bucket).getPublicUrl(objectPath);
+  }
+
+  // ── Offline retry ───────────────────────────────────────────────────────────
+
+  /// Uploads any photos saved offline for [businessId] and reports each public
+  /// URL back via [onUploaded] (which writes it onto the product row so it
+  /// syncs). Only entries for [businessId] are handled — the DAO patch is
+  /// business-scoped, so another business's pending uploads wait until it is
+  /// the active one. Failed uploads stay pending for the next reconnect.
+  Future<void> flushPending(
+    String businessId,
+    Future<void> Function(String productId, String url) onUploaded,
+  ) async {
+    final prefs = await SharedPreferences.getInstance();
+    final entries = prefs.getStringList(_pendingKey) ?? const <String>[];
+    if (entries.isEmpty) return;
+
+    final keep = <String>[];
+    for (final entry in entries) {
+      final sep = entry.indexOf('|');
+      if (sep <= 0) continue; // malformed → drop
+      final entryBiz = entry.substring(0, sep);
+      final productId = entry.substring(sep + 1);
+      if (entryBiz != businessId) {
+        keep.add(entry); // not this business — leave for when it's active
+        continue;
+      }
+      final file = File(await _localPath(productId));
+      if (!file.existsSync()) continue; // cache gone → nothing to upload, drop
+      try {
+        final url = await _upload(entryBiz, productId, await file.readAsBytes());
+        await onUploaded(productId, url);
+      } catch (_) {
+        keep.add(entry); // still offline / failed — retry next reconnect
+      }
+    }
+    await prefs.setStringList(_pendingKey, keep);
+  }
+
+  Future<void> _markPending(String businessId, String productId) async {
+    final prefs = await SharedPreferences.getInstance();
+    final entries = (prefs.getStringList(_pendingKey) ?? const <String>[])
+        .where((e) => !e.endsWith('|$productId'))
+        .toList()
+      ..add('$businessId|$productId');
+    await prefs.setStringList(_pendingKey, entries);
+  }
+
+  Future<void> _unmarkPending(String productId) async {
+    final prefs = await SharedPreferences.getInstance();
+    final entries = prefs.getStringList(_pendingKey);
+    if (entries == null || entries.isEmpty) return;
+    final next = entries.where((e) => !e.endsWith('|$productId')).toList();
+    if (next.length != entries.length) {
+      await prefs.setStringList(_pendingKey, next);
+    }
+  }
+
+  // ── Local cache helpers ────────────────────────────────────────────────────
+
+  /// Returns the expected local file path for [productId] — does not check
+  /// whether the file exists.
+  Future<String> localPathFor(String productId) => _localPath(productId);
+
+  /// Returns the local file path if the cached file exists, otherwise null.
+  Future<String?> localPathIfExists(String productId) async {
+    final path = await _localPath(productId);
+    return File(path).existsSync() ? path : null;
+  }
+
+  /// Returns the local file path, downloading from [imageUrl] once if the local
+  /// cache is absent. Returns null if neither the local cache nor the URL
+  /// yields an image (e.g. offline with no cache).
+  Future<String?> ensureCached({
+    required String productId,
+    required String? imageUrl,
+  }) async {
+    final path = await _localPath(productId);
+    if (File(path).existsSync()) return path;
+    if (imageUrl == null || imageUrl.isEmpty) return null;
+
+    try {
+      await File(path).parent.create(recursive: true);
+      final bytes = await _downloadBytes(imageUrl);
+      if (bytes == null) return null;
+      await File(path).writeAsBytes(bytes, flush: true);
+      return path;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  Future<Uint8List?> _downloadBytes(String imageUrl) async {
+    // A public-bucket URL embeds the object path after `/object/public/<bucket>/`.
+    // Prefer the authenticated Storage client so a member can fetch even if the
+    // public URL is unreachable; fall back to null on any failure.
+    const marker = '/object/public/$_bucket/';
+    final idx = imageUrl.indexOf(marker);
+    if (idx == -1) return null;
+    final objectPath = imageUrl.substring(idx + marker.length);
+    try {
+      return await _client.storage.from(_bucket).download(objectPath);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  // ── Clear ──────────────────────────────────────────────────────────────────
+
+  /// Deletes the local cache file and the Storage object.
+  Future<Result<void, AppError>> clear({
+    required String businessId,
+    required String productId,
+  }) async {
+    try {
+      final path = await _localPath(productId);
+      final file = File(path);
+      if (file.existsSync()) await file.delete();
+
+      await _client.storage
+          .from(_bucket)
+          .remove([_objectPath(businessId, productId)]);
+      return Result.ok(null);
+    } on StorageException catch (e) {
+      return Result.err(AppError.network('Storage delete failed: ${e.message}'));
+    } catch (e) {
+      return Result.err(AppError.unknown(e));
+    }
+  }
+
+  // ── Internals ──────────────────────────────────────────────────────────────
+
+  String _objectPath(String businessId, String productId) =>
+      '$businessId/$productId.png';
+
+  Future<String> _localPath(String productId) async {
+    final docs = await getApplicationDocumentsDirectory();
+    return '${docs.path}/product_images/$productId.png';
+  }
+}

--- a/lib/core/services/supabase_sync_service.dart
+++ b/lib/core/services/supabase_sync_service.dart
@@ -331,8 +331,21 @@ class SupabaseSyncService {
   /// transition, if the last pull failed and we have a businessId, kicks
   /// off `pullChanges` once. Single shot, not a retry loop — relying on
   /// the OS-provided connectivity signal instead of polling.
+  /// Wired by the app (app_providers) to run work that was deferred while
+  /// offline — e.g. the product-photo offline upload flush (#78). Fired once on
+  /// each `false → true` connectivity transition.
+  VoidCallback? onReconnected;
+
   void _onOnlineChanged() {
     final nowOnline = isOnline.value;
+    if (!_wasOnline && nowOnline) {
+      // Connectivity recovered: let deferred work (offline photo uploads) retry.
+      try {
+        onReconnected?.call();
+      } catch (e) {
+        debugPrint('[SyncService] onReconnected hook threw: $e');
+      }
+    }
     if (!_wasOnline &&
         nowOnline &&
         pullStatus.value.stage == PullStage.failed &&

--- a/lib/features/inventory/screens/add_product_screen.dart
+++ b/lib/features/inventory/screens/add_product_screen.dart
@@ -4,6 +4,8 @@ import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:reebaplus_pos/core/permissions/permissions.dart';
 import 'package:reebaplus_pos/core/providers/app_providers.dart';
+import 'package:reebaplus_pos/core/result.dart';
+import 'package:reebaplus_pos/features/inventory/widgets/product_photo_field.dart';
 import 'package:reebaplus_pos/core/providers/stream_providers.dart';
 import 'package:reebaplus_pos/core/utils/currency_input_formatter.dart';
 import 'package:reebaplus_pos/core/utils/number_format.dart';
@@ -83,6 +85,10 @@ class _AddProductScreenState extends ConsumerState<AddProductScreen> {
   ProductData? _selectedExistingProduct;
   bool _isSaving = false;
   String? _errorMessage;
+
+  /// Optional product photo picked but not yet saved (#78). Uploaded after the
+  /// new product row is created, in [_persistNewProduct].
+  Uint8List? _pendingImageBytes;
 
   /// Fast-Add: the "More details" section is collapsed by default (ADR 0006).
   bool _showMoreDetails = false;
@@ -981,6 +987,22 @@ class _AddProductScreenState extends ConsumerState<AddProductScreen> {
         );
       }
 
+      // Optional product photo (#78): the row exists now, so upload keyed by its
+      // id and write the URL (which syncs). The service also caches the bytes
+      // locally, so the photo renders offline; if the upload fails (offline) the
+      // reconnect flush patches image_url later.
+      if (_pendingImageBytes != null) {
+        final imgSvc = ref.read(productImageServiceProvider);
+        final res = await imgSvc.save(
+          businessId: businessId,
+          productId: productId,
+          bytes: _pendingImageBytes!,
+        );
+        if (res case Ok(:final value)) {
+          await db.catalogDao.setProductImageUrl(productId, value);
+        }
+      }
+
       final newProduct = await (db.select(
         db.products,
       )..where((t) => t.id.equals(productId))).getSingle();
@@ -1006,6 +1028,22 @@ class _AddProductScreenState extends ConsumerState<AddProductScreen> {
       }
     } finally {
       if (mounted) setState(() => _isSaving = false);
+    }
+  }
+
+  /// Pick + process an optional product photo, held in memory until the product
+  /// is saved (#78). Cancelling or a decode error leaves the current selection.
+  Future<void> _pickPhoto() async {
+    final svc = ref.read(productImageServiceProvider);
+    final result = await svc.pickAndProcess();
+    if (!mounted) return;
+    switch (result) {
+      case Ok(:final value):
+        setState(() => _pendingImageBytes = value);
+      case Err(:final error):
+        if (!error.isCancelled) {
+          AppNotification.showError(context, 'Could not load image.');
+        }
     }
   }
 
@@ -1710,6 +1748,17 @@ class _AddProductScreenState extends ConsumerState<AddProductScreen> {
     required Color border,
   }) {
     return [
+      // ── PHOTO (optional, new products only — edits use Update Product) ───
+      if (_selectedExistingProduct == null && !widget.receiveMode) ...[
+        ProductPhotoField(
+          pendingBytes: _pendingImageBytes,
+          onPick: _pickPhoto,
+          onRemove: _pendingImageBytes == null
+              ? null
+              : () => setState(() => _pendingImageBytes = null),
+        ),
+        const SizedBox(height: 14),
+      ],
       // ── DESCRIPTION (optional) ──────────────────────────────────────────
       AppInput(
         controller: _subtitleCtrl,

--- a/lib/features/inventory/screens/product_detail_screen.dart
+++ b/lib/features/inventory/screens/product_detail_screen.dart
@@ -1617,8 +1617,9 @@ class _ProductDetailScreenState extends ConsumerState<ProductDetailScreen> {
 
     try {
       // Upload (keyed by product id) + local cache; offline it caches locally
-      // and queues for the reconnect flush. The cache path becomes imagePath
-      // (offline render) and the cloud URL is patched to sync cross-device. #78.
+      // and queues for the reconnect flush. The photo lives in image_url + the
+      // ProductImageService cache (never products.image_path, so it stays off
+      // the POS grid); the cache path drives the local preview. #78.
       final res = await imgSvc.save(
         businessId: businessId,
         productId: productId,
@@ -1629,24 +1630,8 @@ class _ProductDetailScreenState extends ConsumerState<ProductDetailScreen> {
       setState(() => _imagePath = localPath);
 
       final db = ref.read(databaseProvider);
-      await db.catalogDao.updateProductDetails(
-        productId,
-        name: _nameController.text.trim(),
-        manufacturerId: _selectedManufacturerId,
-        buyingPriceKobo:
-            ((parseCurrency(_buyingPriceController.text)) * 100).round(),
-        retailerPriceKobo:
-            ((parseCurrency(_retailPriceController.text)) * 100).round(),
-        wholesalerPriceKobo:
-            ((parseCurrency(_wholesalerPriceController.text)) * 100).round(),
-        emptyCrateValueKobo:
-            (parseCurrency(_emptyCrateValueController.text) * 100).toInt(),
-        categoryId: _selectedCategoryId,
-        unit: _selectedUnit,
-        lowStockThreshold: widget.item.lowStockThreshold.toInt(),
-        imagePath: localPath,
-      );
       if (res case Ok(:final value)) {
+        // Persists the URL and enqueues the FULL product row (coalesce-safe).
         await db.catalogDao.setProductImageUrl(productId, value);
       }
 

--- a/lib/features/inventory/screens/product_detail_screen.dart
+++ b/lib/features/inventory/screens/product_detail_screen.dart
@@ -316,7 +316,10 @@ class _ProductDetailScreenState extends ConsumerState<ProductDetailScreen> {
     _trackEmpties = product.trackEmpties;
     _size = product.size;
     _expiryDate = product.expiryDate;
-    _imagePath = product.imagePath;
+    // Only adopt a non-null legacy imagePath — a cross-device photo has its
+    // renderable path resolved via ensureCached (#78), so don't blank it here
+    // when a synced row carries a null/foreign imagePath.
+    if (product.imagePath != null) _imagePath = product.imagePath;
     // Keep the unit dropdown inclusive of a (possibly new) synced unit value.
     if (!_allUnits.contains(product.unit)) {
       _allUnits = ({..._allUnits, product.unit}.toList())..sort();

--- a/lib/features/inventory/screens/product_detail_screen.dart
+++ b/lib/features/inventory/screens/product_detail_screen.dart
@@ -5,9 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
-import 'package:image_picker/image_picker.dart';
-import 'package:path_provider/path_provider.dart';
-import 'package:path/path.dart' as p;
+import 'package:reebaplus_pos/core/result.dart';
 
 import 'package:reebaplus_pos/shared/widgets/auto_lock_wrapper.dart';
 import 'package:reebaplus_pos/core/theme/colors.dart';
@@ -168,6 +166,13 @@ class _ProductDetailScreenState extends ConsumerState<ProductDetailScreen> {
     final manufacturers = await db.inventoryDao.getAllManufacturers();
     final suppliers = await db.catalogDao.getAllSuppliers();
     final uniqueUnits = await db.catalogDao.getUniqueProductUnits();
+    // Resolve a renderable path for the photo — downloads from Storage once if
+    // only the cloud URL is known, so a cross-device photo shows here and
+    // renders offline from the cache. #78.
+    final cachedPhoto = await ref.read(productImageServiceProvider).ensureCached(
+          productId: productId,
+          imageUrl: product?.imageUrl,
+        );
 
     if (mounted) {
       setState(() {
@@ -195,6 +200,7 @@ class _ProductDetailScreenState extends ConsumerState<ProductDetailScreen> {
           _lowStockController.text = product.lowStockThreshold.toString();
           _emptyCrateValueController.text = (product.emptyCrateValueKobo / 100)
               .toStringAsFixed(0);
+          if (cachedPhoto != null) _imagePath = cachedPhoto;
         }
       });
       // Load empty crate stock from manufacturer if linked
@@ -1587,59 +1593,63 @@ class _ProductDetailScreenState extends ConsumerState<ProductDetailScreen> {
     if (!_editMode) return;
 
     AutoLockWrapper.suppressNextResume = true;
-    final picker = ImagePicker();
-    try {
-      final XFile? image = await picker.pickImage(
-        source: ImageSource.gallery,
-        maxWidth: 800,
-        maxHeight: 800,
-        imageQuality: 85,
-      );
+    final imgSvc = ref.read(productImageServiceProvider);
+    final picked = await imgSvc.pickAndProcess();
+    if (!mounted) return;
 
-      if (image == null) return;
-
-      // Save image to app directory for persistence
-      final appDir = await getApplicationDocumentsDirectory();
-      final fileName =
-          'product_${widget.item.id}_${DateTime.now().millisecondsSinceEpoch}${p.extension(image.path)}';
-      final savedImage = await File(
-        image.path,
-      ).copy('${appDir.path}/$fileName');
-
-      setState(() {
-        _imagePath = savedImage.path;
-      });
-
-      // Update in DB
-      final productId = widget.item.id;
-      if (productId.isNotEmpty) {
-        await ref
-            .read(databaseProvider)
-            .catalogDao
-            .updateProductDetails(
-              productId,
-              name: _nameController.text.trim(),
-              manufacturerId: _selectedManufacturerId,
-              buyingPriceKobo:
-                  ((parseCurrency(_buyingPriceController.text)) * 100).round(),
-              retailerPriceKobo:
-                  ((parseCurrency(_retailPriceController.text)) * 100).round(),
-              wholesalerPriceKobo:
-                  ((parseCurrency(_wholesalerPriceController.text)) * 100)
-                      .round(),
-              emptyCrateValueKobo:
-                  (parseCurrency(_emptyCrateValueController.text) * 100)
-                      .toInt(),
-              categoryId: _selectedCategoryId,
-              unit: _selectedUnit,
-              lowStockThreshold: widget.item.lowStockThreshold.toInt(),
-              imagePath: _imagePath,
-            );
-
-        if (mounted) {
-          AppNotification.showSuccess(context, 'Product image updated');
-          widget.onUpdateStock(); // Refresh parent view
+    final Uint8List bytes;
+    switch (picked) {
+      case Ok(:final value):
+        bytes = value;
+      case Err(:final error):
+        if (!error.isCancelled) {
+          AppNotification.showError(context, 'Could not load image.');
         }
+        return;
+    }
+
+    final productId = widget.item.id;
+    final businessId = ref.read(authProvider).currentUser?.businessId;
+    if (productId.isEmpty || businessId == null) return;
+
+    try {
+      // Upload (keyed by product id) + local cache; offline it caches locally
+      // and queues for the reconnect flush. The cache path becomes imagePath
+      // (offline render) and the cloud URL is patched to sync cross-device. #78.
+      final res = await imgSvc.save(
+        businessId: businessId,
+        productId: productId,
+        bytes: bytes,
+      );
+      final localPath = await imgSvc.localPathFor(productId);
+      if (!mounted) return;
+      setState(() => _imagePath = localPath);
+
+      final db = ref.read(databaseProvider);
+      await db.catalogDao.updateProductDetails(
+        productId,
+        name: _nameController.text.trim(),
+        manufacturerId: _selectedManufacturerId,
+        buyingPriceKobo:
+            ((parseCurrency(_buyingPriceController.text)) * 100).round(),
+        retailerPriceKobo:
+            ((parseCurrency(_retailPriceController.text)) * 100).round(),
+        wholesalerPriceKobo:
+            ((parseCurrency(_wholesalerPriceController.text)) * 100).round(),
+        emptyCrateValueKobo:
+            (parseCurrency(_emptyCrateValueController.text) * 100).toInt(),
+        categoryId: _selectedCategoryId,
+        unit: _selectedUnit,
+        lowStockThreshold: widget.item.lowStockThreshold.toInt(),
+        imagePath: localPath,
+      );
+      if (res case Ok(:final value)) {
+        await db.catalogDao.setProductImageUrl(productId, value);
+      }
+
+      if (mounted) {
+        AppNotification.showSuccess(context, 'Product image updated');
+        widget.onUpdateStock(); // Refresh parent view
       }
     } catch (e, st) {
       CrashReporter.record(
@@ -1648,7 +1658,7 @@ class _ProductDetailScreenState extends ConsumerState<ProductDetailScreen> {
         context: 'inventory.product_detail.update_image',
       );
       if (mounted) {
-        AppNotification.showError(context, 'Failed to pick image: $e');
+        AppNotification.showError(context, 'Failed to update image: $e');
       }
     }
   }

--- a/lib/features/inventory/widgets/product_photo_field.dart
+++ b/lib/features/inventory/widgets/product_photo_field.dart
@@ -1,0 +1,136 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+
+import 'package:reebaplus_pos/core/utils/responsive.dart';
+
+/// The one product-photo picker shared by Add Product and Update Product (#78,
+/// PRD #76) — a tappable square that shows, in priority order, a freshly picked
+/// image ([pendingBytes]), the cached local file ([existingPath]), or a clean
+/// "Add photo" placeholder. The photo is optional, so a photo-less product
+/// always renders the placeholder and never blocks saving.
+///
+/// Pure presentation: the owning screen holds the picked bytes / cached path
+/// and does the upload on save (via ProductImageService). Mirrors the design
+/// system idiom of `_LogoSection` (business_info_screen) — every size via
+/// `context.getRSize`, every font via `context.getRFontSize`, colours resolved
+/// through the theme so it stays responsive and theme-aware.
+class ProductPhotoField extends StatelessWidget {
+  const ProductPhotoField({
+    super.key,
+    this.pendingBytes,
+    this.existingPath,
+    required this.onPick,
+    this.onRemove,
+  });
+
+  /// A freshly picked image not yet saved — takes precedence over [existingPath].
+  final Uint8List? pendingBytes;
+
+  /// Path to the cached local file for an already-saved photo (edit flow).
+  final String? existingPath;
+
+  /// Open the picker.
+  final VoidCallback onPick;
+
+  /// Clear the current photo. Null hides the remove affordance.
+  final VoidCallback? onRemove;
+
+  bool get _hasImage =>
+      pendingBytes != null ||
+      (existingPath != null && File(existingPath!).existsSync());
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final box = context.getRSize(80);
+
+    Widget preview;
+    if (pendingBytes != null) {
+      preview =
+          Image.memory(pendingBytes!, width: box, height: box, fit: BoxFit.cover);
+    } else if (existingPath != null && File(existingPath!).existsSync()) {
+      preview = Image.file(
+        File(existingPath!),
+        width: box,
+        height: box,
+        fit: BoxFit.cover,
+      );
+    } else {
+      preview = Icon(
+        FontAwesomeIcons.image.data,
+        size: context.getRSize(26),
+        color: theme.colorScheme.onSurface.withValues(alpha: 0.4),
+      );
+    }
+
+    return Row(
+      children: [
+        Container(
+          width: box,
+          height: box,
+          alignment: Alignment.center,
+          clipBehavior: Clip.antiAlias,
+          decoration: BoxDecoration(
+            color: theme.colorScheme.surface,
+            borderRadius: BorderRadius.circular(14),
+            border: Border.all(color: theme.dividerColor),
+          ),
+          child: preview,
+        ),
+        SizedBox(width: context.getRSize(16)),
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              GestureDetector(
+                onTap: onPick,
+                child: Container(
+                  padding: EdgeInsets.symmetric(
+                    horizontal: context.getRSize(16),
+                    vertical: context.getRSize(10),
+                  ),
+                  decoration: BoxDecoration(
+                    color: theme.colorScheme.primary.withValues(alpha: 0.12),
+                    borderRadius: BorderRadius.circular(12),
+                  ),
+                  child: Text(
+                    _hasImage ? 'Change photo' : 'Add photo',
+                    style: TextStyle(
+                      color: theme.colorScheme.primary,
+                      fontWeight: FontWeight.w600,
+                      fontSize: context.getRFontSize(14),
+                    ),
+                  ),
+                ),
+              ),
+              if (_hasImage && onRemove != null) ...[
+                SizedBox(height: context.getRSize(8)),
+                GestureDetector(
+                  onTap: onRemove,
+                  child: Text(
+                    'Remove photo',
+                    style: TextStyle(
+                      color: theme.colorScheme.error,
+                      fontSize: context.getRFontSize(13),
+                    ),
+                  ),
+                ),
+              ],
+              SizedBox(height: context.getRSize(6)),
+              Text(
+                'Optional — shown on the product’s details.',
+                style: TextStyle(
+                  color: theme.colorScheme.onSurface.withValues(alpha: 0.5),
+                  fontSize: context.getRFontSize(11),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/inventory/widgets/product_photo_field.dart
+++ b/lib/features/inventory/widgets/product_photo_field.dart
@@ -98,11 +98,8 @@ class ProductPhotoField extends StatelessWidget {
                   ),
                   child: Text(
                     _hasImage ? 'Change photo' : 'Add photo',
-                    style: TextStyle(
-                      color: theme.colorScheme.primary,
-                      fontWeight: FontWeight.w600,
-                      fontSize: context.getRFontSize(14),
-                    ),
+                    style: theme.textTheme.labelLarge
+                        ?.copyWith(color: theme.colorScheme.primary),
                   ),
                 ),
               ),
@@ -112,19 +109,16 @@ class ProductPhotoField extends StatelessWidget {
                   onTap: onRemove,
                   child: Text(
                     'Remove photo',
-                    style: TextStyle(
-                      color: theme.colorScheme.error,
-                      fontSize: context.getRFontSize(13),
-                    ),
+                    style: theme.textTheme.titleSmall
+                        ?.copyWith(color: theme.colorScheme.error),
                   ),
                 ),
               ],
               SizedBox(height: context.getRSize(6)),
               Text(
                 'Optional — shown on the product’s details.',
-                style: TextStyle(
+                style: theme.textTheme.labelSmall?.copyWith(
                   color: theme.colorScheme.onSurface.withValues(alpha: 0.5),
-                  fontSize: context.getRFontSize(11),
                 ),
               ),
             ],

--- a/lib/features/inventory/widgets/update_product_sheet.dart
+++ b/lib/features/inventory/widgets/update_product_sheet.dart
@@ -504,11 +504,11 @@ class _UpdateProductSheetState extends ConsumerState<UpdateProductSheet> {
       final buyingKobo = (buyingPrice * 100).round();
       final lowStock = int.tryParse(_lowStockCtrl.text) ?? 5;
 
-      // Optional product photo (#78): upload a freshly picked image (keyed by
-      // the product id) BEFORE the details write, so the local cache path
-      // becomes the product's imagePath and renders offline; the cloud URL is
-      // patched after (it also syncs cross-device). Offline, save() caches
-      // locally + marks the product pending so the reconnect flush uploads later.
+      // Optional product photo (#78): upload a freshly picked image, keyed by
+      // the product id. The photo lives in image_url + the ProductImageService
+      // cache (never products.image_path, so it stays off the POS grid); the
+      // cache path drives the local preview here. Offline, save() caches locally
+      // + marks the product pending so the reconnect flush uploads it later.
       String? newImageUrl;
       if (_pendingImageBytes != null) {
         final businessId = auth.currentUser?.businessId;
@@ -537,7 +537,6 @@ class _UpdateProductSheetState extends ConsumerState<UpdateProductSheet> {
         unit: _unit,
         trackEmpties: _effectiveTrackEmpties,
         allowFractionalSales: _allowFractionalSales,
-        imagePath: _imagePath,
         lowStockThreshold: lowStock,
         subtitle: _subtitleCtrl.text.trim().isEmpty
             ? null

--- a/lib/features/inventory/widgets/update_product_sheet.dart
+++ b/lib/features/inventory/widgets/update_product_sheet.dart
@@ -3,10 +3,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
-import 'package:image_picker/image_picker.dart';
-import 'package:path_provider/path_provider.dart';
-import 'package:path/path.dart' as p;
 import 'package:reebaplus_pos/core/providers/app_providers.dart';
+import 'package:reebaplus_pos/core/result.dart';
 import 'package:reebaplus_pos/core/providers/stream_providers.dart';
 import 'package:reebaplus_pos/core/utils/currency_input_formatter.dart';
 import 'package:reebaplus_pos/core/utils/number_format.dart';
@@ -76,7 +74,11 @@ class _UpdateProductSheetState extends ConsumerState<UpdateProductSheet> {
 
   bool _isSaving = false;
   String? _errorMessage;
+  // Renderable local path of the current photo (legacy local file or the
+  // ProductImageService cache for a cross-device photo). [_pendingImageBytes]
+  // holds a freshly picked image not yet saved (#78).
   String? _imagePath;
+  Uint8List? _pendingImageBytes;
 
   static const _units = ['Crate', 'Bottle', 'Pack', 'Carton', 'Keg', 'Can'];
   List<String> _dynamicUnits = _units;
@@ -177,6 +179,13 @@ class _UpdateProductSheetState extends ConsumerState<UpdateProductSheet> {
     final manufacturers = await db.inventoryDao.getAllManufacturers();
     final cats = await db.inventoryDao.getAllCategories();
     final uniqueUnits = await db.catalogDao.getUniqueProductUnits();
+    // Resolve a renderable path for an existing photo (downloads from Storage
+    // once if only the cloud URL is known), so a cross-device photo shows in
+    // the edit preview. #78.
+    final cachedPhoto = await ref.read(productImageServiceProvider).ensureCached(
+          productId: widget.product.id,
+          imageUrl: widget.product.imageUrl,
+        );
 
     if (!mounted) return;
     setState(() {
@@ -186,6 +195,7 @@ class _UpdateProductSheetState extends ConsumerState<UpdateProductSheet> {
       _allCategories = cats;
       _dynamicUnits = <String>{..._units, _unit, ...uniqueUnits}.toList()
         ..sort();
+      if (cachedPhoto != null) _imagePath = cachedPhoto;
 
       // Pre-select store: prefer currentStoreId, else first
       if (widget.currentStoreId != null) {
@@ -388,29 +398,16 @@ class _UpdateProductSheetState extends ConsumerState<UpdateProductSheet> {
 
   Future<void> _pickImage() async {
     AutoLockWrapper.suppressNextResume = true;
-    final picker = ImagePicker();
-    try {
-      final XFile? image = await picker.pickImage(
-        source: ImageSource.gallery,
-        maxWidth: 800,
-        maxHeight: 800,
-        imageQuality: 85,
-      );
-
-      if (image == null) return;
-
-      final appDir = await getApplicationDocumentsDirectory();
-      final fileName =
-          'product_${widget.product.id}_${DateTime.now().millisecondsSinceEpoch}${p.extension(image.path)}';
-      final savedImage = await File(
-        image.path,
-      ).copy('${appDir.path}/$fileName');
-
-      setState(() {
-        _imagePath = savedImage.path;
-      });
-    } catch (e) {
-      setState(() => _errorMessage = 'Failed to pick image: $e');
+    final svc = ref.read(productImageServiceProvider);
+    final result = await svc.pickAndProcess();
+    if (!mounted) return;
+    switch (result) {
+      case Ok(:final value):
+        setState(() => _pendingImageBytes = value);
+      case Err(:final error):
+        if (!error.isCancelled) {
+          setState(() => _errorMessage = 'Could not load image.');
+        }
     }
   }
 
@@ -507,6 +504,26 @@ class _UpdateProductSheetState extends ConsumerState<UpdateProductSheet> {
       final buyingKobo = (buyingPrice * 100).round();
       final lowStock = int.tryParse(_lowStockCtrl.text) ?? 5;
 
+      // Optional product photo (#78): upload a freshly picked image (keyed by
+      // the product id) BEFORE the details write, so the local cache path
+      // becomes the product's imagePath and renders offline; the cloud URL is
+      // patched after (it also syncs cross-device). Offline, save() caches
+      // locally + marks the product pending so the reconnect flush uploads later.
+      String? newImageUrl;
+      if (_pendingImageBytes != null) {
+        final businessId = auth.currentUser?.businessId;
+        if (businessId != null) {
+          final imgSvc = ref.read(productImageServiceProvider);
+          final res = await imgSvc.save(
+            businessId: businessId,
+            productId: widget.product.id,
+            bytes: _pendingImageBytes!,
+          );
+          _imagePath = await imgSvc.localPathFor(widget.product.id);
+          if (res case Ok(:final value)) newImageUrl = value;
+        }
+      }
+
       // 1. Update product (core + cosmetic fields in one enqueue).
       await db.catalogDao.updateProductDetails(
         widget.product.id,
@@ -530,6 +547,12 @@ class _UpdateProductSheetState extends ConsumerState<UpdateProductSheet> {
         size: _size,
         expiryDate: _expiryDate,
       );
+
+      // Patch the cloud image URL (separate minimal upsert) so the photo
+      // converges cross-device. Null when offline — the reconnect flush sets it.
+      if (newImageUrl != null) {
+        await db.catalogDao.setProductImageUrl(widget.product.id, newImageUrl);
+      }
 
       // 2. Persist the crate value at the manufacturer level so every product
       //    of this manufacturer shares one value (§16.5).
@@ -732,19 +755,28 @@ class _UpdateProductSheetState extends ConsumerState<UpdateProductSheet> {
                               ).colorScheme.primary.withValues(alpha: 0.2),
                             ),
                           ),
-                          child: _imagePath != null
+                          child: _pendingImageBytes != null
                               ? ClipRRect(
                                   borderRadius: BorderRadius.circular(11),
-                                  child: Image.file(
-                                    File(_imagePath!),
+                                  child: Image.memory(
+                                    _pendingImageBytes!,
                                     fit: BoxFit.cover,
                                   ),
                                 )
-                              : Icon(
-                                  FontAwesomeIcons.image.data,
-                                  color: Theme.of(context).colorScheme.primary,
-                                  size: 18,
-                                ),
+                              : _imagePath != null
+                                  ? ClipRRect(
+                                      borderRadius: BorderRadius.circular(11),
+                                      child: Image.file(
+                                        File(_imagePath!),
+                                        fit: BoxFit.cover,
+                                      ),
+                                    )
+                                  : Icon(
+                                      FontAwesomeIcons.image.data,
+                                      color:
+                                          Theme.of(context).colorScheme.primary,
+                                      size: 18,
+                                    ),
                         ),
                         Positioned(
                           right: -2,

--- a/supabase/migrations/0143_product_image_url.sql
+++ b/supabase/migrations/0143_product_image_url.sql
@@ -1,0 +1,21 @@
+-- 0143_product_image_url.sql
+--
+-- #78 / PRD #76 — optional synced product photo.
+--
+-- Adds products.image_url: the public URL of a product's photo in the
+-- `product-images` Storage bucket. The client uploads the picked image, then
+-- writes this URL onto the product row, which converges cross-device through
+-- the normal outbox → upsert → pull path (products is a pass-through push
+-- table, so no RPC or whitelist change is needed — the column rides sync as
+-- soon as it exists on both sides).
+--
+-- Nullable and additive: photo-less products stay NULL, existing rows are
+-- untouched. The existing local `image_path` column is unchanged (it keeps
+-- serving offline render on the device that added the image).
+--
+-- Deploy-ordering: this must land on the cloud BEFORE any client on Drift
+-- schema v59 pushes a product upsert carrying image_url, or the upsert would
+-- reference an unknown column and jam the outbox.
+
+ALTER TABLE public.products
+  ADD COLUMN IF NOT EXISTS image_url text;

--- a/supabase/migrations/0144_product_images_bucket.sql
+++ b/supabase/migrations/0144_product_images_bucket.sql
@@ -1,0 +1,55 @@
+-- 0144_product_images_bucket.sql
+--
+-- #78 / PRD #76 — Storage bucket for the optional synced product photo.
+--
+-- ProductImageService uploads a product's picked image here and writes the
+-- resulting public URL onto products.image_url (0143), which converges
+-- cross-device via the normal sync path. Reuses the BusinessLogoService
+-- pattern (public bucket + local file cache), but business-scopes the object
+-- path so writes are gated by RLS.
+--
+-- Path scheme: <businessId>/<productId>.png — the first folder segment is the
+-- owning business, checked against current_user_business_ids(). Public read so
+-- getPublicUrl renders on every device (and offline from the local cache);
+-- writes restricted to authenticated members of that business.
+--
+-- Idempotent (ON CONFLICT / DROP POLICY IF EXISTS) so it is safe to re-run.
+
+insert into storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+values (
+  'product-images', 'product-images', true, 5242880,
+  array['image/png','image/jpeg','image/jpg','image/webp','image/heic','image/heif']
+)
+on conflict (id) do nothing;
+
+drop policy if exists "product_images_read" on storage.objects;
+create policy "product_images_read" on storage.objects
+  for select using (bucket_id = 'product-images');
+
+drop policy if exists "product_images_insert" on storage.objects;
+create policy "product_images_insert" on storage.objects
+  for insert to authenticated
+  with check (
+    bucket_id = 'product-images'
+    and ((storage.foldername(name))[1])::uuid in (select current_user_business_ids())
+  );
+
+drop policy if exists "product_images_update" on storage.objects;
+create policy "product_images_update" on storage.objects
+  for update to authenticated
+  using (
+    bucket_id = 'product-images'
+    and ((storage.foldername(name))[1])::uuid in (select current_user_business_ids())
+  )
+  with check (
+    bucket_id = 'product-images'
+    and ((storage.foldername(name))[1])::uuid in (select current_user_business_ids())
+  );
+
+drop policy if exists "product_images_delete" on storage.objects;
+create policy "product_images_delete" on storage.objects
+  for delete to authenticated
+  using (
+    bucket_id = 'product-images'
+    and ((storage.foldername(name))[1])::uuid in (select current_user_business_ids())
+  );

--- a/test/sync/product_image_url_sync_test.dart
+++ b/test/sync/product_image_url_sync_test.dart
@@ -55,4 +55,46 @@ void main() {
       await boot.db.close();
     }
   });
+
+  test('patching the photo after a details edit keeps the edit (coalesce-safe)',
+      () async {
+    // The outbox keeps ONE pending row per (action_type, id): a details edit
+    // then a photo patch both enqueue a products upsert for the same id and
+    // coalesce. setProductImageUrl must enqueue the FULL row so the coalesced
+    // payload carries BOTH the edited name AND image_url — a partial
+    // {id, image_url} upsert would replace the edit and silently drop it.
+    final boot = await bootstrapTestDb();
+    try {
+      final id = UuidV7.generate();
+      await boot.db.into(boot.db.products).insert(
+            ProductsCompanion.insert(
+              id: Value(id),
+              businessId: boot.businessId,
+              name: 'Old name',
+            ),
+          );
+
+      await boot.db.catalogDao.updateProductDetails(
+        id,
+        name: 'New name',
+        buyingPriceKobo: 100,
+        retailerPriceKobo: 200,
+        wholesalerPriceKobo: 150,
+      );
+      await boot.db.catalogDao.setProductImageUrl(id, 'https://x/p.png');
+
+      final products = (await getPendingQueue(boot.db))
+          .where((q) =>
+              q.actionType.startsWith('products') &&
+              (jsonDecode(q.payload) as Map)['id'] == id)
+          .toList();
+      expect(products, hasLength(1), reason: 'coalesced to one products upsert');
+      final payload = jsonDecode(products.single.payload) as Map<String, dynamic>;
+      expect(payload['name'], 'New name',
+          reason: 'the details edit must survive the photo patch');
+      expect(payload['image_url'], 'https://x/p.png');
+    } finally {
+      await boot.db.close();
+    }
+  });
 }

--- a/test/sync/product_image_url_sync_test.dart
+++ b/test/sync/product_image_url_sync_test.dart
@@ -1,0 +1,58 @@
+// Product photo — the URL write rides the sync path (#78, PRD #76).
+//
+// The photo bytes live in Storage + a local cache; only products.image_url
+// crosses devices. This is the locked DAO/sync seam for that field: writing the
+// URL via CatalogDao.setProductImageUrl must (a) persist it on the local row and
+// (b) enqueue a products upsert whose snake_case payload carries `image_url`, so
+// peers converge through the normal outbox → upsert → pull path (products is a
+// pass-through push table). The pull side rides the generic ProductData restore
+// already covered for every product column, so it needs no separate test.
+
+import 'dart:convert';
+
+import 'package:drift/drift.dart' show Value;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reebaplus_pos/core/database/app_database.dart';
+import 'package:reebaplus_pos/core/database/uuid_v7.dart';
+
+import '../helpers/dispatch_test_utils.dart';
+
+void main() {
+  test('setProductImageUrl persists the URL and enqueues it for sync', () async {
+    final boot = await bootstrapTestDb();
+    try {
+      final id = UuidV7.generate();
+      await boot.db.into(boot.db.products).insert(
+            ProductsCompanion.insert(
+              id: Value(id),
+              businessId: boot.businessId,
+              name: 'Widget',
+            ),
+          );
+
+      // A product with no photo starts null (optional — save is never blocked).
+      final before = await boot.db.catalogDao.findById(id);
+      expect(before!.imageUrl, isNull);
+
+      const url =
+          'https://x.supabase.co/storage/v1/object/public/product-images/b/p.png';
+      await boot.db.catalogDao.setProductImageUrl(id, url);
+
+      // (a) Local row carries the URL (renders on this device immediately).
+      final after = await boot.db.catalogDao.findById(id);
+      expect(after!.imageUrl, url);
+
+      // (b) An outbox products upsert carries image_url so peers converge.
+      final pending = await getPendingQueue(boot.db);
+      final carrying = pending.where((q) {
+        if (!q.actionType.startsWith('products')) return false;
+        final p = jsonDecode(q.payload) as Map<String, dynamic>;
+        return p['id'] == id && p['image_url'] == url;
+      });
+      expect(carrying, isNotEmpty,
+          reason: 'a products upsert must push image_url cross-device');
+    } finally {
+      await boot.db.close();
+    }
+  });
+}


### PR DESCRIPTION
Closes okworemmanuelc/Reebaplus_POS#78 — the optional synced product photo (PRD okworemmanuelc/Reebaplus_POS#76, ADR 0015). Independent slice; runs in parallel with the industry chain (#77/#79/#80/#81).

## What this does
Owners attach an optional photo to a product on Add / Update Product; it uploads to Storage, its URL syncs onto the product so every device shows it, a local cache renders it instantly and offline, and skipping it never blocks a save.

## How
- **Data layer.** Drift **v58→v59** `products.image_url` (nullable, idempotent onUpgrade). Cloud migration **0143** — additive `ADD COLUMN`; `products` is a pass-through push table, so the column rides the normal outbox→upsert→pull path with **no RPC/whitelist change** (dodges the [param-add overload trap](../../)). `CatalogDao.setProductImageUrl` writes `image_url` and enqueues the **full** product row.
- **Service + storage.** `ProductImageService` mirrors `BusinessLogoService`: pick+resize, upload to the **product-images** bucket at `<businessId>/<productId>.png`, local file cache, and a SharedPreferences pending set so a photo saved offline auto-uploads when connectivity returns (new `SupabaseSyncService.onReconnected` hook, business-scoped). Cloud migration **0144** creates the public bucket + business-scoped storage RLS (writes gated on `current_user_business_ids()` via the first path segment).
- **UI.** `ProductPhotoField` — a shared, responsive, theme-aware picker (mirrors `_LogoSection`'s design-system idiom: `context.getRSize`/theme `textTheme`/theme colours, no hardcoded values) on Add Product. The Update Product sheet + Product detail screen route their pickers through `ProductImageService` and resolve a renderable path via `ensureCached`.
- **Exclusions honoured:** photo stays **off the POS grid** (it lives in `image_url` + the local cache, never `products.image_path` which the grid renders) and **off receipts**; one photo per product; photo-less products render a clean placeholder.

## Cloud (applied)
Migrations **0143** + **0144** applied to the project via MCP `apply_migration`. `products.image_url` present; `product-images` bucket public with 4 storage policies. (The project's recorded migration versions already diverge — `0140/0141` are timestamped on the cloud — so a blind `db push` was avoided.)

## Tests
`test/sync/product_image_url_sync_test.dart`: (a) `setProductImageUrl` persists locally + enqueues an `image_url`-bearing products upsert; (b) **coalesce-safety** — a details edit followed by a photo patch keeps the edit (the outbox coalesces one row per `(action_type, id)`; the full-row enqueue prevents the partial upsert from dropping concurrent edits). Pull side rides the generic `ProductData` restore already covered for every column.

## Verification
- `flutter analyze` → clean project-wide.
- `flutter test test/sync test/inventory test/crates test/database test/dashboard` → green.
- `flutter run` on the Android emulator → built + booted; log shows `onUpgrade: v58 → v59` on the populated device DB with no runtime errors.

## Two-axis code review applied
Fixed two confirmed findings before this PR: **(1)** the outbox-coalesce data-loss (partial `image_url` upsert clobbering a same-save details edit) → `setProductImageUrl` now enqueues the full row; **(2)** the photo appearing on the POS grid → stopped writing the cache path to `products.image_path`.

## Notes for the reviewer/merger
- **Migration ordering:** `0142` belongs to the unmerged web-pos **#56** branch (cloud-only). `0143`/`0144` are collision-free but leave a `0142` gap on main until okworemmanuelc/reebaplus-web#54 lands — reconcile deploy order at merge (or a one-line repair).
- The **`business-logos` bucket was never created** on this project — the business-logo cloud upload has been a silent no-op (local cache only). `product-images` is created here fresh; worth back-filling `business-logos` separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional product photos for inventory items, including add/change/remove photo actions.
  * Product images now sync to the cloud and can be restored across devices, including after going offline.
  * New product photos are supported during both product creation and editing.

* **Bug Fixes**
  * Improved photo loading so existing images continue to display correctly after reconnecting or switching devices.
  * Updated save behavior so photo changes no longer overwrite other recent product edits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->