### PR TITLE
fix(sync): make realtime live sync work — one channel + authorize the socket (#95, #97)

### DIFF
--- a/BUILD_LOG.md
+++ b/BUILD_LOG.md
@@ -2,6 +2,38 @@
 
 ---
 
+## 2026-07-07 — Realtime: one channel with many bindings, not one-per-table (issue #95)
+
+**What changed.** After #93 let the channels actually attempt to subscribe, the
+device log showed **every** synced table's channel go `channelError` → `timedOut`
+(~55 of them) and never `subscribed`. Supabase realtime logs: tenant connects
+fine, healthy broadcast replication, but **zero postgres_changes (CDC) activity**
+and repeated `Stop tenant … no connected users` — i.e. the socket connects but all
+~55 `postgres_changes` joins are rejected before CDC setup, then the client
+disconnects.
+
+**Root cause.** `SupabaseCloudTransport.startRealtime` opened **one channel per
+synced table** (`channel('public:<table>')`), so sign-in fired ~55
+near-simultaneous `phx_join`s on one socket → past the realtime per-client
+channel/join ceiling → all error + time out.
+
+**Fix.** Collapse to **one channel with a `postgres_changes` binding per table**
+(single websocket join, N bindings) — the supported many-table pattern in
+realtime_client 2.x. Full coverage preserved (all synced tables; `businesses`
+filtered on `id`; `system_config` skipped). All bindings share one `onChange`;
+the engine still dispatches by `payload.table` (one binding per table → no double
+delivery). Single channel `_channel` replaces `_tableChannels`/`_businessesChannel`;
+the #93 synchronous-clear teardown preserved for it. One subscribe-status log for
+the whole tenant channel.
+
+**Verified.** `flutter analyze` clean; `test/sync/` 186 passing. Live
+subscribe/deliver requires on-device confirmation (emulator) — expect a single
+`Realtime subscribed (tenant channel)` on launch instead of ~55 error lines.
+
+**Files changed:** `lib/core/services/supabase_cloud_transport.dart`.
+
+---
+
 ## 2026-07-07 — Fix realtime resubscribe teardown/re-create race (issue #93)
 
 **What changed.** Console edits/soft-deletes never propagated **live** to the

--- a/BUILD_LOG.md
+++ b/BUILD_LOG.md
@@ -2,6 +2,35 @@
 
 ---
 
+## 2026-07-07 — Realtime: authorize the socket for postgres_changes (issue #97)
+
+**What changed.** After the single-channel change (#95), **every** `postgres_changes`
+binding still failed `channelError` → `timedOut` — including `products` (valid, in
+publication, RLS-OK for REST). Realtime server logs: socket connects, broadcast
+replication healthy, but **no `supabase_realtime` CDC slot ever starts**. That is a
+global authorization rejection, not a per-table or channel-count issue.
+
+**Root cause.** `postgres_changes` is RLS-gated: the channel join must carry the
+user's JWT. A realtime channel only reads `socket.accessToken` into its join
+payload **at subscribe time** (realtime_channel.dart). supabase_flutter's
+auto-`setAuth` runs on auth events, but nothing guarantees the socket holds the
+*user* token (vs the anon key) at the instant `startRealtime` subscribes — so joins
+went out unauthenticated. REST/pull always worked because the JWT rides each HTTPS
+request independently.
+
+**Fix.** In `startRealtime`, explicitly `realtime.setAuth(currentSession.accessToken)`
+immediately before `channel.subscribe()` (synchronous for a non-null token, so the
+join carries the JWT). Added a diagnostic — `socketAlreadyHadSessionToken` — that
+prints on-device whether the socket was already authed (true) or on the anon key
+(false → this was the fix).
+
+**Verified.** `flutter analyze` clean; `test/sync/` 186 passing. On-device
+confirmation pending (expect `Realtime subscribed (tenant channel)`).
+
+**Files changed:** `lib/core/services/supabase_cloud_transport.dart`.
+
+---
+
 ## 2026-07-07 — Realtime: one channel with many bindings, not one-per-table (issue #95)
 
 **What changed.** After #93 let the channels actually attempt to subscribe, the

--- a/lib/core/services/supabase_cloud_transport.dart
+++ b/lib/core/services/supabase_cloud_transport.dart
@@ -212,6 +212,24 @@ class SupabaseCloudTransport implements CloudTransport {
       );
     }
 
+    // `postgres_changes` is RLS-gated: the channel join must carry the user's
+    // JWT or the realtime server rejects EVERY binding (channelError, no CDC —
+    // #97). A channel only reads `socket.accessToken` into its join payload at
+    // subscribe time; supabase_flutter's auto-setAuth runs on auth events, but
+    // nothing guarantees the socket holds the *user* token (vs the anon key) at
+    // this exact moment. Force it now — synchronous for a non-null token, so the
+    // subscribe below carries the JWT. The diagnostic reveals whether the socket
+    // was already authed (true → auth was fine, look elsewhere) or on the anon
+    // key (false → this is the fix).
+    final sessionToken = _client.auth.currentSession?.accessToken;
+    final socketAlreadyHadSessionToken =
+        _client.realtime.accessToken == sessionToken;
+    unawaited(_client.realtime.setAuth(sessionToken));
+    debugPrint(
+      '[CloudTransport] Realtime auth: session=${sessionToken != null} '
+      'socketAlreadyHadSessionToken=$socketAlreadyHadSessionToken',
+    );
+
     // One subscribe-status callback for the whole tenant channel — surfaces
     // SUBSCRIBED once (live) or CHANNEL_ERROR / TIMED_OUT once (dead).
     channel.subscribe((status, error) {

--- a/lib/core/services/supabase_cloud_transport.dart
+++ b/lib/core/services/supabase_cloud_transport.dart
@@ -9,9 +9,10 @@ import 'package:reebaplus_pos/core/services/cloud_transport.dart';
 ///
 /// A large adapter with a thin per-method implementation: it forwards the push
 /// verbs, owns the pull pagination loop (moved verbatim from the old
-/// `_fetchOneTable`), and owns the realtime channel lifecycle (one channel per
-/// table, the `businesses`-by-`id` filter quirk, subscribe-status logging, and
-/// teardown). Error modes are passed through untouched: PostgREST failures throw
+/// `_fetchOneTable`), and owns the realtime channel lifecycle (a single tenant
+/// channel with one `postgres_changes` binding per table, the `businesses`-by-`id`
+/// filter quirk, subscribe-status logging, and teardown). Error modes are passed
+/// through untouched: PostgREST failures throw
 /// [PostgrestException]; page/chunk timeouts throw [TimeoutException].
 class SupabaseCloudTransport implements CloudTransport {
   final SupabaseClient _client;
@@ -22,8 +23,9 @@ class SupabaseCloudTransport implements CloudTransport {
   /// a timeout is surfaced so the caller can classify the failure.
   static const int _minPullPageSize = 10;
 
-  final List<RealtimeChannel> _tableChannels = [];
-  RealtimeChannel? _businessesChannel;
+  /// Single realtime channel carrying one `postgres_changes` binding per synced
+  /// table — one websocket join for the whole tenant. See [startRealtime].
+  RealtimeChannel? _channel;
 
   // ── PUSH ──────────────────────────────────────────────────────────────────
   @override
@@ -178,92 +180,64 @@ class SupabaseCloudTransport implements CloudTransport {
     String businessId, {
     required void Function(PostgresChangePayload) onChange,
   }) {
-    if (_tableChannels.isNotEmpty || _businessesChannel != null) return;
+    if (_channel != null) return;
 
-    // One channel per synced tenant table, each with an explicit `table:` +
-    // `business_id` filter. A single `channel('public:*')` with a `business_id`
-    // filter but no `table:` cannot honour a filtered postgres_changes binding,
-    // so the whole channel silently fails — no inbound events for ANY table.
-    // Per-table channels also isolate a bad table to its own channel instead of
-    // tearing down every subscription. The permanent subscribe-status callback
-    // surfaces SUBSCRIBED / CHANNEL_ERROR / TIMED_OUT.
+    // ONE channel carrying a `postgres_changes` binding per synced table — a
+    // single websocket join for the whole tenant — instead of one channel per
+    // table. Signing in fans out ~55 tables; one-channel-per-table fired ~55
+    // near-simultaneous `phx_join`s on the socket, blew past the realtime
+    // per-client channel/join ceiling, and every channel came back
+    // CHANNEL_ERROR → TIMED_OUT with no CDC subscription ever established (#95).
+    // Multiple bindings on a single channel is the supported many-table pattern
+    // (realtime_client 2.x) and needs just one join.
     //
-    // `businesses` (no `business_id` column — its `id` IS the business id) is
-    // handled by the separate channel below; `system_config` is global.
+    // All bindings share `onChange`; the engine dispatches by `payload.table`
+    // (there is exactly one binding per table, so no event is delivered twice).
+    // `businesses` has no `business_id` column — its `id` IS the business id, so
+    // it filters on `id`. `system_config` is global and skipped.
+    var channel = _client.channel('public:tenant:$businessId');
     for (final table in tables) {
-      if (table == 'businesses' || table == 'system_config') continue;
-      try {
-        final channel =
-            _client
-                .channel('public:$table')
-                .onPostgresChanges(
-                  event: PostgresChangeEvent.all,
-                  schema: 'public',
-                  table: table,
-                  filter: PostgresChangeFilter(
-                    type: PostgresChangeFilterType.eq,
-                    column: 'business_id',
-                    value: businessId,
-                  ),
-                  callback: onChange,
-                )
-              ..subscribe((status, error) {
-                if (status == RealtimeSubscribeStatus.channelError ||
-                    status == RealtimeSubscribeStatus.timedOut) {
-                  debugPrint(
-                    '[CloudTransport] Realtime channel "$table" $status'
-                    '${error != null ? ' — $error' : ''}',
-                  );
-                } else if (status == RealtimeSubscribeStatus.subscribed) {
-                  debugPrint('[CloudTransport] Realtime subscribed: $table');
-                }
-              });
-        _tableChannels.add(channel);
-      } catch (e) {
-        debugPrint('[CloudTransport] Realtime subscribe failed for "$table": $e');
-      }
+      if (table == 'system_config') continue;
+      final isBusinesses = table == 'businesses';
+      channel = channel.onPostgresChanges(
+        event: PostgresChangeEvent.all,
+        schema: 'public',
+        table: table,
+        filter: PostgresChangeFilter(
+          type: PostgresChangeFilterType.eq,
+          column: isBusinesses ? 'id' : 'business_id',
+          value: businessId,
+        ),
+        callback: onChange,
+      );
     }
 
-    // Separate channel for `businesses` filtered by `id` (no business_id column).
-    if (tables.contains('businesses')) {
-      try {
-        _businessesChannel =
-            _client
-                .channel('public:businesses')
-                .onPostgresChanges(
-                  event: PostgresChangeEvent.all,
-                  schema: 'public',
-                  table: 'businesses',
-                  filter: PostgresChangeFilter(
-                    type: PostgresChangeFilterType.eq,
-                    column: 'id',
-                    value: businessId,
-                  ),
-                  callback: onChange,
-                )
-              ..subscribe();
-      } catch (e) {
-        debugPrint('[CloudTransport] Businesses realtime subscribe failed: $e');
+    // One subscribe-status callback for the whole tenant channel — surfaces
+    // SUBSCRIBED once (live) or CHANNEL_ERROR / TIMED_OUT once (dead).
+    channel.subscribe((status, error) {
+      if (status == RealtimeSubscribeStatus.channelError ||
+          status == RealtimeSubscribeStatus.timedOut) {
+        debugPrint(
+          '[CloudTransport] Realtime tenant channel $status'
+          '${error != null ? ' — $error' : ''}',
+        );
+      } else if (status == RealtimeSubscribeStatus.subscribed) {
+        debugPrint('[CloudTransport] Realtime subscribed (tenant channel)');
       }
-    }
+    });
+    _channel = channel;
   }
 
   @override
   Future<void> stopRealtime() async {
-    // Snapshot + clear the channel holders *synchronously* before the first
-    // await, so `startRealtime`'s `isNotEmpty` guard reflects reality the moment
-    // this yields control: a fire-and-forget stop immediately followed by a start
-    // must not see the not-yet-removed channels and bail (the #93 resubscribe
-    // race, where recreating mid-teardown created zero channels).
-    final channels = List<RealtimeChannel>.from(_tableChannels);
-    _tableChannels.clear();
-    final businessesChannel = _businessesChannel;
-    _businessesChannel = null;
-    for (final channel in channels) {
+    // Clear the holder *synchronously* before the await so `startRealtime`'s
+    // guard reflects reality the moment this yields control — a fire-and-forget
+    // stop immediately followed by a start must not see the not-yet-removed
+    // channel and bail (the #93 resubscribe race).
+    final channel = _channel;
+    _channel = null;
+    if (channel != null) {
       await _client.removeChannel(channel);
-    }
-    if (businessesChannel != null) {
-      await _client.removeChannel(businessesChannel);
     }
   }
 


### PR DESCRIPTION
Closes #95, closes #97. Follows #94 (#93 resubscribe race).

This PR makes realtime `postgres_changes` (live console→app sync) actually work. It took two layers, uncovered by device logs:

## 1. One channel, many bindings (#95)
`startRealtime` opened one channel per synced table → ~55 simultaneous `phx_join`s at sign-in. Collapsed to **one tenant channel with a `postgres_changes` binding per table** (single join). *Necessary but not sufficient* — all bindings still errored.

## 2. Authorize the socket (#97 — the actual fix)
Even with one channel, **every** binding failed `channelError`→`timedOut` (products included). Realtime server logs: socket connects, broadcast replication healthy, but **no `supabase_realtime` CDC slot ever starts** — a global authorization rejection.

Root cause: `postgres_changes` is RLS-gated; the channel join must carry the user JWT. A channel only reads `socket.accessToken` into its join payload **at subscribe time**. supabase_flutter's auto-`setAuth` runs on auth events but doesn't guarantee the socket holds the *user* token (vs the anon key) at the instant `startRealtime` subscribes → joins went out unauthenticated. (REST/pull always worked because the JWT rides each HTTPS request.)

Fix: explicitly `realtime.setAuth(currentSession.accessToken)` right before `channel.subscribe()` (synchronous for a non-null token), plus a `socketAlreadyHadSessionToken` diagnostic.

## Verification
- `flutter analyze` clean; `test/sync/` **186 passing**.
- **On-device confirmation pending**: expect one `Realtime subscribed (tenant channel)` on launch and console edits landing live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved realtime syncing reliability by ensuring the current session is applied before subscribing.
  * Simplified tenant updates to use one shared realtime connection, reducing duplicate subscriptions and resubscribe issues during shutdown.
  * Fixed table update handling so synced data stays consistent across tenant-related records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->