### PR TITLE
feat(pos,inventory): terminology morph (Lexicon) on POS, inventory & guides (#81)

### DIFF
--- a/BUILD_LOG.md
+++ b/BUILD_LOG.md
@@ -2,6 +2,42 @@
 
 ---
 
+## 2026-07-07 — Terminology morph (Lexicon) on POS, inventory & guides (issue #81, PRD #76)
+
+**What changed.** Extends the industry Lexicon (from #80) to the remaining
+surfaces, so the whole selling + stock experience speaks the selected trade's
+words. Second half of the terminology morph.
+
+- **`Lexicon.itemPlural`** getter (Products → Medicines / Handsets — a simple
+  `+s` covers every shipped industry).
+- **Wired the item noun** (singular / plural / lowercased) into:
+  - **POS** — the product-grid empty state ("No {items} found") and the tap /
+    long-press coach tips ("Tap a {item} to add it to the cart").
+  - **Inventory** — the tab title ("{Items}"), the Add-{item} FAB (label +
+    "create a {item}…" description), the search tooltip/hint, and the
+    filter-miss empty state.
+  - **Guides / empty states** — the shared first-run empty state ("No {items}
+    yet", "Add your first {item}"), the Home empty state, the stock-count empty
+    state, and the Get Started checklist's Add-{item} step.
+- **Beverage unchanged** (`item = 'Product'`, `itemPlural = 'Products'`) — no
+  regression. Industries without a filled slot fall back to neutral words.
+- **No slot-sprawl** (the ADR audit): neutral labels (Suppliers, History,
+  Save, Price, Stock) stay literal; `manufacturer`/`supplier` nouns are out of
+  the item/unit/category scope and untouched; crate/empties stay `isCrateBusiness`-gated.
+
+**Files changed:** `lib/core/industry/lexicon.dart`, `test/industry/lexicon_test.dart`,
+`pos_home_screen.dart`, `product_grid.dart`, `inventory_screen.dart`,
+`stock_count_screen.dart`, `home_screen.dart`, `get_started_card.dart`,
+`shared/widgets/first_run_empty_state.dart`.
+
+**Verification.**
+- `flutter analyze` → clean project-wide.
+- `flutter test test/industry` → 21 green (incl. the new `itemPlural` case).
+- `flutter run` on the Android emulator → built + booted cleanly; the Beverage
+  business shows unchanged POS/inventory/guide wording.
+
+This completes PRD #76's terminology morph (#80 forms + #81 POS/inventory/guides).
+
 ## 2026-07-07 — Terminology morph (Lexicon) on Add/Update Product (issue #80, PRD #76)
 
 **What changed.** The Add Product and Update Product forms now speak the selected

--- a/CONTEXT/progress-tracker.md
+++ b/CONTEXT/progress-tracker.md
@@ -23,13 +23,21 @@ photo (independent). Status:
   off. No UI code changed (onboarding + Settings render from `Industry.catalogue`);
   all nine selectable, crate opt-in still Bar/Beverage-only, industry editable
   with data preserved.
-- ✅ **#80 Lexicon on product forms — IN REVIEW** (branch `feat/lexicon-product-forms`).
-  New `Lexicon` module (per-industry item/unit/category nouns + starter presets +
-  hints, generic per-slot fallback; Beverage reproduces today's wording verbatim)
-  + `industryLexiconProvider` (Business-Scoped). Add/Update Product read all
-  industry-sensitive nouns from it; Add Product surfaces starter categories for a
-  fresh shop. 7 Lexicon seam tests; analyze clean; boots on emulator.
-- ⏭ **#81 Lexicon on POS/inventory/guides** — next, blocked by #80.
+- ✅ **#80 Lexicon on product forms — SHIPPED** (PR #85 merged). New `Lexicon`
+  module (per-industry item/unit/category nouns + starter presets + hints, generic
+  per-slot fallback; Beverage verbatim) + `industryLexiconProvider`. Add/Update
+  Product read all industry-sensitive nouns from it; starter categories surfaced.
+- ✅ **#81 Lexicon on POS/inventory/guides — IN REVIEW** (branch
+  `feat/lexicon-pos-inventory`). Added `Lexicon.itemPlural` and wired the item
+  noun into the POS grid empty state + coach tips, the Inventory tab/FAB/search,
+  and the Home/first-run/stock-count empty states + Get Started checklist.
+  Beverage unchanged; no slot-sprawl (manufacturer/supplier out of scope). 21
+  industry tests; analyze clean; boots on emulator. **Completes PRD #76's
+  terminology morph.**
+
+**PRD #76 status: all five slices (#77–#81) DONE.** #77/#78/#79/#80 merged to
+main; #81 in review (PR pending). Deeper per-industry features (IMEI, expiry,
+cold-chain) are the phased follow-ups (one industry per PR), not this PRD.
 
 ### IN REVIEW: Optional synced product photo (issue #78, PRD #76 / ADR 0015)
 Branch `feat/product-photo-sync` (off main; independent slice of the

--- a/lib/core/industry/lexicon.dart
+++ b/lib/core/industry/lexicon.dart
@@ -53,6 +53,11 @@ class Lexicon {
   /// "Handsets"). A simple `+s` covers every shipped industry's noun.
   String get itemPlural => '${item}s';
 
+  /// Lowercased [item] / [itemPlural] for mid-sentence use ("tap a product",
+  /// "no products found").
+  String get itemLower => item.toLowerCase();
+  String get itemPluralLower => itemPlural.toLowerCase();
+
   static const _genericUnits = ['Piece', 'Pack', 'Box', 'Carton', 'Bag', 'Other'];
   static const _genericCategories = ['General'];
 }

--- a/lib/core/industry/lexicon.dart
+++ b/lib/core/industry/lexicon.dart
@@ -49,6 +49,10 @@ class Lexicon {
   /// Example description hint text.
   final String itemDescriptionHint;
 
+  /// The plural of [item] for list/tab headings ("Products", "Medicines",
+  /// "Handsets"). A simple `+s` covers every shipped industry's noun.
+  String get itemPlural => '${item}s';
+
   static const _genericUnits = ['Piece', 'Pack', 'Box', 'Carton', 'Bag', 'Other'];
   static const _genericCategories = ['General'];
 }

--- a/lib/features/dashboard/screens/home_screen.dart
+++ b/lib/features/dashboard/screens/home_screen.dart
@@ -827,7 +827,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
               Padding(
                 padding: EdgeInsets.all(context.spacingM),
                 child: Text(
-                  'No products yet',
+                  'No ${ref.read(industryLexiconProvider).itemPlural.toLowerCase()} yet',
                   style: TextStyle(
                     color: _subtext,
                     fontSize: context.getRFontSize(13),

--- a/lib/features/dashboard/screens/home_screen.dart
+++ b/lib/features/dashboard/screens/home_screen.dart
@@ -637,7 +637,9 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
           value: profit != null ? formatCurrency(profit) : '—',
           subtitle: profit != null
               ? 'Revenue minus cost of goods & expenses'
-              : 'Add buying prices to products to see profit',
+              : 'Add buying prices to '
+                    '${ref.watch(industryLexiconProvider).itemPluralLower} to '
+                    'see profit',
           icon: FontAwesomeIcons.chartLine.data,
           color: profit != null
               ? (profit >= 0 ? success : danger)
@@ -827,7 +829,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
               Padding(
                 padding: EdgeInsets.all(context.spacingM),
                 child: Text(
-                  'No ${ref.read(industryLexiconProvider).itemPlural.toLowerCase()} yet',
+                  'No ${ref.watch(industryLexiconProvider).itemPluralLower} yet',
                   style: TextStyle(
                     color: _subtext,
                     fontSize: context.getRFontSize(13),

--- a/lib/features/dashboard/widgets/get_started_card.dart
+++ b/lib/features/dashboard/widgets/get_started_card.dart
@@ -113,7 +113,7 @@ class GetStartedCard extends ConsumerWidget {
     WidgetRef ref,
     GetStartedStep step,
   ) {
-    final meta = _metaFor(step.id);
+    final meta = _metaFor(step.id, ref.watch(industryLexiconProvider).item);
     final theme = Theme.of(context);
     final subtext =
         theme.textTheme.bodySmall?.color ?? theme.iconTheme.color!;
@@ -198,12 +198,13 @@ class GetStartedCard extends ConsumerWidget {
     }
   }
 
-  _StepMeta _metaFor(GetStartedStepId id) {
+  _StepMeta _metaFor(GetStartedStepId id, String item) {
+    final itemLower = item.toLowerCase();
     switch (id) {
       case GetStartedStepId.addProduct:
-        return const _StepMeta(
-          title: 'Add a product',
-          subtitle: "Create a product and set what's on your shelf",
+        return _StepMeta(
+          title: 'Add a $itemLower',
+          subtitle: "Create a $itemLower and set what's on your shelf",
         );
       case GetStartedStepId.makeSale:
         return const _StepMeta(

--- a/lib/features/inventory/screens/inventory_screen.dart
+++ b/lib/features/inventory/screens/inventory_screen.dart
@@ -176,7 +176,7 @@ class _InventoryScreenState extends ConsumerState<InventoryScreen>
     'suppliers' => 'Suppliers',
     'crates' => 'Empty Crates',
     'history' => 'History',
-    _ => 'Products',
+    _ => ref.read(industryLexiconProvider).itemPlural,
   };
 
   Widget _tabBody(BuildContext context, String key) => switch (key) {
@@ -356,12 +356,14 @@ class _InventoryScreenState extends ConsumerState<InventoryScreen>
     // direct FAB when only one gate passes and shows nothing when neither does,
     // so a stock keeper with only `stock.add` still gets a direct Receive Stock
     // FAB but never the Add Product option.
+    final lex = ref.read(industryLexiconProvider);
     final speedDialActions = <AppSpeedDialAction>[
       if (Gates.addProduct.allows(ref))
         AppSpeedDialAction(
           icon: FontAwesomeIcons.tag.data,
-          label: 'Add Product',
-          description: 'Create a product and set what’s on your shelf',
+          label: 'Add ${lex.item}',
+          description:
+              'Create a ${lex.item.toLowerCase()} and set what’s on your shelf',
           onPressed: () => Navigator.of(context)
               .push(slideDownRoute(const AddProductScreen())),
         ),
@@ -428,7 +430,9 @@ class _InventoryScreenState extends ConsumerState<InventoryScreen>
         // Search toggle — only meaningful on the Products tab (§16.4).
         if (_currentTab == 0)
           IconButton(
-            tooltip: _showSearch ? 'Close search' : 'Search products',
+            tooltip: _showSearch
+                ? 'Close search'
+                : 'Search ${ref.read(industryLexiconProvider).itemPlural.toLowerCase()}',
             icon: Icon(_showSearch ? Icons.close : Icons.search),
             onPressed: () => setState(() {
               _showSearch = !_showSearch;
@@ -722,7 +726,7 @@ class _InventoryScreenState extends ConsumerState<InventoryScreen>
                     ? const FirstRunEmptyState()
                     : Center(
                         child: Text(
-                          'No products matching filters',
+                          'No ${ref.read(industryLexiconProvider).itemPlural.toLowerCase()} matching filters',
                           style: TextStyle(color: _subtext),
                         ),
                       )
@@ -962,7 +966,8 @@ class _InventoryScreenState extends ConsumerState<InventoryScreen>
         style: TextStyle(color: _text, fontSize: context.getRFontSize(14)),
         decoration: InputDecoration(
           isDense: true,
-          hintText: 'Search products…',
+          hintText:
+              'Search ${ref.read(industryLexiconProvider).itemPlural.toLowerCase()}…',
           prefixIcon: Icon(Icons.search, size: 18, color: _subtext),
           suffixIcon: _searchQuery.isEmpty
               ? null

--- a/lib/features/inventory/screens/inventory_screen.dart
+++ b/lib/features/inventory/screens/inventory_screen.dart
@@ -176,7 +176,7 @@ class _InventoryScreenState extends ConsumerState<InventoryScreen>
     'suppliers' => 'Suppliers',
     'crates' => 'Empty Crates',
     'history' => 'History',
-    _ => ref.read(industryLexiconProvider).itemPlural,
+    _ => ref.watch(industryLexiconProvider).itemPlural,
   };
 
   Widget _tabBody(BuildContext context, String key) => switch (key) {
@@ -356,7 +356,7 @@ class _InventoryScreenState extends ConsumerState<InventoryScreen>
     // direct FAB when only one gate passes and shows nothing when neither does,
     // so a stock keeper with only `stock.add` still gets a direct Receive Stock
     // FAB but never the Add Product option.
-    final lex = ref.read(industryLexiconProvider);
+    final lex = ref.watch(industryLexiconProvider);
     final speedDialActions = <AppSpeedDialAction>[
       if (Gates.addProduct.allows(ref))
         AppSpeedDialAction(
@@ -432,7 +432,7 @@ class _InventoryScreenState extends ConsumerState<InventoryScreen>
           IconButton(
             tooltip: _showSearch
                 ? 'Close search'
-                : 'Search ${ref.read(industryLexiconProvider).itemPlural.toLowerCase()}',
+                : 'Search ${ref.watch(industryLexiconProvider).itemPluralLower}',
             icon: Icon(_showSearch ? Icons.close : Icons.search),
             onPressed: () => setState(() {
               _showSearch = !_showSearch;
@@ -726,7 +726,7 @@ class _InventoryScreenState extends ConsumerState<InventoryScreen>
                     ? const FirstRunEmptyState()
                     : Center(
                         child: Text(
-                          'No ${ref.read(industryLexiconProvider).itemPlural.toLowerCase()} matching filters',
+                          'No ${ref.watch(industryLexiconProvider).itemPluralLower} matching filters',
                           style: TextStyle(color: _subtext),
                         ),
                       )
@@ -967,7 +967,7 @@ class _InventoryScreenState extends ConsumerState<InventoryScreen>
         decoration: InputDecoration(
           isDense: true,
           hintText:
-              'Search ${ref.read(industryLexiconProvider).itemPlural.toLowerCase()}…',
+              'Search ${ref.watch(industryLexiconProvider).itemPluralLower}…',
           prefixIcon: Icon(Icons.search, size: 18, color: _subtext),
           suffixIcon: _searchQuery.isEmpty
               ? null

--- a/lib/features/inventory/screens/stock_count_screen.dart
+++ b/lib/features/inventory/screens/stock_count_screen.dart
@@ -1557,7 +1557,7 @@ class _StockCountScreenState extends ConsumerState<StockCountScreen> {
                         ),
                         SizedBox(height: context.getRSize(16)),
                         Text(
-                          'No products found',
+                          'No ${ref.read(industryLexiconProvider).itemPlural.toLowerCase()} found',
                           style: TextStyle(
                             color: _subtext,
                             fontSize: context.getRFontSize(16),

--- a/lib/features/inventory/screens/stock_count_screen.dart
+++ b/lib/features/inventory/screens/stock_count_screen.dart
@@ -637,7 +637,8 @@ class _StockCountScreenState extends ConsumerState<StockCountScreen> {
             Future<void> submit() async {
               final qty = int.tryParse(_damageQtyCtrl.text.trim()) ?? 0;
               if (product == null) {
-                AppNotification.showError(sheetCtx, 'Choose a product.');
+                AppNotification.showError(sheetCtx,
+                    'Choose a ${ref.read(industryLexiconProvider).itemLower}.');
                 return;
               }
               if (qty <= 0) {
@@ -859,8 +860,9 @@ class _StockCountScreenState extends ConsumerState<StockCountScreen> {
                     ),
                     SizedBox(height: context.getRSize(16)),
                     AppDropdown<ProductStockWithStore>(
-                      labelText: 'Product',
-                      hintText: 'Choose a product',
+                      labelText: ref.read(industryLexiconProvider).item,
+                      hintText:
+                          'Choose a ${ref.read(industryLexiconProvider).itemLower}',
                       value: product,
                       items: _items.map((it) {
                         return DropdownMenuItem(
@@ -1557,7 +1559,7 @@ class _StockCountScreenState extends ConsumerState<StockCountScreen> {
                         ),
                         SizedBox(height: context.getRSize(16)),
                         Text(
-                          'No ${ref.read(industryLexiconProvider).itemPlural.toLowerCase()} found',
+                          'No ${ref.watch(industryLexiconProvider).itemPluralLower} found',
                           style: TextStyle(
                             color: _subtext,
                             fontSize: context.getRFontSize(16),

--- a/lib/features/pos/screens/pos_home_screen.dart
+++ b/lib/features/pos/screens/pos_home_screen.dart
@@ -293,7 +293,7 @@ class _PosHomeScreenState extends ConsumerState<PosHomeScreen> {
                     _controller!.filteredProducts.isNotEmpty)
                   _buildInlineHint(
                     message: 'Tap a '
-                        '${ref.read(industryLexiconProvider).item.toLowerCase()}'
+                        '${ref.watch(industryLexiconProvider).itemLower}'
                         ' to add it to the cart.',
                     onDismiss: () {
                       setState(() => _showPosTapHint = false);
@@ -303,7 +303,7 @@ class _PosHomeScreenState extends ConsumerState<PosHomeScreen> {
                 if (!_controller!.isLoading && _showPosHint && !needsStoreSelection)
                   _buildInlineHint(
                     message: 'Tap and hold a '
-                        '${ref.read(industryLexiconProvider).item.toLowerCase()}'
+                        '${ref.watch(industryLexiconProvider).itemLower}'
                         ' to edit it.',
                     onDismiss: () {
                       setState(() => _showPosHint = false);
@@ -668,7 +668,8 @@ class _PosHomeScreenState extends ConsumerState<PosHomeScreen> {
         controller: _searchController,
         autofocus: true,
         onChanged: (v) => _controller!.updateSearch(v),
-        hintText: 'Search products...',
+        hintText:
+            'Search ${ref.watch(industryLexiconProvider).itemPluralLower}...',
         prefixIcon: Icon(
           FontAwesomeIcons.magnifyingGlass.data,
           size: context.getRSize(16),

--- a/lib/features/pos/screens/pos_home_screen.dart
+++ b/lib/features/pos/screens/pos_home_screen.dart
@@ -292,7 +292,9 @@ class _PosHomeScreenState extends ConsumerState<PosHomeScreen> {
                     !needsStoreSelection &&
                     _controller!.filteredProducts.isNotEmpty)
                   _buildInlineHint(
-                    message: 'Tap a product to add it to the cart.',
+                    message: 'Tap a '
+                        '${ref.read(industryLexiconProvider).item.toLowerCase()}'
+                        ' to add it to the cart.',
                     onDismiss: () {
                       setState(() => _showPosTapHint = false);
                       uiHintService.markShown(UiHintService.hintPosTapAdd);
@@ -300,7 +302,9 @@ class _PosHomeScreenState extends ConsumerState<PosHomeScreen> {
                   ),
                 if (!_controller!.isLoading && _showPosHint && !needsStoreSelection)
                   _buildInlineHint(
-                    message: 'Tap and hold a product to edit it.',
+                    message: 'Tap and hold a '
+                        '${ref.read(industryLexiconProvider).item.toLowerCase()}'
+                        ' to edit it.',
                     onDismiss: () {
                       setState(() => _showPosHint = false);
                       uiHintService.markShown(UiHintService.hintPosLongpress);

--- a/lib/features/pos/widgets/product_grid.dart
+++ b/lib/features/pos/widgets/product_grid.dart
@@ -57,12 +57,14 @@ class ProductGrid extends StatelessWidget {
               color: subtextCol.withValues(alpha: 0.3),
             ),
             SizedBox(height: context.getRSize(16)),
-            Text(
-              'No products found',
-              style: TextStyle(
-                fontSize: context.getRFontSize(16),
-                color: subtextCol,
-                fontWeight: FontWeight.w600,
+            Consumer(
+              builder: (context, ref, _) => Text(
+                'No ${ref.watch(industryLexiconProvider).itemPlural.toLowerCase()} found',
+                style: TextStyle(
+                  fontSize: context.getRFontSize(16),
+                  color: subtextCol,
+                  fontWeight: FontWeight.w600,
+                ),
               ),
             ),
           ],

--- a/lib/features/pos/widgets/product_grid.dart
+++ b/lib/features/pos/widgets/product_grid.dart
@@ -59,7 +59,7 @@ class ProductGrid extends StatelessWidget {
             SizedBox(height: context.getRSize(16)),
             Consumer(
               builder: (context, ref, _) => Text(
-                'No ${ref.watch(industryLexiconProvider).itemPlural.toLowerCase()} found',
+                'No ${ref.watch(industryLexiconProvider).itemPluralLower} found',
                 style: TextStyle(
                   fontSize: context.getRFontSize(16),
                   color: subtextCol,

--- a/lib/shared/widgets/first_run_empty_state.dart
+++ b/lib/shared/widgets/first_run_empty_state.dart
@@ -45,7 +45,7 @@ class FirstRunEmptyState extends ConsumerWidget {
       case FirstRunSurfaceState.neutralEmpty:
         return _EmptyMessage(
           icon: FontAwesomeIcons.boxOpen.data,
-          title: 'No ${lex.itemPlural.toLowerCase()} yet',
+          title: 'No ${lex.itemPluralLower} yet',
           subtitle: 'A manager can add them.',
           subtext: subtext,
         );
@@ -53,13 +53,13 @@ class FirstRunEmptyState extends ConsumerWidget {
       case FirstRunSurfaceState.addProductCta:
         return _EmptyMessage(
           icon: FontAwesomeIcons.boxOpen.data,
-          title: 'No ${lex.itemPlural.toLowerCase()} yet',
-          subtitle: 'Add your first ${lex.item.toLowerCase()} to start selling.',
+          title: 'No ${lex.itemPluralLower} yet',
+          subtitle: 'Add your first ${lex.itemLower} to start selling.',
           subtext: subtext,
           action: ConstrainedBox(
             constraints: BoxConstraints(maxWidth: context.getRSize(280)),
             child: AppButton(
-              text: 'Add your first ${lex.item.toLowerCase()}',
+              text: 'Add your first ${lex.itemLower}',
               icon: FontAwesomeIcons.plus.data,
               onPressed: () => Navigator.of(context).push(
                 // Direct (non-receive) mode — the Fast-Add form (#30).

--- a/lib/shared/widgets/first_run_empty_state.dart
+++ b/lib/shared/widgets/first_run_empty_state.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 
+import 'package:reebaplus_pos/core/providers/app_providers.dart';
 import 'package:reebaplus_pos/core/providers/first_run_surface_state.dart';
 import 'package:reebaplus_pos/core/utils/responsive.dart';
 import 'package:reebaplus_pos/features/inventory/screens/add_product_screen.dart';
@@ -29,6 +30,7 @@ class FirstRunEmptyState extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final surface = ref.watch(firstRunSurfaceStateProvider);
+    final lex = ref.watch(industryLexiconProvider);
     final theme = Theme.of(context);
     final subtext =
         theme.textTheme.bodySmall?.color ?? theme.iconTheme.color!;
@@ -43,7 +45,7 @@ class FirstRunEmptyState extends ConsumerWidget {
       case FirstRunSurfaceState.neutralEmpty:
         return _EmptyMessage(
           icon: FontAwesomeIcons.boxOpen.data,
-          title: 'No products yet',
+          title: 'No ${lex.itemPlural.toLowerCase()} yet',
           subtitle: 'A manager can add them.',
           subtext: subtext,
         );
@@ -51,13 +53,13 @@ class FirstRunEmptyState extends ConsumerWidget {
       case FirstRunSurfaceState.addProductCta:
         return _EmptyMessage(
           icon: FontAwesomeIcons.boxOpen.data,
-          title: 'No products yet',
-          subtitle: 'Add your first product to start selling.',
+          title: 'No ${lex.itemPlural.toLowerCase()} yet',
+          subtitle: 'Add your first ${lex.item.toLowerCase()} to start selling.',
           subtext: subtext,
           action: ConstrainedBox(
             constraints: BoxConstraints(maxWidth: context.getRSize(280)),
             child: AppButton(
-              text: 'Add your first product',
+              text: 'Add your first ${lex.item.toLowerCase()}',
               icon: FontAwesomeIcons.plus.data,
               onPressed: () => Navigator.of(context).push(
                 // Direct (non-receive) mode — the Fast-Add form (#30).

--- a/test/industry/lexicon_test.dart
+++ b/test/industry/lexicon_test.dart
@@ -33,6 +33,13 @@ void main() {
       expect(lexiconFor(Industry.restaurant).item, 'Item');
     });
 
+    test('itemPlural pluralises the item noun for headings (#81)', () {
+      expect(lexiconFor(Industry.beverage).itemPlural, 'Products');
+      expect(lexiconFor(Industry.pharmacy).itemPlural, 'Medicines');
+      expect(lexiconFor(Industry.phoneAndGadgets).itemPlural, 'Handsets');
+      expect(lexiconFor(Industry.generic).itemPlural, 'Products');
+    });
+
     test('resolves through the registry: industryOf → lexicon', () {
       // The UI path: stored type → industryOf → lexiconFor.
       expect(lexiconFor(industryOf('Pharmacy')).item, 'Medicine');


### PR DESCRIPTION
Closes #81 — the terminology morph, second half (PRD #76, ADR 0015). Blocked by #80 (merged); branches off updated main. **This completes PRD #76's terminology morph.**

## What this does
Extends the industry Lexicon (from #80) to the rest of the selling + stock experience, so the whole app speaks the selected trade's words. A pharmacy sees "No medicines yet", the "Medicines" tab, "Add Medicine", "Search medicines", "Tap a medicine to add it to the cart"; a Beverage distributor sees **exactly today's wording** (no regression).

## How
- **`Lexicon.itemPlural`** getter (Products → Medicines/Handsets; simple `+s` covers every shipped noun) plus **`itemLower`/`itemPluralLower`** for mid-sentence use.
- Wired the item noun into: the **POS** grid empty state, tap/long-press coach tips, and search hint; the **Inventory** tab title, Add-{item} FAB, search, and filter-miss empty state; and the **guides / empty states** — the shared first-run empty state ("Add your first {item}"), the Home empty state + buying-price hint, the stock-count empty state + picker, and the Get Started checklist.
- Read via `industryLexiconProvider` with **`ref.watch`** in build paths (words follow a live industry switch); callbacks use `ref.read`.
- **No slot-sprawl** (the ADR audit): "Receive Stock" (ADR-locked), "Suppliers", "History", "Save/Price/Stock" stay literal; `manufacturer`/`supplier` are out of the item/unit/category scope; crate/empties stay `isCrateBusiness`-gated. Industries without a filled slot fall back to the generic word.

## Tests
`test/industry/lexicon_test.dart` gains an `itemPlural` case (Products/Medicines/Handsets, generic → Products).

## Verification
- `flutter analyze` → clean project-wide.
- `flutter test test/industry` → 21 green.
- `flutter run` on the Android emulator → built + booted + rendered cleanly (0 errors; the `watch` calls run at boot); the Beverage business shows unchanged wording.

## Two-axis code review applied
Standards: switched build-time `ref.read` → `ref.watch` (per the provider's live-switch contract) and DRYed the lowercase interpolations via new getters. Spec: wired three surfaces the first pass missed (POS search hint, stock-count picker, Home buying-price hint). No over-reach (forms untouched — those were #80; locked/neutral words left literal).

With #77–#81 all landed, PRD #76 (multi-industry onboarding & app morphing) is complete; deeper per-industry features (IMEI, expiry, cold-chain) are the phased follow-ups.