### PR TITLE
fix(sync): await realtime teardown before re-subscribe so live sync survives (#93)

### DIFF
--- a/BUILD_LOG.md
+++ b/BUILD_LOG.md
@@ -2,6 +2,50 @@
 
 ---
 
+## 2026-07-07 — Fix realtime resubscribe teardown/re-create race (issue #93)
+
+**What changed.** Console edits/soft-deletes never propagated **live** to the
+app — a deleted product stayed sellable until a manual pull-to-refresh. Device
+logs showed `Starting real-time sync` twice but never
+`[CloudTransport] Realtime subscribed: <table>`. Root cause: a teardown/re-create
+race in `restartRealtimeSync` (fired on app-resume + connectivity-recovery, so
+≈ every launch).
+
+- `_tearDownRealtimeChannels()` fired `unawaited(_transport.stopRealtime())` then
+  synchronously re-created via `startRealtimeSync`. The real
+  `SupabaseCloudTransport.stopRealtime()` cleared `_tableChannels` **after** its
+  `await removeChannel` loop, so it suspended with the list still full; the
+  recreate's `startRealtime` guard (`if (_tableChannels.isNotEmpty ...) return;`)
+  then bailed and created **zero** channels. Net: no live channels for the whole
+  session (all ~40 synced tables), REST/pull unaffected.
+
+**Fix.**
+- `restartRealtimeSync` now **awaits** the full teardown before re-subscribing;
+  `_tearDownRealtimeChannels` flips `_realtimeActive=false` *synchronously* (before
+  the await) as a re-entrancy guard. Awaiting also removes the same-topic
+  two-live-channels hazard.
+- Hardened `SupabaseCloudTransport.stopRealtime()` to snapshot+clear its channel
+  holders **synchronously** before the awaited removals, so its own guard can't be
+  lied to by a fire-and-forget caller.
+- The two fire-and-forget call sites (`auto_lock_wrapper` resume,
+  `_onOnlineChanged` reconnect) wrapped in `unawaited(...)`.
+
+**Scope note.** Coverage was already all synced tables (`{..._pullOrder,
+'businesses'}`) — the race disabled every table together, so this restores live
+sync across every console-editable entity at once. No topology change.
+
+**Verified.** New `test/sync/realtime_resubscribe_test.dart` (3 tests) models a
+worst-case late-releasing transport; confirmed red with the fix reverted
+(`+1 -2`), green with it. Full `test/sync/` suite: 186 passing. `flutter analyze`
+clean on all four touched files.
+
+**Files changed:** `lib/core/services/supabase_sync_service.dart`,
+`lib/core/services/supabase_cloud_transport.dart`,
+`lib/shared/widgets/auto_lock_wrapper.dart`,
+`test/sync/realtime_resubscribe_test.dart`.
+
+---
+
 ## 2026-07-07 — Forbid client hard-delete of soft-delete tables (issue #87)
 
 **What changed.** Migration `0145_forbid_hard_delete_soft_tables.sql` —

--- a/lib/core/services/supabase_cloud_transport.dart
+++ b/lib/core/services/supabase_cloud_transport.dart
@@ -250,13 +250,20 @@ class SupabaseCloudTransport implements CloudTransport {
 
   @override
   Future<void> stopRealtime() async {
-    for (final channel in _tableChannels) {
+    // Snapshot + clear the channel holders *synchronously* before the first
+    // await, so `startRealtime`'s `isNotEmpty` guard reflects reality the moment
+    // this yields control: a fire-and-forget stop immediately followed by a start
+    // must not see the not-yet-removed channels and bail (the #93 resubscribe
+    // race, where recreating mid-teardown created zero channels).
+    final channels = List<RealtimeChannel>.from(_tableChannels);
+    _tableChannels.clear();
+    final businessesChannel = _businessesChannel;
+    _businessesChannel = null;
+    for (final channel in channels) {
       await _client.removeChannel(channel);
     }
-    _tableChannels.clear();
-    if (_businessesChannel != null) {
-      await _client.removeChannel(_businessesChannel!);
-      _businessesChannel = null;
+    if (businessesChannel != null) {
+      await _client.removeChannel(businessesChannel);
     }
   }
 

--- a/lib/core/services/supabase_sync_service.dart
+++ b/lib/core/services/supabase_sync_service.dart
@@ -3160,16 +3160,22 @@ class SupabaseSyncService {
   /// Stops listening to real-time changes (e.g., on logout).
   void stopRealtimeSync() {
     debugPrint('[SyncService] Stopping real-time sync.');
-    _tearDownRealtimeChannels();
+    unawaited(_tearDownRealtimeChannels());
     stopAutoPush();
   }
 
   /// Removes the active realtime channels without touching auto-push. Shared by
-  /// [stopRealtimeSync] (logout) and [restartRealtimeSync] (resubscribe). The
-  /// channel teardown is fire-and-forget (as the old `removeChannel` calls were).
-  void _tearDownRealtimeChannels() {
-    unawaited(_transport.stopRealtime());
+  /// [stopRealtimeSync] (logout) and [restartRealtimeSync] (resubscribe).
+  ///
+  /// `_realtimeActive` flips to false *synchronously* (before the await) so a
+  /// concurrent [restartRealtimeSync] can't slip past its own guard mid-teardown
+  /// and double-subscribe. The removal is then awaited so a resubscribing caller
+  /// sees a fully-cleared transport: `startRealtime` no-ops while any channel
+  /// object is still held, so re-creating before `stopRealtime` finished silently
+  /// dropped every channel — realtime dead for the whole session (#93).
+  Future<void> _tearDownRealtimeChannels() async {
     _realtimeActive = false;
+    await _transport.stopRealtime();
   }
 
   /// Re-establishes the realtime subscriptions after they may have been
@@ -3184,10 +3190,14 @@ class SupabaseSyncService {
   /// Driven by app-resume and connectivity-recovery. Idempotent and cheap (a
   /// few channels); a no-op when there were no channels to begin with (not yet
   /// signed in) — `startRealtimeSync` itself requires a logged-in business.
-  void restartRealtimeSync(String businessId) {
+  Future<void> restartRealtimeSync(String businessId) async {
     if (!_realtimeActive) return;
     debugPrint('[SyncService] Re-subscribing realtime for $businessId.');
-    _tearDownRealtimeChannels();
+    // Await the full teardown before re-subscribing: `startRealtime` no-ops while
+    // the previous channel objects are still held, so recreating before
+    // `stopRealtime` completes drops every channel and leaves realtime dead for
+    // the session (#93). Awaiting also avoids two live channels on one topic.
+    await _tearDownRealtimeChannels();
     startRealtimeSync(businessId);
   }
 
@@ -3447,7 +3457,7 @@ class SupabaseSyncService {
         // this listener) can leave the realtime websocket dead with no SDK
         // rejoin — resubscribe so live updates resume, not just the one-shot
         // catch-up pull below.
-        restartRealtimeSync(businessId);
+        unawaited(restartRealtimeSync(businessId));
         unawaited(() async {
           try {
             // Reconnect backstop for a staff device that was offline when the

--- a/lib/shared/widgets/auto_lock_wrapper.dart
+++ b/lib/shared/widgets/auto_lock_wrapper.dart
@@ -98,7 +98,7 @@ class _AutoLockWrapperState extends ConsumerState<AutoLockWrapper>
         // channel rejoin is not guaranteed after a long suspension — without
         // this, "live" sync silently stays dead after the app comes back even
         // though refreshBusinessRow above does a one-shot catch-up.
-        _sync.restartRealtimeSync(subBizId);
+        unawaited(_sync.restartRealtimeSync(subBizId));
         // Beyond the businesses row above: pull the full delta since the last
         // watermark so any INSERT/UPDATE the realtime socket missed while the
         // app was backgrounded lands now — most importantly a product

--- a/test/sync/realtime_resubscribe_test.dart
+++ b/test/sync/realtime_resubscribe_test.dart
@@ -1,0 +1,121 @@
+// realtime_resubscribe_test.dart
+//
+// #93: realtime live sync died every session. `restartRealtimeSync` (fired on
+// app-resume + connectivity-recovery, ~every launch) tore the channels down
+// fire-and-forget, then synchronously re-created them — but the transport's
+// `startRealtime` no-ops while any channel object is still held, so the recreate
+// bailed and left ZERO channels. Symptom: logs show "Starting real-time sync"
+// twice but never "Realtime subscribed: <table>", and console edits/deletes only
+// land on a manual pull.
+//
+// This test drives a transport that models the worst case — `stopRealtime`
+// yields (suspends) *before* releasing its channels, exactly like the real
+// adapter's `await removeChannel(...)` loop that only clears afterwards. The fix
+// is that `restartRealtimeSync` now awaits the full teardown before
+// re-subscribing, so it works even against such a transport.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:supabase_flutter/supabase_flutter.dart' show PostgresChangePayload;
+
+import 'package:reebaplus_pos/core/database/app_database.dart';
+import 'package:reebaplus_pos/core/services/supabase_sync_service.dart';
+
+import '../helpers/dispatch_test_utils.dart';
+import '../helpers/in_memory_cloud_transport.dart';
+
+/// A transport whose realtime teardown releases its channels *after* an async
+/// gap — reproducing the pre-#93 race window where `startRealtime`'s
+/// "channels still held" guard would see stale channels and refuse to subscribe.
+class _LateReleaseRealtimeTransport extends InMemoryCloudTransport {
+  _LateReleaseRealtimeTransport({super.authUserId});
+
+  /// Mirrors the real adapter's `_tableChannels.isNotEmpty` guard state.
+  bool held = false;
+
+  @override
+  void startRealtime(
+    Iterable<String> tables,
+    String businessId, {
+    required void Function(PostgresChangePayload) onChange,
+  }) {
+    if (held) return; // the guard that silently dropped every channel (#93)
+    held = true;
+    super.startRealtime(tables, businessId, onChange: onChange);
+  }
+
+  @override
+  Future<void> stopRealtime() async {
+    // Yield BEFORE releasing the channels, exactly like the real adapter
+    // suspending at its first `await removeChannel` with `_tableChannels` full.
+    await Future<void>.delayed(Duration.zero);
+    held = false;
+    await super.stopRealtime();
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('restartRealtimeSync teardown/re-create ordering (#93)', () {
+    late AppDatabase db;
+    late String businessId;
+    late _LateReleaseRealtimeTransport transport;
+    late SupabaseSyncService sync;
+
+    setUp(() async {
+      final boot = await bootstrapTestDb();
+      db = boot.db;
+      businessId = boot.businessId;
+      transport = _LateReleaseRealtimeTransport(authUserId: 'user-1');
+      sync = SupabaseSyncService(db, transport);
+    });
+
+    tearDown(() async {
+      await transport.dispose();
+      await db.close();
+    });
+
+    test('initial start subscribes every synced table, not just products',
+        () async {
+      sync.startRealtimeSync(businessId);
+
+      expect(transport.held, isTrue);
+      // Coverage is the whole synced set — the console can edit any of these.
+      expect(transport.subscribedTables, contains('products'));
+      expect(transport.subscribedTables, contains('categories'));
+      expect(transport.subscribedTables, contains('customers'));
+      expect(transport.subscribedTables, contains('manufacturers'));
+      expect(transport.subscribedTables, contains('suppliers'));
+    });
+
+    test('restart re-subscribes after teardown instead of dropping all channels',
+        () async {
+      sync.startRealtimeSync(businessId);
+      expect(transport.subscribedTables, contains('products'));
+
+      // The pre-fix race: recreate raced the still-in-flight teardown and the
+      // guard bailed, leaving zero channels. Awaiting the teardown fixes it.
+      await sync.restartRealtimeSync(businessId);
+      // Drain any still-pending teardown: without the fix, the fire-and-forget
+      // `stopRealtime` finishes here and wipes the (never-recreated) channels,
+      // so the assertions below go red. With the fix there is nothing pending.
+      await pumpEventQueue();
+
+      expect(transport.held, isTrue,
+          reason: 'realtime must be live again after a restart');
+      expect(transport.subscribedTables, contains('products'));
+      expect(transport.subscribedTables, contains('categories'));
+    });
+
+    test('a second restart is still live (repeatable across resumes)', () async {
+      sync.startRealtimeSync(businessId);
+
+      await sync.restartRealtimeSync(businessId);
+      await sync.restartRealtimeSync(businessId);
+      await pumpEventQueue();
+
+      expect(transport.held, isTrue);
+      expect(transport.subscribedTables, contains('products'));
+    });
+  });
+}


### PR DESCRIPTION
Closes #93.

## Problem
Console edits/soft-deletes never reached the app **live** — a deleted product stayed sellable until a manual pull-to-refresh. Device logs showed `Starting real-time sync` twice but **never** `[CloudTransport] Realtime subscribed: <table>`.

## Root cause — teardown/re-create race
`restartRealtimeSync` (fires on app-resume + connectivity-recovery, ≈ every launch):
1. `_tearDownRealtimeChannels()` calls `unawaited(_transport.stopRealtime())`, then synchronously re-creates via `startRealtimeSync`.
2. `SupabaseCloudTransport.stopRealtime()` clears `_tableChannels` **after** its `await removeChannel` loop → it suspends with the list still full.
3. The recreate's guard `if (_tableChannels.isNotEmpty || _businessesChannel != null) return;` sees the stale list and **bails → zero channels created**.
4. The suspended `stopRealtime` then removes the original channels too.

Net: no live channels for the whole session (all ~40 synced tables); REST/pull unaffected (why manual refresh worked).

## Fix
- `restartRealtimeSync` **awaits** the full teardown before re-subscribing; `_tearDownRealtimeChannels` flips `_realtimeActive=false` **synchronously** (re-entrancy guard). Awaiting also removes the same-topic two-live-channels hazard.
- Hardened `SupabaseCloudTransport.stopRealtime()` to snapshot+clear its channel holders **synchronously** before the awaited removals, so its own guard can't be lied to by a fire-and-forget caller.
- The two fire-and-forget call sites (`auto_lock_wrapper` resume, `_onOnlineChanged` reconnect) wrapped in `unawaited(...)`.

## Scope
Realtime already subscribes to the whole synced set (`{..._pullOrder, 'businesses'}`) — the race disabled every table together, so this restores live sync across **every** console-editable entity at once. No topology change.

## Verification
- New `test/sync/realtime_resubscribe_test.dart` (3 tests) models a worst-case late-releasing transport. Confirmed **red with the fix reverted** (`+1 -2`), green with it.
- Full `test/sync/` suite: **186 passing**.
- `flutter analyze` clean on all four touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where live updates could stop working after a realtime reconnect or app resume.
  * Improved restart handling so realtime subscriptions are torn down and recreated in the correct order, helping prevent stalled sync sessions.
  * Added regression coverage to verify realtime resubscription works reliably across repeated restarts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->