### PR TITLE
fix(pos): reset stale category selection to avoid firstWhere crash (#89)

### DIFF
--- a/BUILD_LOG.md
+++ b/BUILD_LOG.md
@@ -2,6 +2,32 @@
 
 ---
 
+## 2026-07-07 — Fix POS crash on stale category selection (deleted-category dangle)
+
+**What changed.** `pos_home_screen.dart:272` built the active category chip
+label with `_controller!.categories.firstWhere((c) => c.id == selectedCategoryId)`.
+When the selected category disappears from the stream — renamed away,
+soft-deleted, or removed on the console then synced down — `firstWhere` throws
+`StateError: Bad state: No element` and the POS screen crashes.
+
+- **Root-cause fix (`pos_controller.dart` `_loadCategories`):** when the
+  `watchAllCategories()` stream emits a list that no longer contains
+  `selectedCategoryId`, reset the selection to `null` (→ "All").
+- **Defense-in-depth (`pos_home_screen.dart`):** new `_selectedCategoryLabel()`
+  helper does a plain loop with an `'All'` fallback instead of `firstWhere`, so
+  the label can never throw even during the momentary window before the
+  controller resets.
+
+`flutter analyze` on both files: no issues. Behavioural fix; no schema/sync
+change. Part of the deleted-product / downward-tombstone investigation — the
+crash is a *symptom* of category removals syncing down while the POS selection
+is stale.
+
+**Files changed:** `lib/features/pos/screens/pos_home_screen.dart`,
+`lib/features/pos/controllers/pos_controller.dart`.
+
+---
+
 ## 2026-07-07 — Terminology morph (Lexicon) on POS, inventory & guides (issue #81, PRD #76)
 
 **What changed.** Extends the industry Lexicon (from #80) to the remaining

--- a/lib/features/pos/controllers/pos_controller.dart
+++ b/lib/features/pos/controllers/pos_controller.dart
@@ -69,6 +69,14 @@ class PosController extends ChangeNotifier {
     _categoriesSub = _database.inventoryDao.watchAllCategories().listen((list) {
       if (_disposed) return;
       categories = list;
+      // A category the cashier had filtered on can disappear from the stream
+      // (renamed away, soft-deleted, or removed on the console then synced
+      // down). Drop the now-dangling selection back to "All" so the chip-row
+      // lookup in pos_home_screen can't `firstWhere` on a missing id and crash.
+      if (selectedCategoryId != null &&
+          !list.any((c) => c.id == selectedCategoryId)) {
+        selectedCategoryId = null;
+      }
       notifyListeners();
     });
   }

--- a/lib/features/pos/screens/pos_home_screen.dart
+++ b/lib/features/pos/screens/pos_home_screen.dart
@@ -265,15 +265,11 @@ class _PosHomeScreenState extends ConsumerState<PosHomeScreen> {
                           'All',
                           ..._controller!.categories.map((c) => c.name),
                         ],
-                        selectedCategory:
-                            _controller!.selectedCategoryId == null
-                            ? 'All'
-                            : _controller!.categories
-                                  .firstWhere(
-                                    (c) =>
-                                        c.id == _controller!.selectedCategoryId,
-                                  )
-                                  .name,
+                        // Defense-in-depth: the controller already resets a
+                        // dangling selectedCategoryId, but never let the chip
+                        // label `firstWhere` throw if the selected category is
+                        // momentarily absent from the list — fall back to 'All'.
+                        selectedCategory: _selectedCategoryLabel(),
                         onCategorySelected: (name) {
                           if (name == 'All') {
                             _controller!.selectCategory(null);
@@ -403,6 +399,19 @@ class _PosHomeScreenState extends ConsumerState<PosHomeScreen> {
         ),
       ),
     );
+  }
+
+  // Chip label for the active category filter. A plain lookup that falls back
+  // to 'All' rather than `firstWhere` (which throws StateError when the
+  // selected category is momentarily missing from the list — e.g. right after
+  // a soft-delete/console removal syncs down before the selection resets).
+  String _selectedCategoryLabel() {
+    final id = _controller!.selectedCategoryId;
+    if (id == null) return 'All';
+    for (final c in _controller!.categories) {
+      if (c.id == id) return c.name;
+    }
+    return 'All';
   }
 
   // Inline dismissible hint shown above the product grid (first couple of


### PR DESCRIPTION
Closes #89

The POS home screen crashed with `StateError: Bad state: No element` when the active category filter no longer existed in the list (category renamed, soft-deleted, or removed on the console then synced down).

**Root cause** — `pos_controller.dart` `_loadCategories` replaced the list on every cloud update but never reset a now-dangling `selectedCategoryId`; `pos_home_screen.dart:272` then `firstWhere`'d on the missing id.

**Fix**
- `pos_controller.dart`: when the category stream emits a list without `selectedCategoryId`, reset it to `null` (→ "All").
- `pos_home_screen.dart`: new `_selectedCategoryLabel()` helper uses a plain loop with an `'All'` fallback instead of `firstWhere` (defense-in-depth).

Behavioural fix, no schema/sync change. `flutter analyze` on both files: clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented the POS screen from crashing when the selected category is no longer available.
  * The category filter now safely falls back to **All** if the active category disappears or can’t be found.
* **Documentation**
  * Added a release log entry summarizing the fix and verification status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->