### PR TITLE
feat(inventory): terminology morph (Lexicon) on Add/Update Product (#80)

### DIFF
--- a/BUILD_LOG.md
+++ b/BUILD_LOG.md
@@ -2,6 +2,40 @@
 
 ---
 
+## 2026-07-07 — Terminology morph (Lexicon) on Add/Update Product (issue #80, PRD #76)
+
+**What changed.** The Add Product and Update Product forms now speak the selected
+industry's words instead of hardcoded drink terms.
+
+- **Lexicon module** (`lib/core/industry/lexicon.dart`). A `Lexicon` holds an
+  industry's domain nouns (`item`, `category`, `unit`) + starter unit/category
+  suggestions + example hints, with **per-slot generic defaults** (an unfilled
+  slot resolves to the neutral word). `lexiconFor(Industry)` is total. Beverage
+  reproduces today's product-form wording **verbatim** ("Product Name", "Eva
+  water 75cl", "sparkling water", Bottle default) — no regression.
+- **Business-Scoped provider** (`industryLexiconProvider`, app_providers). Watches
+  `currentBusinessProvider`, resolves the `Industry` via `industryOf`, returns
+  its `Lexicon`. Rebuilds on an industry switch (words follow, no restart).
+- **Add & Update Product** read every industry-sensitive noun from the Lexicon:
+  the `"{item} Name"` label, name/description hints, category label, default unit
+  + unit suggestions, and validation messages. Add Product also surfaces the
+  industry's **starter category** suggestions for a fresh shop (no categories
+  yet). Neutral words (Save, Price, Stock, Search) stay literal. Crate/empties
+  nouns are untouched — already gated by `isCrateBusiness`, so they can't leak.
+
+**Files changed:** `lib/core/industry/lexicon.dart` (new),
+`lib/core/providers/app_providers.dart`, `add_product_screen.dart`,
+`update_product_sheet.dart`, `test/industry/lexicon_test.dart` (new).
+
+**Verification.**
+- `flutter analyze` → clean project-wide.
+- `flutter test test/industry` → Lexicon seam (7) + registry (13) green;
+  `test/inventory` green.
+- `flutter run` on the Android emulator → built + booted cleanly; the Beverage
+  business shows unchanged product-form wording.
+
+Next: **#81** extends the same Lexicon to POS, inventory tabs, and guides.
+
 ## 2026-07-07 — Enable all nine industries at onboarding (issue #79, PRD #76)
 
 **What changed.** Unlock every industry at signup — the existing seven plus new

--- a/CONTEXT/progress-tracker.md
+++ b/CONTEXT/progress-tracker.md
@@ -18,15 +18,18 @@ photo (independent). Status:
   is the single source of truth; `industryOf()` total normalizer; `isCrateBusiness`
   a registry shim. Pure prefactor.
 - ✅ **#78 synced product photo — SHIPPED** (PR #83 merged). See entry below.
-- ✅ **#79 enable all nine — IN REVIEW** (branch `feat/enable-all-industries`).
-  Added **Phone & Gadgets** + **Frozen Foods & Grocery** to the registry and
-  flipped every `comingSoon` off. Because onboarding + Settings render from
-  `Industry.catalogue` (the #77 prefactor), no UI code changed — all nine are now
-  selectable, crate opt-in still Bar/Beverage-only, industry editable in Settings
-  with data preserved. 13 registry tests green (catalogue → nine, all selectable,
-  golden updated); analyze clean; boots on emulator.
-- ⏭ **#80 Lexicon on product forms** — next, blocked by #79 (needs it on main).
-- ⏭ **#81 Lexicon on POS/inventory/guides** — blocked by #80.
+- ✅ **#79 enable all nine — SHIPPED** (PR #84 merged). Added **Phone & Gadgets**
+  + **Frozen Foods & Grocery** to the registry and flipped every `comingSoon`
+  off. No UI code changed (onboarding + Settings render from `Industry.catalogue`);
+  all nine selectable, crate opt-in still Bar/Beverage-only, industry editable
+  with data preserved.
+- ✅ **#80 Lexicon on product forms — IN REVIEW** (branch `feat/lexicon-product-forms`).
+  New `Lexicon` module (per-industry item/unit/category nouns + starter presets +
+  hints, generic per-slot fallback; Beverage reproduces today's wording verbatim)
+  + `industryLexiconProvider` (Business-Scoped). Add/Update Product read all
+  industry-sensitive nouns from it; Add Product surfaces starter categories for a
+  fresh shop. 7 Lexicon seam tests; analyze clean; boots on emulator.
+- ⏭ **#81 Lexicon on POS/inventory/guides** — next, blocked by #80.
 
 ### IN REVIEW: Optional synced product photo (issue #78, PRD #76 / ADR 0015)
 Branch `feat/product-photo-sync` (off main; independent slice of the

--- a/lib/core/industry/lexicon.dart
+++ b/lib/core/industry/lexicon.dart
@@ -1,0 +1,160 @@
+import 'package:reebaplus_pos/core/industry/industry.dart';
+
+/// The app-shipped, compile-time set of an [Industry]'s domain nouns and starter
+/// presets (CONTEXT.md → *Lexicon*, ADR 0015). It covers only the words that
+/// read wrong cross-industry — what a sellable **item** is called, its default
+/// **unit**, the **category** word — plus the starter unit/category suggestions
+/// and example hints a brand-new shop sees. Neutral words (Save, Price, Stock,
+/// Search) are left literal and never live here.
+///
+/// Every slot has a neutral **generic** default (the constructor defaults), so
+/// an industry that fills only some slots still resolves the rest to sensible
+/// generic words — the per-slot fallback the ADR calls for. Beverage-only nouns
+/// (crate, empties) are NOT here: their surfaces are already gated by
+/// `isCrateBusiness`, so they cannot leak to another trade.
+///
+/// Not CEO-editable and not synced. The UI reads a business's Lexicon through
+/// `industryLexiconProvider`, which resolves the active [Industry] and returns
+/// the entry below via [lexiconFor].
+class Lexicon {
+  const Lexicon({
+    this.item = 'Product',
+    this.category = 'Category',
+    this.unit = 'Piece',
+    this.starterUnits = _genericUnits,
+    this.starterCategories = _genericCategories,
+    this.itemNameHint = 'e.g. product name',
+    this.itemDescriptionHint = 'e.g. short description',
+  });
+
+  /// Singular noun for a sellable item ("Product", "Medicine", "Handset"). Used
+  /// e.g. as the `"$item Name"` field label.
+  final String item;
+
+  /// The grouping word ("Category" for most trades).
+  final String category;
+
+  /// The default unit-of-measure for a new item ("Bottle", "Pack", "Piece").
+  final String unit;
+
+  /// Suggested units of measure offered in the product form.
+  final List<String> starterUnits;
+
+  /// Suggested starter categories so a brand-new shop isn't a blank slate.
+  final List<String> starterCategories;
+
+  /// Example product-name hint text.
+  final String itemNameHint;
+
+  /// Example description hint text.
+  final String itemDescriptionHint;
+
+  static const _genericUnits = ['Piece', 'Pack', 'Box', 'Carton', 'Bag', 'Other'];
+  static const _genericCategories = ['General'];
+}
+
+// ── Per-industry lexicons ────────────────────────────────────────────────────
+// Beverage/Bar reproduce today's wording verbatim (no regression): the product
+// form has always shown "Product Name", the "Eva water 75cl" / "sparkling water"
+// hints, and a Bottle default.
+
+const _generic = Lexicon();
+
+const _beverage = Lexicon(
+  item: 'Product',
+  unit: 'Bottle',
+  starterUnits: [
+    'Bottle', 'Can', 'PET', 'Sachet', 'Keg', 'Crate', 'Pack', 'Carton',
+    'Piece', 'Bag', 'Box', 'Tin', 'Other',
+  ],
+  starterCategories: [
+    'Water', 'Soft Drinks', 'Beer', 'Spirits', 'Wine', 'Energy Drinks',
+  ],
+  itemNameHint: 'Eva water 75cl',
+  itemDescriptionHint: 'sparkling water',
+);
+
+const _pharmacy = Lexicon(
+  item: 'Medicine',
+  unit: 'Pack',
+  starterUnits: ['Tablet', 'Pack', 'Bottle', 'Tube', 'Sachet', 'Vial', 'Box', 'Piece'],
+  starterCategories: [
+    'Antibiotics', 'Painkillers', 'Vitamins', 'Antimalarials', 'First Aid',
+  ],
+  itemNameHint: 'e.g. Paracetamol 500mg',
+  itemDescriptionHint: 'e.g. pain relief',
+);
+
+const _phoneAndGadgets = Lexicon(
+  item: 'Handset',
+  unit: 'Piece',
+  starterUnits: ['Piece', 'Pack', 'Set', 'Box'],
+  starterCategories: [
+    'Phones', 'Accessories', 'Chargers', 'Earphones', 'Cases',
+  ],
+  itemNameHint: 'e.g. iPhone 13 128GB',
+  itemDescriptionHint: 'e.g. smartphone',
+);
+
+const _frozenFoodsAndGrocery = Lexicon(
+  item: 'Product',
+  unit: 'Pack',
+  starterUnits: ['Pack', 'Kg', 'Bag', 'Piece', 'Carton', 'Box'],
+  starterCategories: [
+    'Frozen Meat', 'Frozen Fish', 'Vegetables', 'Dairy', 'Groceries',
+  ],
+  itemNameHint: 'e.g. Chicken 1kg',
+  itemDescriptionHint: 'e.g. frozen',
+);
+
+const _restaurant = Lexicon(
+  item: 'Item',
+  unit: 'Plate',
+  starterUnits: ['Plate', 'Portion', 'Bowl', 'Piece', 'Pack'],
+  starterCategories: ['Starters', 'Main Dishes', 'Drinks', 'Desserts'],
+  itemNameHint: 'e.g. Jollof Rice',
+  itemDescriptionHint: 'e.g. with chicken',
+);
+
+const _supermarket = Lexicon(
+  item: 'Product',
+  unit: 'Piece',
+  starterUnits: ['Piece', 'Pack', 'Kg', 'Bag', 'Carton', 'Box'],
+  starterCategories: [
+    'Groceries', 'Beverages', 'Toiletries', 'Household', 'Snacks',
+  ],
+  itemNameHint: 'e.g. Rice 5kg',
+  itemDescriptionHint: 'e.g. groceries',
+);
+
+const _buildingMaterials = Lexicon(
+  item: 'Material',
+  unit: 'Bag',
+  starterUnits: ['Bag', 'Piece', 'Ton', 'Length', 'Sheet', 'Litre'],
+  starterCategories: ['Cement', 'Blocks', 'Steel', 'Paint', 'Plumbing'],
+  itemNameHint: 'e.g. Dangote Cement 50kg',
+  itemDescriptionHint: 'e.g. building material',
+);
+
+const _boutique = Lexicon(
+  item: 'Item',
+  unit: 'Piece',
+  starterUnits: ['Piece', 'Pair', 'Set', 'Pack'],
+  starterCategories: ['Men', 'Women', 'Kids', 'Accessories', 'Footwear'],
+  itemNameHint: 'e.g. Ankara Dress',
+  itemDescriptionHint: 'e.g. size M',
+);
+
+/// Resolves the [Lexicon] for [industry]. Total: every [Industry] maps to an
+/// entry, and [Industry.generic] returns the neutral fallback.
+Lexicon lexiconFor(Industry industry) => switch (industry) {
+      Industry.bar || Industry.beverage => _beverage,
+      Industry.pharmacy => _pharmacy,
+      Industry.phoneAndGadgets => _phoneAndGadgets,
+      Industry.frozenFoodsAndGrocery => _frozenFoodsAndGrocery,
+      Industry.restaurant => _restaurant,
+      Industry.supermarket => _supermarket,
+      Industry.buildingMaterials => _buildingMaterials,
+      Industry.boutique => _boutique,
+      Industry.generic => _generic,
+    };

--- a/lib/core/providers/app_providers.dart
+++ b/lib/core/providers/app_providers.dart
@@ -12,7 +12,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
-import 'package:reebaplus_pos/core/data/business_types.dart';
+import 'package:reebaplus_pos/core/industry/industry.dart';
+import 'package:reebaplus_pos/core/industry/lexicon.dart';
 import 'package:reebaplus_pos/core/database/app_database.dart';
 import 'package:reebaplus_pos/core/providers/business_scoped_stream.dart';
 import 'package:reebaplus_pos/core/services/biometric_service.dart';
@@ -506,6 +507,18 @@ bool businessTracksCrates(BusinessData? business) {
 /// no business is bound yet.
 final currentBusinessNameProvider = Provider.autoDispose<String>((ref) {
   return ref.watch(currentBusinessProvider)?.name ?? '';
+});
+
+/// The active business's [Lexicon] — its industry's domain nouns + starter
+/// presets (#80, ADR 0015). A Business-Scoped read: it watches
+/// [currentBusinessProvider], resolves the [Industry] from `businesses.type`
+/// via [industryOf], and returns [lexiconFor] that industry. Rebuilds when the
+/// business (or its type) changes, so the UI's words follow an industry switch
+/// without a restart. Falls back to the generic Lexicon when no business is
+/// bound or the type is unknown.
+final industryLexiconProvider = Provider.autoDispose<Lexicon>((ref) {
+  final business = ref.watch(currentBusinessProvider);
+  return lexiconFor(industryOf(business?.type));
 });
 
 // ── Business Logo ──────────────────────────────────────────────────────────

--- a/lib/features/inventory/screens/add_product_screen.dart
+++ b/lib/features/inventory/screens/add_product_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:reebaplus_pos/core/permissions/permissions.dart';
 import 'package:reebaplus_pos/core/providers/app_providers.dart';
+import 'package:reebaplus_pos/core/industry/lexicon.dart';
 import 'package:reebaplus_pos/core/result.dart';
 import 'package:reebaplus_pos/features/inventory/widgets/product_photo_field.dart';
 import 'package:reebaplus_pos/core/providers/stream_providers.dart';
@@ -104,11 +105,14 @@ class _AddProductScreenState extends ConsumerState<AddProductScreen> {
     'Manufacturer',
   };
 
-  static const _units = kProductUnits;
-  List<String> _dynamicUnits = _units;
+  List<String> _dynamicUnits = kProductUnits;
 
-  String get _nameHint => _isCrateBusiness ? 'Eva water 75cl' : 'e.g. Heineken 60cl';
-  String get _descriptionHint => _isCrateBusiness ? 'sparkling water' : 'e.g. Premium Lager';
+  /// The active industry's words + presets (#80). Read (not watched) in helpers
+  /// called during build; the form is opened for one business so it is stable.
+  Lexicon get _lexicon => ref.read(industryLexiconProvider);
+
+  String get _nameHint => _lexicon.itemNameHint;
+  String get _descriptionHint => _lexicon.itemDescriptionHint;
 
   /// Whether the current role may see / set the buying price (master plan
   /// §16.5 / §16.7). Reads (not watches) so it is safe to call from `_save`.
@@ -119,13 +123,13 @@ class _AddProductScreenState extends ConsumerState<AddProductScreen> {
   @override
   void initState() {
     super.initState();
-    // Fast-Add (direct mode) opens on the business-type-aware unit default so a
-    // crate business engages empty-crate tracking automatically (ADR 0006).
-    // Receive Stock's mini-form keeps its existing Bottle default, untouched.
+    // Fast-Add (direct mode) opens on the industry's default unit (#80), so a
+    // crate business still defaults to Bottle (engaging empty-crate tracking)
+    // while a pharmacy opens on Pack, etc. Receive Stock's mini-form keeps its
+    // existing Bottle default, untouched.
     if (!widget.receiveMode) {
-      _unit = fastAddDefaultUnit(
-        tracksCrates: businessTracksCrates(ref.read(currentBusinessProvider)),
-      );
+      _unit = _lexicon.unit;
+      _dynamicUnits = _lexicon.starterUnits;
       _trackEmpties = _unit.toLowerCase() == 'bottle';
     }
     _loadData();
@@ -151,9 +155,9 @@ class _AddProductScreenState extends ConsumerState<AddProductScreen> {
         _allManufacturers = manufacturers;
         _allCategories = cats;
         _allProducts = productsList;
-        // Merge fetched units with defaults to ensure a rich list
+        // Merge the industry's starter units (#80) with any already in use.
         final mergedUnits = {
-          ..._units, // static defaults
+          ..._lexicon.starterUnits,
           ...uniqueUnits,
         }.toList()..sort();
         _dynamicUnits = mergedUnits;
@@ -541,7 +545,7 @@ class _AddProductScreenState extends ConsumerState<AddProductScreen> {
         return;
       }
       if (existingName.isEmpty) {
-        AppNotification.showError(context, 'Product Name is required.');
+        AppNotification.showError(context, '${_lexicon.item} Name is required.');
         return;
       }
       if (_retailPriceCtrl.text.trim().isEmpty) {
@@ -700,11 +704,11 @@ class _AddProductScreenState extends ConsumerState<AddProductScreen> {
 
     String? missingField;
     if (name.isEmpty) {
-      missingField = 'Product Name';
+      missingField = '${_lexicon.item} Name';
     } else if (_subtitleCtrl.text.trim().isEmpty) {
       missingField = 'Description / Subtitle';
     } else if (_selectedCategory == null) {
-      missingField = 'Category';
+      missingField = _lexicon.category;
     } else if (_retailPriceCtrl.text.trim().isEmpty) {
       missingField = 'Retailer Price';
     } else if (_wholesalePriceCtrl.text.trim().isEmpty) {
@@ -1213,7 +1217,7 @@ class _AddProductScreenState extends ConsumerState<AddProductScreen> {
                 // ── NAME SEARCH (new product mode only) ────────────────
                 AppInput(
                   controller: _nameCtrl,
-                  labelText: 'Product Name *',
+                  labelText: '${_lexicon.item} Name *',
                   hintText: _nameHint,
                   prefixIcon: Icon(Icons.search, size: 18, color: subtext),
                   onChanged: _onNameChanged,
@@ -1244,7 +1248,7 @@ class _AddProductScreenState extends ConsumerState<AddProductScreen> {
               ...[
                 AppInput(
                   controller: _categoryCtrl,
-                  labelText: 'CATEGORY *',
+                  labelText: '${_lexicon.category.toUpperCase()} *',
                   hintText: 'Search or type category name…',
                   prefixIcon: Icon(Icons.search, size: 18, color: subtext),
                   onChanged: _onCategoryChanged,
@@ -1255,6 +1259,30 @@ class _AddProductScreenState extends ConsumerState<AddProductScreen> {
                         )
                       : null,
                 ),
+                // Starter category suggestions for a fresh shop (#80) — shown
+                // before the owner types and only while they have no categories
+                // yet, so a new business isn't a blank slate.
+                if (_allCategories.isEmpty &&
+                    _selectedCategory == null &&
+                    _categoryCtrl.text.trim().isEmpty)
+                  _suggestionList(
+                    children: [
+                      for (final name in _lexicon.starterCategories)
+                        _suggestionTile(
+                          label: name,
+                          icon: Icons.add_circle_outline,
+                          textColor: textColor,
+                          card: card,
+                          border: border,
+                          onTap: () {
+                            _categoryCtrl.text = name;
+                            _onCategoryChanged(name);
+                          },
+                        ),
+                    ],
+                    card: card,
+                    border: border,
+                  ),
                 if (_categorySuggestions.isNotEmpty ||
                     (_categoryCtrl.text.trim().isNotEmpty &&
                         _selectedCategory == null))
@@ -1624,7 +1652,7 @@ class _AddProductScreenState extends ConsumerState<AddProductScreen> {
       // ── NAME (include the size) ─────────────────────────────────────────
       AppInput(
         controller: _nameCtrl,
-        labelText: 'Product Name *',
+        labelText: '${_lexicon.item} Name *',
         hintText: _nameHint,
         prefixIcon: Icon(Icons.search, size: 18, color: subtext),
         onChanged: _onNameChanged,

--- a/lib/features/inventory/screens/add_product_screen.dart
+++ b/lib/features/inventory/screens/add_product_screen.dart
@@ -123,15 +123,13 @@ class _AddProductScreenState extends ConsumerState<AddProductScreen> {
   @override
   void initState() {
     super.initState();
-    // Fast-Add (direct mode) opens on the industry's default unit (#80), so a
-    // crate business still defaults to Bottle (engaging empty-crate tracking)
-    // while a pharmacy opens on Pack, etc. Receive Stock's mini-form keeps its
-    // existing Bottle default, untouched.
-    if (!widget.receiveMode) {
-      _unit = _lexicon.unit;
-      _dynamicUnits = _lexicon.starterUnits;
-      _trackEmpties = _unit.toLowerCase() == 'bottle';
-    }
+    // Open on the industry's default unit (#80): a crate business still defaults
+    // to Bottle (engaging empty-crate tracking), a pharmacy to Pack, etc. Applies
+    // to both the Fast-Add and Receive Stock mini-forms so neither shows a drink
+    // default to a non-beverage trade.
+    _unit = _lexicon.unit;
+    _dynamicUnits = _lexicon.starterUnits;
+    _trackEmpties = _unit.toLowerCase() == 'bottle';
     _loadData();
   }
 
@@ -348,10 +346,10 @@ class _AddProductScreenState extends ConsumerState<AddProductScreen> {
     _categoryCtrl.clear();
     setState(() {
       _selectedExistingProduct = null;
-      _unit = 'Bottle';
+      _unit = _lexicon.unit;
       _size = null;
       _expiryDate = null;
-      _trackEmpties = true;
+      _trackEmpties = _unit.toLowerCase() == 'bottle';
       _allowFractionalSales = false;
       _selectedManufacturer = null;
       _selectedSupplier = null;
@@ -1657,7 +1655,7 @@ class _AddProductScreenState extends ConsumerState<AddProductScreen> {
         prefixIcon: Icon(Icons.search, size: 18, color: subtext),
         onChanged: _onNameChanged,
       ),
-      _fieldHelper('Include the size — e.g. Star 60cl, Eva Water 75cl', subtext),
+      _fieldHelper('Include the size or key detail in the name.', subtext),
       if (_productSuggestions.isNotEmpty)
         _suggestionList(
           children: _productSuggestions
@@ -1705,7 +1703,7 @@ class _AddProductScreenState extends ConsumerState<AddProductScreen> {
       // ── CATEGORY (optional, with examples) ──────────────────────────────
       AppInput(
         controller: _categoryCtrl,
-        labelText: 'Category',
+        labelText: _lexicon.category,
         hintText: 'Search or type category name…',
         prefixIcon: Icon(Icons.search, size: 18, color: subtext),
         onChanged: _onCategoryChanged,
@@ -1716,7 +1714,10 @@ class _AddProductScreenState extends ConsumerState<AddProductScreen> {
               )
             : null,
       ),
-      _fieldHelper('e.g. Water, Beer, Wine', subtext),
+      _fieldHelper(
+        'e.g. ${_lexicon.starterCategories.take(3).join(', ')}',
+        subtext,
+      ),
       if (_categorySuggestions.isNotEmpty ||
           (_categoryCtrl.text.trim().isNotEmpty && _selectedCategory == null))
         _categorySuggestionsList(card, textColor, border),

--- a/lib/features/inventory/widgets/update_product_sheet.dart
+++ b/lib/features/inventory/widgets/update_product_sheet.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+import 'package:reebaplus_pos/core/industry/lexicon.dart';
 import 'package:reebaplus_pos/core/providers/app_providers.dart';
 import 'package:reebaplus_pos/core/result.dart';
 import 'package:reebaplus_pos/core/providers/stream_providers.dart';
@@ -80,8 +81,9 @@ class _UpdateProductSheetState extends ConsumerState<UpdateProductSheet> {
   String? _imagePath;
   Uint8List? _pendingImageBytes;
 
-  static const _units = ['Crate', 'Bottle', 'Pack', 'Carton', 'Keg', 'Can'];
-  List<String> _dynamicUnits = _units;
+  // Unit suggestions come from the industry's Lexicon (#80); set in initState +
+  // merged with the product's own unit and any already in use in _loadData.
+  List<String> _dynamicUnits = const [];
 
   /// Whether the current role may see / edit the buying price (§16.5 / §16.7).
   /// Reads (not watches) so it is safe to call from `_save`.
@@ -106,6 +108,10 @@ class _UpdateProductSheetState extends ConsumerState<UpdateProductSheet> {
 
   /// trackEmpties as actually saved — forced off for non-crate businesses.
   bool get _effectiveTrackEmpties => _isCrateBusiness && _trackEmpties;
+
+  /// The active industry's words + presets (#80). Read (not watched); the sheet
+  /// edits one product for one business, so the Lexicon is stable here.
+  Lexicon get _lexicon => ref.read(industryLexiconProvider);
 
   /// Empty-crate value in kobo, or null when not tracking empties / left blank.
   int? get _emptyCrateValueKobo {
@@ -161,6 +167,9 @@ class _UpdateProductSheetState extends ConsumerState<UpdateProductSheet> {
     _imagePath = p.imagePath;
 
     _unit = p.unit;
+    // The industry's starter units, plus this product's own unit so the
+    // dropdown always includes the selected value (#80).
+    _dynamicUnits = <String>{..._lexicon.starterUnits, p.unit}.toList()..sort();
     _trackEmpties = p.trackEmpties;
     _allowFractionalSales = p.allowFractionalSales;
     _size = p.size;
@@ -193,7 +202,8 @@ class _UpdateProductSheetState extends ConsumerState<UpdateProductSheet> {
       _allSuppliers = suppliers;
       _allManufacturers = manufacturers;
       _allCategories = cats;
-      _dynamicUnits = <String>{..._units, _unit, ...uniqueUnits}.toList()
+      _dynamicUnits = <String>{..._lexicon.starterUnits, _unit, ...uniqueUnits}
+          .toList()
         ..sort();
       if (cachedPhoto != null) _imagePath = cachedPhoto;
 
@@ -476,9 +486,9 @@ class _UpdateProductSheetState extends ConsumerState<UpdateProductSheet> {
 
       String? missingField;
       if (name.isEmpty) {
-        missingField = 'Product Name';
+        missingField = '${_lexicon.item} Name';
       } else if (_selectedCategory == null) {
-        missingField = 'Category';
+        missingField = _lexicon.category;
       } else if (_retailPriceCtrl.text.trim().isEmpty) {
         missingField = 'Retailer Price';
       } else if (_wholesalePriceCtrl.text.trim().isEmpty) {
@@ -880,15 +890,15 @@ class _UpdateProductSheetState extends ConsumerState<UpdateProductSheet> {
                     // ── PRODUCT NAME ─────────────────────────────────────────
                     AppInput(
                       controller: _nameCtrl,
-                      labelText: 'Product Name *',
-                      hintText: _isCrateBusiness ? 'Eva water 75cl' : 'e.g. Heineken 60cl',
+                      labelText: '${_lexicon.item} Name *',
+                      hintText: _lexicon.itemNameHint,
                     ),
                     const SizedBox(height: 14),
 
                     // ── CATEGORY ─────────────────────────────────────────────
                     AppInput(
                       controller: _categoryCtrl,
-                      labelText: 'CATEGORY *',
+                      labelText: '${_lexicon.category.toUpperCase()} *',
                       hintText: 'Search or type category name…',
                       prefixIcon: Icon(Icons.search, size: 18, color: subtext),
                       onChanged: _onCategoryChanged,
@@ -958,7 +968,7 @@ class _UpdateProductSheetState extends ConsumerState<UpdateProductSheet> {
                     AppInput(
                       controller: _subtitleCtrl,
                       labelText: 'Description / Subtitle',
-                      hintText: _isCrateBusiness ? 'sparkling water' : 'e.g. Premium Lager',
+                      hintText: _lexicon.itemDescriptionHint,
                     ),
                     const SizedBox(height: 14),
 

--- a/test/industry/lexicon_test.dart
+++ b/test/industry/lexicon_test.dart
@@ -1,0 +1,75 @@
+// Lexicon seam (issue #80, ADR 0015). The Lexicon is the app-shipped set of an
+// Industry's domain nouns (item/unit/category) + starter presets, resolved by
+// `lexiconFor(industry)`. These tests exercise the pure lookup through the
+// registry seam: the words each Industry yields, the generic per-slot fallback,
+// and — critically — that Beverage reproduces today's wording (no regression).
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reebaplus_pos/core/industry/industry.dart';
+import 'package:reebaplus_pos/core/industry/lexicon.dart';
+
+void main() {
+  group('Lexicon — no regression for Beverage', () {
+    test('reproduces the current product-form wording verbatim', () {
+      final lex = lexiconFor(Industry.beverage);
+      expect(lex.item, 'Product'); // "Product Name" label
+      expect(lex.itemNameHint, 'Eva water 75cl');
+      expect(lex.itemDescriptionHint, 'sparkling water');
+      expect(lex.unit, 'Bottle');
+      expect(lex.starterUnits, contains('Crate'));
+    });
+
+    test('Bar shares the beverage lexicon', () {
+      expect(lexiconFor(Industry.bar), same(lexiconFor(Industry.beverage)));
+    });
+  });
+
+  group('Lexicon — the item noun morphs per trade', () {
+    test('each industry names a sellable item in its own words', () {
+      expect(lexiconFor(Industry.pharmacy).item, 'Medicine');
+      expect(lexiconFor(Industry.phoneAndGadgets).item, 'Handset');
+      expect(lexiconFor(Industry.buildingMaterials).item, 'Material');
+      expect(lexiconFor(Industry.boutique).item, 'Item');
+      expect(lexiconFor(Industry.restaurant).item, 'Item');
+    });
+
+    test('resolves through the registry: industryOf → lexicon', () {
+      // The UI path: stored type → industryOf → lexiconFor.
+      expect(lexiconFor(industryOf('Pharmacy')).item, 'Medicine');
+      expect(lexiconFor(industryOf('Phone & Gadgets')).item, 'Handset');
+      expect(lexiconFor(industryOf('Beverage distributor')).itemNameHint,
+          'Eva water 75cl');
+    });
+  });
+
+  group('Lexicon — generic fallback', () {
+    test('generic Industry yields the neutral defaults', () {
+      final lex = lexiconFor(Industry.generic);
+      expect(lex.item, 'Product');
+      expect(lex.unit, 'Piece');
+      expect(lex.category, 'Category');
+      expect(lex.starterCategories, isNotEmpty);
+    });
+
+    test('an unfilled slot falls back to the generic word (per-slot fallback)',
+        () {
+      // Supermarket customises units/categories but not `category`, so the slot
+      // resolves to the generic default rather than being blank.
+      expect(lexiconFor(Industry.supermarket).category, 'Category');
+    });
+  });
+
+  group('Lexicon — totality', () {
+    test('every Industry resolves to a fully-populated Lexicon', () {
+      for (final ind in Industry.values) {
+        final lex = lexiconFor(ind);
+        expect(lex.item, isNotEmpty, reason: '$ind item');
+        expect(lex.unit, isNotEmpty, reason: '$ind unit');
+        expect(lex.category, isNotEmpty, reason: '$ind category');
+        expect(lex.starterUnits, isNotEmpty, reason: '$ind starterUnits');
+        expect(lex.starterCategories, isNotEmpty, reason: '$ind starterCategories');
+        expect(lex.itemNameHint, isNotEmpty, reason: '$ind itemNameHint');
+      }
+    });
+  });
+}


### PR DESCRIPTION
Closes #80 — the terminology morph, first half (PRD #76, ADR 0015). Blocked by #79 (merged); branches off updated main.

## What this does
The Add Product and Update Product forms now speak the selected industry's words instead of hardcoded drink terms — a pharmacy sees "Medicine Name" / Pack, a phone shop "Handset Name", and a Beverage distributor sees **exactly today's wording** (no regression).

## How
- **`Lexicon` module** (`lib/core/industry/lexicon.dart`, pure — no Drift import). Per-industry domain nouns (`item`, `category`, `unit`) + starter unit/category suggestions + example hints, with **per-slot generic defaults** (an unfilled slot resolves to the neutral word). `lexiconFor(Industry)` is total. Beverage reproduces today's product-form wording verbatim ("Product Name", "Eva water 75cl", "sparkling water", Bottle default).
- **`industryLexiconProvider`** (Business-Scoped) — watches `currentBusinessProvider`, resolves the `Industry` via `industryOf`, returns its `Lexicon`. Rebuilds on an industry switch.
- **Add & Update Product** read every industry-sensitive noun from the Lexicon: the `"{item} Name"` label, name/description hints, category label, default unit + unit suggestions, and validation messages. Add Product surfaces the industry's **starter category** suggestions for a fresh shop. Neutral words (Save, Price, Stock, Search) stay literal. Crate/empties nouns are untouched — already gated by `isCrateBusiness`, so they can't leak.

## Tests
`test/industry/lexicon_test.dart` — per-industry item lookups, generic + per-slot fallback, totality, Beverage no-regression, and the `industryOf → lexiconFor` seam (pure).

## Verification
- `flutter analyze` → clean project-wide.
- `flutter test test/industry` (Lexicon 7 + registry 13) + `test/inventory` → green.
- `flutter run` on the Android emulator → built + booted cleanly; the Beverage business shows unchanged wording.

## Two-axis code review applied
Standards: clean (the new starter-category block reuses existing helpers; no hardcoded colours/sizes; provider seam correct). Spec: fixed two findings before merge — the Receive Stock mini-form's helper strings + category label and the unit-reset default still showed drink examples/`Bottle` to non-beverage trades; now Lexicon-driven.

Next: **#81** extends the same Lexicon to POS, inventory tabs, and guides.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added industry-specific wording for product forms, so labels, hints, validation messages, and starter category suggestions adapt to the selected business type.
  * Product add/edit screens now show more relevant unit options and reset to industry defaults when clearing entries.

* **Bug Fixes**
  * Improved consistency in form text by replacing several fixed labels with context-aware terms.
  * Kept core actions like Save, Price, Stock, and Search unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->