### PR TITLE
fix(sync): reconnect + app-resume catch-up pull so devices don't miss cloud soft-deletes (#88)

### DIFF
--- a/BUILD_LOG.md
+++ b/BUILD_LOG.md
@@ -2,6 +2,35 @@
 
 ---
 
+## 2026-07-07 — Reconnect + app-resume catch-up pull; re-stamp cleanup (issue #88)
+
+**What changed.** Devices missed cloud soft-deletes because Supabase realtime
+never replays events dropped while the socket was down, and the reconnect
+catch-up only fired after a *failed* pull. Live data confirmed the lingering
+"deleted" products were soft-deleted + recent (not hard-deleted).
+
+- **`catchUpPull(businessId)`** — new silent, 20s-debounced delta pull; guarded
+  by the in-flight full-pull flag + online check; pushes the outbox first (§3.4).
+- **Reconnect** (`_onOnlineChanged`) now calls it **unconditionally** on every
+  offline→online (dropped the "only if last pull failed" gate).
+- **App-resume** (`auto_lock_wrapper`) now also fires it (previously only
+  refreshed the businesses row + restarted realtime).
+- **Migration `0146_restamp_soft_deleted_rows.sql`** — one-time
+  `last_updated_at=now() WHERE is_deleted` on the catalog/entity tables so every
+  device re-pulls and drops them. Positive sync only (zero wipe-race). The local
+  "delete rows absent from snapshot" reconcile was explicitly rejected.
+
+**Tests** `test/sync/catch_up_pull_test.dart` (guards + debounce); full
+`test/sync/` suite green (183). **0146 deployed + verified** via `apply_migration`
+(2026-07-07): all 6 soft-deleted products re-stamped.
+
+**Files changed:** `lib/core/services/supabase_sync_service.dart`,
+`lib/shared/widgets/auto_lock_wrapper.dart`,
+`supabase/migrations/0146_restamp_soft_deleted_rows.sql`,
+`test/sync/catch_up_pull_test.dart`.
+
+---
+
 ## 2026-07-07 — Terminology morph (Lexicon) on POS, inventory & guides (issue #81, PRD #76)
 
 **What changed.** Extends the industry Lexicon (from #80) to the remaining

--- a/lib/core/services/supabase_sync_service.dart
+++ b/lib/core/services/supabase_sync_service.dart
@@ -263,6 +263,12 @@ class SupabaseSyncService {
     PullStatus.idle,
   );
 
+  /// Debounce window shared by the reconnect + app-resume [catchUpPull] calls,
+  /// so a device that regains network and foregrounds at nearly the same moment
+  /// doesn't fire two overlapping delta pulls.
+  static const Duration _catchUpDebounce = Duration(seconds: 20);
+  DateTime? _lastCatchUpAt;
+
   /// Re-entrancy guard for `pullChanges`. setCurrentUser fires it on every
   /// login boundary; the connectivity-recovery listener may also fire it;
   /// users can tap the catch-up banner retry. Without a guard these can race
@@ -345,27 +351,17 @@ class SupabaseSyncService {
       } catch (e) {
         debugPrint('[SyncService] onReconnected hook threw: $e');
       }
-    }
-    if (!_wasOnline &&
-        nowOnline &&
-        pullStatus.value.stage == PullStage.failed &&
-        _currentBusinessId != null &&
-        !_fullPullRunning) {
-      debugPrint(
-        '[SyncService] Connectivity recovered while pull was failed — '
-        'auto-retrying pullChanges($_currentBusinessId)',
-      );
-      // Fire-and-forget retry. If we're still offline / the link is flaky this
-      // throws again; swallow it so it can't escape to the top-level zone as an
-      // unhandled error. pullStatus stays `failed` and the next connectivity
-      // flip retries (offline-first — a failed background pull is not a crash).
-      // §3.4: push the outbox first so a device that was offline uploads its
-      // work before re-downloading.
-      unawaited(
-        pushThenPull(_currentBusinessId!).catchError((Object e) {
-          debugPrint('[SyncService] connectivity-retry pull failed: $e');
-        }),
-      );
+      // Unconditional catch-up: realtime never replays `postgres_changes`
+      // missed while the socket was down, so on EVERY reconnect — not only
+      // after a *failed* pull — pull the delta since the last watermark.
+      // Otherwise a product soft-deleted on the console while this device was
+      // offline lingers (still sellable) until the next login or manual
+      // refresh. Debounced + in-flight-guarded inside catchUpPull, which also
+      // pushes the outbox first (§3.4: upload before re-downloading).
+      final bizId = _currentBusinessId;
+      if (bizId != null) {
+        unawaited(catchUpPull(bizId, reason: 'reconnect'));
+      }
     }
     _wasOnline = nowOnline;
   }
@@ -1981,6 +1977,44 @@ class SupabaseSyncService {
     await _runPushOnce();
     await pullChanges(businessId);
   }
+
+  /// Silent, debounced delta catch-up pull for the reconnect + app-resume
+  /// paths. Supabase realtime does NOT replay `postgres_changes` missed while
+  /// the socket was down (offline, or OS-suspended while the app is
+  /// backgrounded), so a console edit — most importantly a product soft-delete
+  /// — can otherwise linger on a logged-in device until the next login or
+  /// manual pull-to-refresh. This pulls the delta since the last watermark with
+  /// no refresh banner (background only). Guarded by the in-flight full-pull
+  /// flag and a shared debounce so a near-simultaneous reconnect + foreground
+  /// can't fire two overlapping pulls; best-effort (never throws to the caller).
+  Future<void> catchUpPull(String businessId, {String reason = ''}) async {
+    if (_currentBusinessId == null || _fullPullRunning || !isOnline.value) {
+      return;
+    }
+    final now = DateTime.now();
+    if (_lastCatchUpAt != null &&
+        now.difference(_lastCatchUpAt!) < _catchUpDebounce) {
+      debugPrint('[SyncService] Catch-up pull ($reason) debounced');
+      return;
+    }
+    _lastCatchUpAt = now;
+    debugPrint('[SyncService] Catch-up pull ($reason) for $businessId');
+    try {
+      await pushThenPull(businessId);
+    } catch (e) {
+      debugPrint('[SyncService] catch-up pull ($reason) failed: $e');
+    }
+  }
+
+  /// Test seam: the timestamp of the last non-debounced [catchUpPull], so a test
+  /// can assert the guard/debounce decisions without driving the full pull.
+  @visibleForTesting
+  DateTime? get lastCatchUpAtForTesting => _lastCatchUpAt;
+
+  /// Test seam: bind the active business without running a login/pull, so
+  /// [catchUpPull]'s guards can be exercised in isolation.
+  @visibleForTesting
+  set currentBusinessIdForTesting(String? id) => _currentBusinessId = id;
 
   /// Minimum-login pull: fetches only the tables required for `MainLayout`
   /// to render. Designed to complete in ~1-6 seconds depending on link

--- a/lib/shared/widgets/auto_lock_wrapper.dart
+++ b/lib/shared/widgets/auto_lock_wrapper.dart
@@ -99,6 +99,13 @@ class _AutoLockWrapperState extends ConsumerState<AutoLockWrapper>
         // this, "live" sync silently stays dead after the app comes back even
         // though refreshBusinessRow above does a one-shot catch-up.
         _sync.restartRealtimeSync(subBizId);
+        // Beyond the businesses row above: pull the full delta since the last
+        // watermark so any INSERT/UPDATE the realtime socket missed while the
+        // app was backgrounded lands now — most importantly a product
+        // soft-deleted on the console, which would otherwise linger (still
+        // sellable) until the next login or manual refresh. Silent + debounced
+        // inside catchUpPull; ref-free (uses captured _sync).
+        unawaited(_sync.catchUpPull(subBizId, reason: 'app-resume'));
       }
 
       final pausedMs = prefs.getInt(_pausedTimeKey);

--- a/supabase/migrations/0146_restamp_soft_deleted_rows.sql
+++ b/supabase/migrations/0146_restamp_soft_deleted_rows.sql
@@ -1,0 +1,39 @@
+-- 0146_restamp_soft_deleted_rows.sql
+--
+-- One-time cleanup for the "deleted product still sellable" symptom (#88). Rows
+-- correctly soft-deleted on the console (is_deleted = true) can still show on a
+-- logged-in device that never received the update: Supabase realtime does not
+-- replay events missed while the socket was down, and before #88's catch-up
+-- pull a device only re-pulled on login / manual refresh.
+--
+-- Bumping last_updated_at = now() on every already-soft-deleted row forces the
+-- next incremental pull (pos_pull_snapshot: WHERE last_updated_at > p_since) to
+-- re-deliver it, so each device applies is_deleted = true and drops it from the
+-- POS grid / lists.
+--
+-- POSITIVE sync only — it never deletes a local row, so there is zero wipe-race
+-- risk. (This is deliberately NOT the rejected "delete local rows absent from a
+-- full cloud snapshot" reconcile, which could wrongly delete valid rows on an
+-- incomplete snapshot.) Pairs with #87 (REVOKE client hard-delete) and #88
+-- (reconnect + app-resume catch-up pull).
+--
+-- Scoped to the user-visible catalog / entity tables, all of which ride
+-- pos_pull_snapshot down. Guarded by to_regclass so it is safe on any schema
+-- subset. Idempotent (re-running simply re-stamps the same rows).
+
+do $$
+declare
+  t text;
+  restamp_tables text[] := array[
+    'products','categories','customers','suppliers','manufacturers','stores',
+    'price_lists','drivers','expenses','expense_categories','expense_budgets'
+  ];
+begin
+  foreach t in array restamp_tables loop
+    if to_regclass('public.' || t) is not null then
+      execute format(
+        'update public.%I set last_updated_at = now() where is_deleted = true', t
+      );
+    end if;
+  end loop;
+end $$;

--- a/test/sync/catch_up_pull_test.dart
+++ b/test/sync/catch_up_pull_test.dart
@@ -1,0 +1,79 @@
+// catch_up_pull_test.dart
+//
+// #88: devices missed cloud soft-deletes because realtime never replays events
+// dropped while the socket was down, and a catch-up pull only fired after a
+// *failed* pull. `catchUpPull` is the shared, silent, debounced delta-pull that
+// the reconnect (unconditional) and app-resume paths now call.
+//
+// These tests pin the guard + debounce decisions in isolation via the
+// @visibleForTesting seams, without driving the full connectivity-guarded pull.
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:reebaplus_pos/core/database/app_database.dart';
+import 'package:reebaplus_pos/core/services/supabase_sync_service.dart';
+
+import '../helpers/dispatch_test_utils.dart';
+import '../helpers/in_memory_cloud_transport.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('catchUpPull guards + debounce', () {
+    late AppDatabase db;
+    late String businessId;
+    late InMemoryCloudTransport transport;
+    late SupabaseSyncService sync;
+
+    setUp(() async {
+      final boot = await bootstrapTestDb();
+      db = boot.db;
+      businessId = boot.businessId;
+      transport = InMemoryCloudTransport(authUserId: 'user-1');
+      sync = SupabaseSyncService(db, transport);
+    });
+
+    tearDown(() async {
+      await transport.dispose();
+      await db.close();
+    });
+
+    test('is a no-op when no business is bound (no pull attempted)', () async {
+      sync.currentBusinessIdForTesting = null;
+      sync.isOnline.value = true;
+
+      await sync.catchUpPull(businessId, reason: 'test');
+
+      expect(sync.lastCatchUpAtForTesting, isNull);
+      expect(transport.fetchQueries, isEmpty);
+    });
+
+    test('is a no-op when offline (no pull attempted)', () async {
+      sync.currentBusinessIdForTesting = businessId;
+      sync.isOnline.value = false;
+
+      await sync.catchUpPull(businessId, reason: 'test');
+
+      expect(sync.lastCatchUpAtForTesting, isNull);
+      expect(transport.fetchQueries, isEmpty);
+    });
+
+    test('proceeds once when eligible, then debounces an immediate second call',
+        () async {
+      sync.currentBusinessIdForTesting = businessId;
+      sync.isOnline.value = true;
+
+      // First call is eligible: it stamps _lastCatchUpAt before pulling. (The
+      // pull itself is best-effort and swallowed — this test only asserts the
+      // gate/debounce decision, not the pull outcome.)
+      await sync.catchUpPull(businessId, reason: 'first');
+      final firstAt = sync.lastCatchUpAtForTesting;
+      expect(firstAt, isNotNull);
+
+      // Second call within the debounce window must NOT re-stamp — proving it
+      // returned early instead of firing another overlapping pull.
+      await sync.catchUpPull(businessId, reason: 'second');
+      expect(sync.lastCatchUpAtForTesting, firstAt);
+    });
+  });
+}


### PR DESCRIPTION
Closes #88

A product soft-deleted on the console (correctly: `is_deleted=true, last_updated_at=now()`) could keep showing — and stay sellable — on a logged-in device for days. Live data confirmed the lingering rows are soft-deleted and recent, **not** hard-deleted: the cloud is right, the device just never received the update.

**Root cause** — realtime subscribes to `products` but Supabase never replays `postgres_changes` missed while the socket was down (offline, or OS-suspended in the background), and pulls only fired on login / manual refresh. The reconnect catch-up (`_onOnlineChanged`) was **gated on the previous pull having *failed***, so a device that last pulled successfully, went offline, missed a delete, and came back online got no catch-up.

**Fix**
- `catchUpPull(businessId)` — new silent, debounced (20s) delta pull; guarded by the in-flight full-pull flag + online check; pushes the outbox first (§3.4).
- **Reconnect:** `_onOnlineChanged` now calls it **unconditionally** on every offline→online (dropped the "only if last pull failed" gate).
- **App-resume:** `auto_lock_wrapper` already refreshed only the *businesses* row on foreground (+ restarted realtime); now it also fires `catchUpPull` to catch missed product/category/etc. soft-deletes.
- **One-time re-stamp** (migration `0146`): bump `last_updated_at=now()` on already-soft-deleted rows so every device re-pulls and drops them. Positive sync only — zero deletion risk. We explicitly rejected a local "delete rows missing from a full snapshot" reconcile (wipe-race).

**Tests** — `test/sync/catch_up_pull_test.dart`: no-op when no business / offline; proceeds once then debounces. Full `test/sync/` suite green (183).

⚠️ Migration `0146` deploy is pending (same production-DDL hand-off as #87).