### PR TITLE
fix(sync): periodic fallback pull for near-live convergence (#98)

### DIFF
--- a/BUILD_LOG.md
+++ b/BUILD_LOG.md
@@ -2,6 +2,39 @@
 
 ---
 
+## 2026-07-07 — Periodic fallback pull: near-live convergence without postgres_changes (issue #98)
+
+**What changed.** Realtime `postgres_changes` is rejected server-side even with an
+authed socket (#97 — channelError, no CDC to the client). Per `architecture.md`,
+Realtime is a **best-effort signal that triggers a pull, not the data transport**,
+and the Pull path documents a **"periodic fallback poll"** — which was **never
+implemented**: the only `Timer.periodic` (30 s) drained the outbox (push). So a
+foregrounded, idle till never pulled, and console edits/soft-deletes only landed on
+a manual refresh / resume / reconnect.
+
+**Fix.** Added the documented periodic fallback **pull** to the existing 30 s sync
+tick in `SupabaseSyncService`: when foregrounded + online + business-bound, fire the
+already-working, guarded, debounced `catchUpPull(reason: 'periodic')` — *before* and
+*independent of* the push drain (so it runs even mid-push). A console-deleted product
+now stops being sellable within ~one tick, regardless of realtime health.
+
+- Reuses the existing timer lifecycle: starts at sign-in (`startAutoPush`), cancels
+  at logout (`stopAutoPush`), and naturally suspends when backgrounded (Dart timers
+  don't fire while paused) — so no battery cost off-screen.
+- `catchUpPull` self-guards (`_currentBusinessId`/`_fullPullRunning`/`isOnline`) and
+  is debounced (< 30 s tick ⇒ never overlaps the reconnect/resume catch-ups).
+- Aligns the implementation with the documented "realtime = signal, pull =
+  transport" model. The realtime channel subscription stays as a best-effort signal.
+
+**Verified.** `flutter analyze` clean; `test/sync/` 186 passing (the called
+`catchUpPull` is covered by `catch_up_pull_test`; the 30 s timer wiring is verified
+on-device — a console delete converges within ~30 s with no manual refresh).
+
+**Files changed:** `lib/core/services/supabase_sync_service.dart`,
+`context/progress-tracker.md`.
+
+---
+
 ## 2026-07-07 — Fix realtime resubscribe teardown/re-create race (issue #93)
 
 **What changed.** Console edits/soft-deletes never propagated **live** to the

--- a/CONTEXT/progress-tracker.md
+++ b/CONTEXT/progress-tracker.md
@@ -10,6 +10,47 @@ The human updates it when resolving open questions or making architectural decis
 
 152 sessions logged. Codebase is live and being verified on-device.
 
+### Live cross-device sync ("deleted product still sellable") — in progress (2026-07-07)
+On-device debugging of "console changes don't reach the app live." Findings + fixes:
+- **Pull works; realtime never delivered.** DB soft-delete + guard already correct
+  (#87/#88/#89 merged; migrations 0145/0146 deployed). A manual pull-to-refresh
+  clears a console-deleted product; only the *live* path was dead.
+- **#93 resubscribe race (PR #94, MERGED).** `restartRealtimeSync` tore channels
+  down fire-and-forget then synchronously re-created them; the transport's
+  `startRealtime` guard bailed on the not-yet-cleared list → **zero** channels every
+  session. Fixed: await teardown before re-subscribe + synchronous `_realtimeActive`
+  flip; transport `stopRealtime` clears holders synchronously. Regression test.
+- **#95 channel fan-out + #97 socket auth (PR #96, OPEN).** After #93, all ~55
+  per-table `postgres_changes` channels errored. Collapsed to **one channel, N
+  bindings** (#95) and forced `realtime.setAuth` before subscribe (#97). On-device
+  diagnostic proved `socketAlreadyHadSessionToken=true` — **the socket IS authed**,
+  yet every `postgres_changes` binding still `channelError → timedOut` and **no
+  `supabase_realtime` CDC slot streams to the client**. Server checks ruled out:
+  slots not exhausted (2/5), all tables in the publication, `authenticated` has
+  SELECT + `business_id`, filter-check passes. **postgres_changes root cause still
+  OPEN** (server-side realtime authorization/delivery).
+- **Key architecture reconciliation.** `architecture.md` defines Realtime as a
+  **signal that triggers a pull, "not the transport for the data itself"** (best-
+  effort; Goal #2 / SC#6 say "when realtime sync is healthy"). The implementation
+  diverged to direct-apply of 55 `postgres_changes` — the failing path. The
+  documented **"periodic fallback poll"** (architecture.md §Pull path) is **NOT
+  implemented**: the only `Timer.periodic` (30 s) drains the outbox (push) — there
+  is no periodic *pull*, so a foregrounded idle till never converges without a
+  working realtime or a manual refresh.
+- **DECISION (resolved 2026-07-07):** implement the documented periodic fallback
+  **pull** → `catchUpPull` for robust near-live convergence (spec-aligned,
+  independent of the broken postgres_changes). Chasing server-side
+  `postgres_changes` deferred. #96 (one channel + setAuth) stays as a best-effort
+  realtime *signal*.
+- **#98 periodic fallback pull — SHIPPED (PR pending).** Added the documented
+  "periodic fallback poll" to the existing 30 s sync tick: foregrounded + online +
+  business-bound → silent, debounced `catchUpPull(reason: 'periodic')` (runs before
+  and independent of the push drain). A console edit/soft-delete now converges
+  within ~one tick with no manual refresh, regardless of realtime health. Timer
+  lifecycle reused (starts at sign-in, cancels at logout, suspends when
+  backgrounded). test/sync 186 green; analyze clean. On-device: a deleted product
+  stops being sellable within ~30 s.
+
 ### Multi-industry onboarding & app morphing (PRD #76, ADR 0015) — in progress
 Slices: **#77** registry foundation → **#79** enable all nine → **#80** Lexicon on
 product forms → **#81** Lexicon on POS/inventory/guides; **#78** synced product

--- a/lib/core/services/supabase_sync_service.dart
+++ b/lib/core/services/supabase_sync_service.dart
@@ -3317,6 +3317,20 @@ class SupabaseSyncService {
       _autoPushPeriodic ??= Timer.periodic(_autoPushPeriodicInterval, (
         _,
       ) async {
+        // Architecture §Pull path — the documented "periodic fallback poll".
+        // Realtime is a best-effort *signal* that triggers a pull, not the data
+        // transport; when it is unhealthy nothing else pulls while the till sits
+        // foregrounded and idle, so a console edit / soft-delete never converges
+        // without a manual refresh. This silent catch-up pull guarantees
+        // convergence within one tick. It runs before — and independently of —
+        // the push drain below (it must fire even while a push is in flight),
+        // and self-guards on business-bound + online + not-mid-full-pull, with a
+        // debounce inside catchUpPull so it never overlaps the reconnect/resume
+        // catch-ups.
+        final pullBizId = _db.businessIdResolver.call();
+        if (pullBizId != null) {
+          unawaited(catchUpPull(pullBizId, reason: 'periodic'));
+        }
         try {
           if (_pushing) return;
           await _db.syncDao.resetStuckInProgress();


### PR DESCRIPTION
Closes #98.

## Why
Realtime `postgres_changes` is rejected server-side even with an authed socket (#97 — channelError, no CDC to the client). Per `architecture.md`, Realtime is a **best-effort signal that triggers a pull, not the data transport**, and the Pull path documents a **"periodic fallback poll"** — which was **never implemented**: the only `Timer.periodic` (30s) drains the outbox (push). So a foregrounded, idle till never pulled, and console edits/soft-deletes only landed on a manual refresh / resume / reconnect.

## What
On the existing 30s sync tick, when foregrounded + online + business-bound, fire the already-working, guarded, debounced `catchUpPull(reason: 'periodic')` — **before and independent of** the push drain (runs even mid-push). A console-deleted product now stops being sellable within ~one tick, regardless of realtime health.

- Reuses the timer lifecycle (starts at sign-in, cancels at logout, suspends when backgrounded — no off-screen battery cost).
- `catchUpPull` self-guards (`_currentBusinessId`/`_fullPullRunning`/`isOnline`) and debounces (< 30s tick ⇒ never overlaps reconnect/resume catch-ups).
- Aligns the implementation with the documented "realtime = signal, pull = transport" model. The realtime channel subscription stays as a best-effort signal (see #96).

## Verification
- `flutter analyze` clean; `test/sync/` **186 passing** (the called `catchUpPull` is covered by `catch_up_pull_test`; the 30s timer wiring is verified on-device — a console delete converges within ~30s with no manual refresh).
- Docs updated in the same unit: `context/progress-tracker.md` + `BUILD_LOG.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved realtime sync reliability by adding a periodic fallback pull when live updates are missed or rejected.
  * Helped ensure changes converge more quickly, reducing cases where deleted items could remain available for a short time.
  * Made the background sync process more resilient by running the catch-up pull independently of the regular sync drain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->