### PR TITLE
feat(onboarding): enable all nine industries at signup (#79)

### DIFF
--- a/BUILD_LOG.md
+++ b/BUILD_LOG.md
@@ -2,6 +2,43 @@
 
 ---
 
+## 2026-07-07 — Enable all nine industries at onboarding (issue #79, PRD #76)
+
+**What changed.** Unlock every industry at signup — the existing seven plus new
+**Phone & Gadgets** and **Frozen Foods & Grocery** (nine total), all selectable.
+
+- **Registry-only change (the #77 prefactor paid off).** Added `phoneAndGadgets`
+  (icon `smartphone_rounded`) and `frozenFoodsAndGrocery` (icon `ac_unit_rounded`)
+  to the `Industry` enum, and flipped `comingSoon` off for all (made `false` the
+  constructor default, dropped the now-redundant explicit flags). The CEO Sign Up
+  picker and the Settings → Business Info dropdown already render from
+  `Industry.catalogue`, so **no UI code changed** — all nine now appear and are
+  selectable automatically, and the greyed-out "coming soon" state is gone.
+- **Crate opt-in unchanged.** "Track empty crates" still gates on
+  `isCrateBusiness` (Bar/Beverage only) — the two new industries never show it.
+- **Onboarding stores the canonical label** (unchanged path); the two new labels
+  equal their DB canonical (no `'Beer distributor'`-style mapping needed).
+- **Industry editable in Settings, data preserved** — switching only rewrites
+  `businesses.type`; product/stock/history rows are untouched (unchanged path).
+- `comingSoon` is retained in the registry per PRD #76 (for a future gated
+  industry) with a documented unused-parameter suppression, since no entry sets
+  it after the unlock.
+
+**Files changed:** `lib/core/industry/industry.dart`,
+`test/industry/industry_registry_test.dart` (catalogue → nine, all-selectable
+assertion, golden updated + two resolution cases).
+
+**Verification.**
+- `flutter analyze` → clean project-wide.
+- `flutter test test/industry` → 13/13 (resolution incl. the two new labels,
+  membership = nine in plan order, all selectable, crate-gate unchanged, golden).
+  Ran `test/auth test/settings test/crates test/providers` → green except the
+  known pre-existing flaky `who_is_working_screen_test.dart` (fails on pristine
+  main, unrelated).
+- `flutter run` on the Android emulator → built + booted cleanly.
+
+---
+
 ## 2026-07-07 — Optional synced product photo (issue #78, PRD #76)
 
 **What changed.** Owners can attach an optional photo to a product on Add /

--- a/CONTEXT/progress-tracker.md
+++ b/CONTEXT/progress-tracker.md
@@ -10,6 +10,24 @@ The human updates it when resolving open questions or making architectural decis
 
 152 sessions logged. Codebase is live and being verified on-device.
 
+### Multi-industry onboarding & app morphing (PRD #76, ADR 0015) — in progress
+Slices: **#77** registry foundation → **#79** enable all nine → **#80** Lexicon on
+product forms → **#81** Lexicon on POS/inventory/guides; **#78** synced product
+photo (independent). Status:
+- ✅ **#77 registry foundation — SHIPPED** (PR #82 merged). One `Industry` enum
+  is the single source of truth; `industryOf()` total normalizer; `isCrateBusiness`
+  a registry shim. Pure prefactor.
+- ✅ **#78 synced product photo — SHIPPED** (PR #83 merged). See entry below.
+- ✅ **#79 enable all nine — IN REVIEW** (branch `feat/enable-all-industries`).
+  Added **Phone & Gadgets** + **Frozen Foods & Grocery** to the registry and
+  flipped every `comingSoon` off. Because onboarding + Settings render from
+  `Industry.catalogue` (the #77 prefactor), no UI code changed — all nine are now
+  selectable, crate opt-in still Bar/Beverage-only, industry editable in Settings
+  with data preserved. 13 registry tests green (catalogue → nine, all selectable,
+  golden updated); analyze clean; boots on emulator.
+- ⏭ **#80 Lexicon on product forms** — next, blocked by #79 (needs it on main).
+- ⏭ **#81 Lexicon on POS/inventory/guides** — blocked by #80.
+
 ### IN REVIEW: Optional synced product photo (issue #78, PRD #76 / ADR 0015)
 Branch `feat/product-photo-sync` (off main; independent slice of the
 multi-industry epic — no blocker). Owners attach an optional product photo on

--- a/lib/core/industry/industry.dart
+++ b/lib/core/industry/industry.dart
@@ -58,9 +58,8 @@ enum Industry {
   const Industry({
     required this.label,
     required this.icon,
-    // Retained per PRD #76 (registry carries a coming-soon flag) for a future
-    // gated industry; uniformly false after the #79 unlock, so no entry sets it
-    // today — hence the unused-parameter suppression.
+    // No entry sets this after the #79 unlock (see the [comingSoon] field doc),
+    // hence the suppression.
     // ignore: unused_element_parameter
     this.comingSoon = false,
     this.crateEligible = false,

--- a/lib/core/industry/industry.dart
+++ b/lib/core/industry/industry.dart
@@ -24,13 +24,12 @@ enum Industry {
   supermarket(label: 'Supermarket', icon: Icons.local_grocery_store_rounded),
   bar(label: 'Bar', icon: Icons.local_bar_rounded, crateEligible: true),
 
-  /// The one industry live today. The DB stores the legacy canonical string
-  /// `'Beer distributor'` for these tenants (mapped to this display label at
-  /// load/save), so [aliases] carries it for resolution.
+  /// The one industry that was live before the multi-industry unlock (#79). The
+  /// DB stores the legacy canonical `'Beer distributor'` for these tenants
+  /// (mapped to this display label at load/save), so [aliases] carries it.
   beverage(
     label: 'Beverage distributor',
     icon: Icons.sports_bar_rounded,
-    comingSoon: false,
     crateEligible: true,
     aliases: {'beer distributor'},
   ),
@@ -38,20 +37,32 @@ enum Industry {
   buildingMaterials(label: 'Building Materials', icon: Icons.foundation_rounded),
   boutique(label: 'Boutique', icon: Icons.checkroom_rounded),
 
+  /// New in the multi-industry unlock (#79). No crate features (bottle/crate
+  /// tracking stays Bar/Beverage-only); deeper serial/IMEI capture is a later,
+  /// separately-flagged slice (ADR 0015).
+  phoneAndGadgets(label: 'Phone & Gadgets', icon: Icons.smartphone_rounded),
+
+  /// New in the multi-industry unlock (#79). No crate features; cold-chain /
+  /// expiry emphasis is a later per-industry slice (ADR 0015).
+  frozenFoodsAndGrocery(
+    label: 'Frozen Foods & Grocery',
+    icon: Icons.ac_unit_rounded,
+  ),
+
   /// Safe fallback for an unknown, legacy, or null `businesses.type`. Never
   /// offered in a picker (excluded from [catalogue]); it exists so [industryOf]
   /// is total and the interior falls back to neutral words and no
   /// industry-only features.
-  generic(
-    label: 'Business',
-    icon: Icons.storefront_rounded,
-    comingSoon: false,
-  );
+  generic(label: 'Business', icon: Icons.storefront_rounded);
 
   const Industry({
     required this.label,
     required this.icon,
-    this.comingSoon = true,
+    // Retained per PRD #76 (registry carries a coming-soon flag) for a future
+    // gated industry; uniformly false after the #79 unlock, so no entry sets it
+    // today — hence the unused-parameter suppression.
+    // ignore: unused_element_parameter
+    this.comingSoon = false,
     this.crateEligible = false,
     this.aliases = const <String>{},
   });
@@ -63,8 +74,9 @@ enum Industry {
   /// Icon shown beside the label in the onboarding picker.
   final IconData icon;
 
-  /// Whether this industry is greyed-out as "coming soon" at onboarding. #77
-  /// preserves today's set (only [beverage] selectable); #79 flips all off.
+  /// Whether this industry is greyed-out as "coming soon" at onboarding. All
+  /// nine are unlocked (#79), so this is uniformly false today; the flag stays
+  /// in the registry (PRD #76) so a future industry can ship gated.
   final bool comingSoon;
 
   /// Whether this industry uses the empty-crate features (Bar / Beverage only).

--- a/test/industry/industry_registry_test.dart
+++ b/test/industry/industry_registry_test.dart
@@ -1,14 +1,13 @@
-// Industry registry seam (issue #77, ADR 0015). The registry is the single
-// source of truth for the app's industries — display label, icon, coming-soon
-// flag, crate-eligibility — and `industryOf()` is the total normalizer that
-// resolves a stored `businesses.type` string to one canonical [Industry].
+// Industry registry seam (issues #77 + #79, ADR 0015). The registry is the
+// single source of truth for the app's industries — display label, icon,
+// coming-soon flag, crate-eligibility — and `industryOf()` is the total
+// normalizer that resolves a stored `businesses.type` string to one [Industry].
 //
 // These tests exercise the module's public behaviour, never its internals:
 //   (a) resolution   — canonical labels, legacy casings, unknown/null → generic;
-//   (b) membership   — the catalogue holds exactly the expected industries, in
-//                      plan order, with no duplicates and the same coming-soon
-//                      set the app shipped (proves the #77 prefactor is
-//                      user-visible-behaviour-preserving);
+//   (b) membership   — the catalogue holds exactly the nine master-plan
+//                      industries, in plan order, with no duplicates and every
+//                      one selectable (the #79 unlock flipped coming-soon off);
 //   (c) crate-gate   — crate-eligibility stays Bar/Beverage-only and reproduces
 //                      the old hardcoded `isCrateBusiness` truth table exactly;
 //   (d) golden pin   — a frozen snapshot of every catalogue entry, so any drift
@@ -53,12 +52,18 @@ void main() {
       expect(industryOf('   '), Industry.generic);
       expect(industryOf('Spaceship Repair'), Industry.generic);
     });
+
+    test('resolves the two industries added by the #79 unlock', () {
+      expect(industryOf('Phone & Gadgets'), Industry.phoneAndGadgets);
+      expect(
+          industryOf('Frozen Foods & Grocery'), Industry.frozenFoodsAndGrocery);
+    });
   });
 
-  // === (b) MEMBERSHIP — the catalogue is exactly today's seven ===========
+  // === (b) MEMBERSHIP — the catalogue is exactly the nine ================
 
   group('registry membership', () {
-    test('catalogue is the seven master-plan industries in plan order', () {
+    test('catalogue is the nine master-plan industries in plan order', () {
       expect(
         Industry.catalogue.map((i) => i.label).toList(),
         const [
@@ -69,6 +74,8 @@ void main() {
           'Pharmacy',
           'Building Materials',
           'Boutique',
+          'Phone & Gadgets',
+          'Frozen Foods & Grocery',
         ],
       );
     });
@@ -83,21 +90,14 @@ void main() {
           reason: 'duplicate label in the catalogue: $labels');
     });
 
-    test('only Beverage distributor is selectable today (rest coming soon)', () {
-      // #77 is a pure prefactor: the onboarding picker must show the same
-      // selectable/greyed set it shows today. #79 flips these all on.
-      final comingSoon = {
-        for (final i in Industry.catalogue) i.label: i.comingSoon,
-      };
-      expect(comingSoon, {
-        'Restaurant': true,
-        'Supermarket': true,
-        'Bar': true,
-        'Beverage distributor': false,
-        'Pharmacy': true,
-        'Building Materials': true,
-        'Boutique': true,
-      });
+    test('every catalogue industry is selectable — none coming soon (#79)', () {
+      // The multi-industry unlock makes all nine selectable at onboarding, so
+      // the picker greys out nothing.
+      expect(
+        Industry.catalogue.where((i) => i.comingSoon).map((i) => i.label),
+        isEmpty,
+        reason: 'no industry may be greyed-out after the #79 unlock',
+      );
     });
   });
 
@@ -129,6 +129,7 @@ void main() {
         'Building Materials',
         'Boutique',
         'Phone & Gadgets',
+        'Frozen Foods & Grocery',
         'nonsense',
         '',
       ];
@@ -159,18 +160,21 @@ void main() {
   // === (d) GOLDEN PIN — frozen snapshot of the catalogue =================
 
   group('catalogue golden', () {
-    // FROZEN GOLDEN DATA — the exact facts each catalogue entry held when the
-    // registry was introduced. A diff here means an industry's label, icon,
-    // coming-soon or crate flag changed: update this golden in the SAME commit,
-    // deliberately. (label | icon codepoint | comingSoon | crateEligible)
+    // FROZEN GOLDEN DATA — the exact facts each catalogue entry holds after the
+    // #79 unlock (nine industries, all selectable). A diff here means an
+    // industry's label, icon, coming-soon or crate flag changed: update this
+    // golden in the SAME commit, deliberately.
+    // (label | icon codepoint | comingSoon | crateEligible)
     const golden = <String>[
-      'Restaurant|0xf0108|true|false',
-      'Supermarket|0xf86e|true|false',
-      'Bar|0xf865|true|true',
+      'Restaurant|0xf0108|false|false',
+      'Supermarket|0xf86e|false|false',
+      'Bar|0xf865|false|true',
       'Beverage distributor|0xf01b8|false|true',
-      'Pharmacy|0xf877|true|false',
-      'Building Materials|0xf7a3|true|false',
-      'Boutique|0xf639|true|false',
+      'Pharmacy|0xf877|false|false',
+      'Building Materials|0xf7a3|false|false',
+      'Boutique|0xf639|false|false',
+      'Phone & Gadgets|0xf019b|false|false',
+      'Frozen Foods & Grocery|0xf516|false|false',
     ];
 
     test('catalogue matches the frozen golden', () {


### PR DESCRIPTION
Closes #79 — the multi-industry unlock (PRD #76, ADR 0015). Blocked by #77 (now merged); this branches off updated main.

## What this does
Unlocks every industry at signup — the existing seven plus new **Phone & Gadgets** and **Frozen Foods & Grocery** (nine total), all selectable.

## How — a registry-only change (the #77 prefactor paid off)
- Added `phoneAndGadgets` (`Icons.smartphone_rounded`) and `frozenFoodsAndGrocery` (`Icons.ac_unit_rounded`) to the `Industry` enum.
- Flipped `comingSoon` off for all — made `false` the constructor default and dropped the now-redundant explicit flags.
- **No UI code changed.** The CEO Sign Up picker and Settings → Business Info dropdown already render from `Industry.catalogue` (built in #77), so all nine now appear and are selectable automatically, and the greyed-out "coming soon" state is gone.
- **Crate opt-in unchanged** — "Track empty crates" still gates on `isCrateBusiness` (Bar/Beverage only); the two new industries never show it.
- **Onboarding stores the canonical label** (unchanged path); the two new labels equal their DB canonical (no `'Beer distributor'`-style mapping needed).
- **Industry editable in Settings, data preserved** — switching only rewrites `businesses.type`; product/stock/history rows are untouched.
- `comingSoon` is retained in the registry per PRD #76 (for a future gated industry, and it still drives the picker's grey-out) with a documented unused-parameter suppression, since no entry sets it after the unlock.

## Tests
`test/industry/industry_registry_test.dart` updated to the nine-industry end state: catalogue = nine in plan order, resolution of the two new labels, every industry selectable (none coming-soon), crate-gate unchanged (Bar/Beverage only), golden refreshed.

## Verification
- `flutter analyze` → clean project-wide.
- `flutter test test/industry` → 13/13; `test/auth test/settings test/crates test/providers` → green except the known pre-existing flaky `who_is_working_screen_test.dart` (fails on pristine main, unrelated).
- `flutter run` on the Android emulator → built + booted `com.reebaplus.pos` cleanly (the registry resolves live at startup).

## Two-axis code review applied
Both axes clean — Spec: all six ACs satisfied (verified the #77 wiring delivers the picker/Settings ACs), no scope creep; Standards: no hard violations. Addressed one cosmetic note (de-duplicated the `comingSoon` rationale).

Next in the chain: **#80** (Lexicon on Add/Update Product forms), blocked by this.