### PR TITLE
fix(sync): exactly-once stock integrity — route checkout through the guarded RPC (#100)

### DIFF
--- a/BUILD_LOG.md
+++ b/BUILD_LOG.md
@@ -2,6 +2,51 @@
 
 ---
 
+## 2026-07-08 — Exactly-once stock: route checkout through the guarded RPC, wallet legs client-side (issue #100, A-S3/A-S4)
+
+**What changed.** Implemented Option ①. `OrdersDao.createOrder` now posts the §14.3
+wallet double-entry through a new private `_postSaleWalletLegs` helper called **before**
+the v1/v2 path split, so the legs are client-authored on BOTH paths (invariant #3 —
+wallet ledgers append-only/derived, never server-minted). The v2 `pos_record_sale_v2`
+envelope is passed **no** `p_wallet_amount_kobo` (its wallet branch stays a no-op), and
+the now-dead v2-only `walletDebitKobo` parameter was removed from `createOrder`. On the
+v2 path the guarded RPC owns only the oversell-safe order/items/stock/payment: server
+`SELECT … FOR UPDATE` + relative `quantity = quantity - n WHERE quantity >= n` +
+`insufficient_stock`/`inventory_row_missing` (P0001) + `ON CONFLICT (id) DO NOTHING`.
+The local pre-check is kept for fast offline UX, but the server decision is authoritative.
+
+Beyond fixing the flag-flip viability, this removes a latent v2 split-brain: the old v2
+path minted only a server-side wallet debit with no local mirror, which would have broken
+cancel/refund/reports on v2. v2's wallet rows are now byte-identical to v1's.
+
+**Tests.** `exactly_once_stock_integrity_test.dart` gains the A-S3 v2 group: two devices
+race the last unit through a faithful in-memory model of the RPC's guard — the server
+accepts the first sale and **rejects the second** (`insufficient_stock`), on-hand never
+goes below 0, and the loser's envelope **orphans visibly** in `sync_queue_orphans`
+(Invariant #12 — the A-S4 coverage); plus a lost-ack replay proving idempotency (no
+second decrement). Updated `record_sale_dispatch_test` (v2 registered sale → 2 local
+wallet legs + 1 envelope, no `p_wallet_amount_kobo`; new register-as-credit case nets
+−150000, never gated by the RPC), `credit_ledger_logic_test`, `pr_4c_test` (dropped the
+removed arg — behaviour identical, the legs never used it).
+
+**Known v2 characteristic (documented).** An **offline** registered/crate sale's wallet
++ crate legs FK-reference the RPC-minted order; the reconnect drain pushes table rows
+before domain envelopes, so they FK-defer once and converge on retry. The **online**
+path front-runs this via `flushSale`. Matches existing crate behaviour; cheap follow-up
+noted. The go-live flag flip is a per-env ops decision, surfaced in the PR, not applied.
+
+**Verified.** `flutter analyze` clean project-wide; sync/dispatch/wallet/orders/crates/
+golden/costing suites green.
+
+**Files changed:** `lib/core/database/daos_orders.dart`,
+`lib/shared/services/orders/order_commands.dart`,
+`test/sync/exactly_once_stock_integrity_test.dart`,
+`test/sync/dispatch/record_sale_dispatch_test.dart`,
+`test/wallet/credit_ledger_logic_test.dart`, `test/orders/pr_4c_test.dart`,
+`context/progress-tracker.md`.
+
+---
+
 ## 2026-07-08 — Exactly-once stock: reproduce the silent oversell + RPC viability (issue #100, A-S1/A-S2)
 
 **What changed.** Added `test/sync/exactly_once_stock_integrity_test.dart` — a RED-first

--- a/BUILD_LOG.md
+++ b/BUILD_LOG.md
@@ -2,6 +2,38 @@
 
 ---
 
+## 2026-07-08 — Exactly-once stock: reproduce the silent oversell + RPC viability (issue #100, A-S1/A-S2)
+
+**What changed.** Added `test/sync/exactly_once_stock_integrity_test.dart` — a RED-first
+regression that reproduces the headline defect on the current v1 checkout path: two
+devices, stock 1, both sell 1 unit offline (walk-in, so the sale is a pure stock
+movement), both push the **absolute** `inventory.quantity=0` row; the natural-key LWW
+cache collapses them onto one cloud row at 0 while **two** orders land — 2 units sold
+from a stock of 1, silently, no error. It passes today (documents the bug) and flips to
+the fixed path in A-S3. Uses two `AppDatabase` instances sharing one
+`InMemoryCloudTransport` (the "cloud"); the shared `inventoryId` is what makes the two
+absolute pushes collapse (mirrors the real `onConflict (business_id, product_id,
+store_id)` merge).
+
+**A-S2 verification (no code — findings drive the fix).** Verified `pos_record_sale_v2`
+against the LIVE database. Its stock write is exactly the guarded, serialized relative
+decrement A wants, with no schema drift, and `_applyDomainResponse` writes back the
+authoritative `inventory_after` as the sole local writer. **But** its wallet model is
+incompatible with the live v1 path (single `p_wallet_amount_kobo` debit vs. v1's full
+double-entry per registered sale), so a blanket flag flip would drop wallet history on
+cash sales and outright reject register-as-credit sales. Re-scoped (human decision) to
+**Option ①**: keep the wallet double-entry client-side on the v2 path (as
+`crate_ledger`/`cost_batches` already are), pass `p_wallet_amount_kobo=0`, let the RPC
+own only the oversell-safe stock/order/items/payment. Details in
+`progress-tracker.md` → "Exactly-once stock integrity (#100, Workstream A)".
+
+**Verified.** `flutter analyze` clean on the new test; the test passes (bug reproduced).
+
+**Files changed:** `test/sync/exactly_once_stock_integrity_test.dart` (new);
+`context/progress-tracker.md`.
+
+---
+
 ## 2026-07-07 — Realtime: authorize the socket for postgres_changes (issue #97)
 
 **What changed.** After the single-channel change (#95), **every** `postgres_changes`

--- a/BUILD_LOG.md
+++ b/BUILD_LOG.md
@@ -2,6 +2,40 @@
 
 ---
 
+## 2026-07-08 — Exactly-once stock: idempotency backstops + mutable-balance-cache audit (issue #100, A-S5/A-S6)
+
+**A-S5 (idempotency backstops).** Added `test/sync/stock_reprocess_idempotency_test.dart`:
+restoring the till's OWN just-pushed inventory cache + append-only stock ledger (and
+re-restoring it, modelling a second pull / broadcast re-pull) does not double-decrement —
+on-hand stays 4 and equals opening + SUM(ledger deltas). This pins the PULL-side
+idempotency; A-S3's lost-ack replay pins the PUSH side (`ON CONFLICT DO NOTHING`). The
+"no blind insert" property is structural — the only cloud-write paths are
+`enqueueUpsert`/`enqueueDelete` (no `enqueueInsert`) and the transport always `.upsert()`s;
+the clobber-guard is already pinned by `outbox_sacred_restore_test`.
+
+**A-S6 (audit of every `isCache` table).** `inventory` is FIXED (A-S3 guarded RPC). The
+four crate balance caches (`customer`/`manufacturer`/`store`/`supplier`) share inventory's
+push-absolute-LWW shape, so concurrent OFFLINE crate movements to the same owner can drift
+the cache — BUT they are backed by append-only ledgers (`crate_ledger` /
+`supplier_crate_ledger`, both movements survive), the movement writes are relative
+(`balance = balance + δ`), and the balance is recomputable via
+`verifyCrateReconciliation`. Lower severity than the stock oversell (a deposit tally
+reconciliation fixes, not silent money-for-nothing). Genuine gap found but DEFERRED:
+`verifyCrateReconciliation` is not auto-wired → follow-up issue (auto-schedule, or
+derive-on-read, or a server-guarded crate RPC). The `store_crate_balances` absolute
+`setBalance` is an intentional manual override, not a race.
+
+**Open question (human).** The recovery UX for a background-reconnect-rejected oversell
+(auto-cancel / notify / re-ring?) is undefined product behaviour — logged, not invented
+(the detect-and-surface mechanism, which is #100's goal, is complete).
+
+**Verified.** `flutter analyze` clean; the new test green.
+
+**Files changed:** `test/sync/stock_reprocess_idempotency_test.dart` (new),
+`context/progress-tracker.md`.
+
+---
+
 ## 2026-07-08 — Exactly-once stock: route checkout through the guarded RPC, wallet legs client-side (issue #100, A-S3/A-S4)
 
 **What changed.** Implemented Option ①. `OrdersDao.createOrder` now posts the §14.3

--- a/CONTEXT/progress-tracker.md
+++ b/CONTEXT/progress-tracker.md
@@ -10,6 +10,53 @@ The human updates it when resolving open questions or making architectural decis
 
 152 sessions logged. Codebase is live and being verified on-device.
 
+### Exactly-once stock integrity (#100, Workstream A) — in progress (2026-07-08)
+Implementing Workstream A of the live-sync/exactly-once loop (plan:
+`docs/design/live-sync-exactly-once-implementation-plan.md`, PRD:
+`context/specs/brief-live-sync-signal-and-exactly-once.md` — both live on the
+`docs/live-sync-exactly-once-prd` branch, not yet on `main`). Branch
+`fix/exactly-once-stock-integrity` off `origin/main`.
+- **A-S0/A-S1 done.** `test/sync/exactly_once_stock_integrity_test.dart` RED-first
+  reproduces the silent oversell on the current v1 path: two devices, stock 1,
+  both sell 1 offline (walk-in, so it's a pure stock movement), both push the
+  absolute `inventory.quantity=0` row; the natural-key LWW cache collapses them to
+  one row at 0 while **two** orders land — 2 sold from 1, no error. Green (it
+  documents today's behaviour); flips to the fixed path in A-S3.
+- **A-S2 done — committed A1-flag path is UNVIABLE as-is; re-scoped to "Option ①"
+  (client-side wallet on the v2 path).** Verified `pos_record_sale_v2` against the
+  LIVE db: its STOCK write is exactly what A wants (`SELECT … FOR UPDATE`, relative
+  `quantity = quantity - n`, `insufficient_stock`/`inventory_row_missing` P0001,
+  `ON CONFLICT (id) DO NOTHING`) with **no schema drift** (`store_id`,
+  `stock_transactions.location_id`, null-product quick-sale handled), and
+  `_applyDomainResponse` writes back authoritative `inventory_after` as the sole
+  local writer (no dup). BUT its **wallet model is incompatible** with the live v1
+  path: the RPC posts only a single `p_wallet_amount_kobo` debit (and only when
+  >0), whereas v1 posts full double-entry for every registered sale (goods debit of
+  total + cash credit of paid + held-deposit carve-out). A blanket flag flip would
+  (a) drop wallet history on cash sales and (b) **reject "register-as-credit" sales**
+  (`insufficient_wallet_balance` — the RPC has no debt-limit/negative path). The
+  inline comment `daos_orders.dart:796-798` ("R2") already flagged this; PRD risk #2
+  now confirmed negative. The narrow "route only the inventory delta" alternative is
+  forbidden by design (`pos_inventory_delta_v2` rejects `movement_type='sale'`).
+  **Human decision (2026-07-08): Option ①** — restructure `createOrder` so the full
+  wallet double-entry posts client-side on the v2 path too (exactly as
+  `crate_ledger`/`cost_batches` already do), pass `p_wallet_amount_kobo=0` so the
+  RPC owns only the oversell-safe stock/order/items/payment, then flip. No
+  migration, no money-model change; wallet stays append-only/derived (invariant #3),
+  so credit sales work and aren't gated by the RPC's balance check.
+- **FK-ordering note for A-S3:** `wallet_transactions.order_id`,
+  `crate_ledger.reference_order_id`, `order_crate_lines.order_id` all have enforced
+  cloud FKs to `orders`. On v2 the order is minted by the RPC (which must run to
+  enforce the guard), so these client-authored children are enqueued before the
+  order exists and converge via the engine's FK-deferred retry — the same behaviour
+  crate rows already have on the v2 path; the new wallet legs match it.
+- **Open question (A-S3 rollout — for the human):** how to actually flip
+  `feature.domain_rpcs_v2.record_sale` — a global cloud `system_config` UPDATE
+  (affects all businesses at once) vs. a client-default change shipped in the PR.
+  The v2 dispatch path has never run in production (flag off since 0011), so the
+  flip activates dormant code (crate/cost/wallet client rows, thin-item flow); A-S3
+  will land it behind tests but the go-live flip is a deployment decision.
+
 ### Live cross-device sync ("deleted product still sellable") — in progress (2026-07-07)
 On-device debugging of "console changes don't reach the app live." Findings + fixes:
 - **Pull works; realtime never delivered.** DB soft-delete + guard already correct

--- a/CONTEXT/progress-tracker.md
+++ b/CONTEXT/progress-tracker.md
@@ -10,7 +10,12 @@ The human updates it when resolving open questions or making architectural decis
 
 152 sessions logged. Codebase is live and being verified on-device.
 
-### Exactly-once stock integrity (#100, Workstream A) — in progress (2026-07-08)
+### Exactly-once stock integrity (#100, Workstream A) — PR #105 OPEN, awaiting human merge (2026-07-08)
+All 8 slices (A-S0…A-S7) done; **PR #105** (`fix/exactly-once-stock-integrity` →
+`main`) opened `Closes #100`. Stop-for-human-merge. Two decisions carried in the PR:
+the **go-live flag flip** (per-env ops, fix inert until flipped) and the **orphan-UX
+recovery flow** (undefined product behaviour, logged not invented). Workstream C (#102)
+is independent and may proceed alongside; B (#101) stays blocked until A merges + B0.
 Implementing Workstream A of the live-sync/exactly-once loop (plan:
 `docs/design/live-sync-exactly-once-implementation-plan.md`, PRD:
 `context/specs/brief-live-sync-signal-and-exactly-once.md` — both live on the

--- a/CONTEXT/progress-tracker.md
+++ b/CONTEXT/progress-tracker.md
@@ -50,12 +50,41 @@ Implementing Workstream A of the live-sync/exactly-once loop (plan:
   enforce the guard), so these client-authored children are enqueued before the
   order exists and converge via the engine's FK-deferred retry — the same behaviour
   crate rows already have on the v2 path; the new wallet legs match it.
-- **Open question (A-S3 rollout — for the human):** how to actually flip
-  `feature.domain_rpcs_v2.record_sale` — a global cloud `system_config` UPDATE
-  (affects all businesses at once) vs. a client-default change shipped in the PR.
-  The v2 dispatch path has never run in production (flag off since 0011), so the
-  flip activates dormant code (crate/cost/wallet client rows, thin-item flow); A-S3
-  will land it behind tests but the go-live flip is a deployment decision.
+- **A-S3 done (Option ① implemented) + A-S4 proven.** `OrdersDao.createOrder` now
+  posts the wallet double-entry via a new `_postSaleWalletLegs` helper called
+  **before** the v1/v2 split, so the legs are client-authored on BOTH paths
+  (invariant #3). The v2 envelope no longer carries `p_wallet_amount_kobo` (the RPC's
+  wallet branch stays a no-op), and the v2-only `walletDebitKobo` param was removed
+  from `createOrder` (it fed only `p_wallet_amount_kobo`; the v1 legs always derived
+  from total/paid/deposit). This ALSO removes a latent v2 split-brain: previously v2
+  minted only a server-side wallet debit with no local mirror, which would have
+  broken cancel/refund/reports on v2 — now v2's wallet rows are byte-identical to
+  v1's, so every downstream flow already tested on v1 holds on v2. Tests: the
+  headline `exactly_once_stock_integrity_test.dart` gains the v2 group — two devices
+  race the last unit, the server accepts the first and **rejects the second**
+  (`insufficient_stock` P0001), on-hand never goes below 0, and the loser's envelope
+  **orphans visibly** in `sync_queue_orphans` (that orphan assertion is the **A-S4**
+  coverage) — plus a lost-ack replay proving `ON CONFLICT DO NOTHING` idempotency (no
+  second decrement). Updated `record_sale_dispatch_test` (registered v2 sale posts 2
+  local wallet legs + 1 envelope, no `p_wallet_amount_kobo`; and a
+  register-as-credit v2 sale nets −150000 and is never gated by the RPC),
+  `credit_ledger_logic_test` (2 args), `pr_4c_test` (1 arg). `flutter analyze` clean;
+  the affected suites (sync/dispatch/wallet/orders/crates/golden/costing) green.
+- **Known v2 convergence characteristic (documented, not a defect).** For a
+  registered/crate sale created **offline**, the wallet + crate legs FK-reference an
+  `orders` row the RPC mints, but the reconnect drain pushes table rows *before*
+  domain envelopes — so the legs FK-fail once (23503) and converge on the next
+  FK-deferred retry (~15 min). The **online** checkout path front-runs this: it calls
+  `flushSale` right after `createOrder`, which pushes the domain envelope (creating
+  the order) before the background drain reaches the legs. This matches the existing
+  crate-leg behaviour on v2 and is invisible online; a cheap follow-up (teach the
+  push to flush a sale's envelope before its child legs) could remove the offline
+  lag. Not fixed here (Option ①: no migration; global push-reorder is out of scope).
+- **Go-live flip NOT executed (human/ops decision).** The code is correct on both
+  flag states; flipping `feature.domain_rpcs_v2.record_sale` is a per-environment,
+  production-wide runtime change that activates the dormant v2 path (crate/cost/wallet
+  client rows, thin-item flow, the offline FK-defer above) — surfaced in the PR as a
+  one-line reversible config step, not applied autonomously in this loop.
 
 ### Live cross-device sync ("deleted product still sellable") — in progress (2026-07-07)
 On-device debugging of "console changes don't reach the app live." Findings + fixes:

--- a/CONTEXT/progress-tracker.md
+++ b/CONTEXT/progress-tracker.md
@@ -85,6 +85,49 @@ Implementing Workstream A of the live-sync/exactly-once loop (plan:
   production-wide runtime change that activates the dormant v2 path (crate/cost/wallet
   client rows, thin-item flow, the offline FK-defer above) — surfaced in the PR as a
   one-line reversible config step, not applied autonomously in this loop.
+- **A-S5 done (idempotency backstops locked).** (a) *No blind insert* is structural:
+  the only cloud-write paths are `enqueueUpsert`/`enqueueDelete` (there is no
+  `enqueueInsert`) and the transport always `.upsert()`s — client-id minting is pinned
+  by the existing dispatch tests; A-S3's lost-ack replay pins the sale envelope's
+  push-side idempotency (`ON CONFLICT DO NOTHING`). (b) *Clobber-guard* (a pending
+  local row survives an incoming newer cloud row) is pinned by
+  `outbox_sacred_restore_test`. (c) NEW `stock_reprocess_idempotency_test.dart` pins
+  the PULL side — restoring the till's OWN just-pushed inventory cache + append-only
+  stock ledger (and re-restoring it) does not double-decrement; on-hand equals opening
+  + SUM(ledger deltas). Events applied exactly once.
+- **A-S6 audit — mutable-balance caches (`isCache` tables).** Verdict per table:
+  | Cache table | Movement write | Push shape | Backing ledger | Verdict |
+  |---|---|---|---|---|
+  | `inventory` | relative (pre-check) | absolute LWW | `stock_transactions` | **FIXED** — v2 guarded RPC (`FOR UPDATE`+relative+`>=n` reject) is authoritative |
+  | `customer_crate_balances` | relative (`balance+δ`) | absolute LWW | `crate_ledger` (append-only) | mitigated gap → follow-up |
+  | `manufacturer_crate_balances` | relative | absolute LWW | `crate_ledger` | mitigated gap → follow-up |
+  | `store_crate_balances` | relative (+ intentional `setBalance` absolute override) | absolute LWW | `crate_ledger` | mitigated gap → follow-up |
+  | `supplier_crate_balances` | relative | absolute LWW | `supplier_crate_ledger` | mitigated gap → follow-up |
+  The 4 crate caches share inventory's push-absolute-LWW shape, so two devices making
+  concurrent **offline** crate movements to the same (owner, manufacturer) can drift
+  the cache. **Why lower severity than the stock oversell, and not a #100 gap:** the
+  truth is the append-only ledger (both movements survive, id-keyed — no data loss),
+  the balance is recomputable (`CrateLedgerDao.verifyCrateReconciliation` = SUM of
+  ledger deltas), and a crate tally is not a hard-limited sellable resource that
+  silently takes money for nothing — it's a deposit tally reconciliation corrects. The
+  `setBalance` absolute write is an intentional manual management-dialog override
+  (set-to-known), correctly LWW — not a race. **Genuine gap found (deferred):**
+  `verifyCrateReconciliation` is **not auto-wired** (no caller), so cache drift is not
+  auto-healed. **Follow-up issue (not #100):** either auto-schedule the reconciliation,
+  derive crate balances from the ledger on read (wallet-style), or route crate
+  movements through a server-guarded relative RPC mirroring `pos_record_sale_v2`. Not
+  fixed here — it's a structural change of A1-ledger's magnitude, outside #100's
+  "close the silent stock oversell" scope, and the drift is mitigated, not unbounded.
+- **OPEN QUESTION (A-S6, human decision — surfaced, not invented).** When the server
+  rejects the 2nd offline sale on the **background reconnect** path (not the foreground
+  `flushSale` path, which already compensates + surfaces), the envelope orphans
+  **visibly** (Sync Issues) but the local device still shows the order (`pending`) +
+  the local inventory pre-check decrement. The cashier **recovery flow** — auto-cancel
+  the orphaned order? notify the cashier to re-ring / refund / restock? re-price? — is
+  **undefined product behaviour**. The mechanism (detect + surface, never silently
+  absorb) is complete and is the #100 goal; the recovery UX is a separate product +
+  UI decision (a feature-folder change, which the split rules keep out of this
+  sync-integrity PR). Logged for the human; NOT invented here.
 
 ### Live cross-device sync ("deleted product still sellable") — in progress (2026-07-07)
 On-device debugging of "console changes don't reach the app live." Findings + fixes:

--- a/lib/core/database/daos_orders.dart
+++ b/lib/core/database/daos_orders.dart
@@ -490,9 +490,12 @@ class OrdersDao extends DatabaseAccessor<AppDatabase>
   /// Atomic order + items + inventory + ledger + payment + wallet in a single txn.
   /// Returns the new order ID.
   ///
-  /// [walletDebitKobo] is the amount to debit from the customer's wallet. Used
-  /// for wallet payments (full balance), partial payments (the remainder put on
-  /// account), and credit sales (the full total). Requires [customerId].
+  /// For a registered [customerId] the wallet double-entry is derived here from
+  /// [totalAmountKobo], [amountPaidKobo], and [crateDepositPaidByManufacturer]
+  /// (see [_postSaleWalletLegs]) — the customer's position is net (paid − total),
+  /// so a wallet/partial/credit sale simply pays less than the total and the
+  /// wallet goes negative by the balance owed. Walk-ins ([customerId] == null)
+  /// never touch the wallet.
   Future<String> createOrder({
     required OrdersCompanion order,
     required List<OrderItemsCompanion> items,
@@ -501,7 +504,6 @@ class OrdersDao extends DatabaseAccessor<AppDatabase>
     required int totalAmountKobo,
     required String staffId,
     String? storeId,
-    int walletDebitKobo = 0,
     String paymentMethod = 'cash',
     // §13.4 — deposit actually paid at checkout, per manufacturer/brand. Empty
     // = no per-brand deposit captured yet (every crate brand is "no deposit" →
@@ -676,6 +678,21 @@ class OrdersDao extends DatabaseAccessor<AppDatabase>
         }
       }
 
+      // §14.3 wallet double-entry — client-authored on BOTH sync paths
+      // (invariant #3: wallet ledgers are append-only/derived, never
+      // server-minted). pos_record_sale_v2 owns only the oversell-safe
+      // stock/order/items/payment and receives no wallet amount, so these legs
+      // must be posted here, before the path split. Walk-ins are a no-op.
+      await _postSaleWalletLegs(
+        customerId: customerId,
+        orderId: orderId,
+        staffId: staffId,
+        totalAmountKobo: totalAmountKobo,
+        amountPaidKobo: amountPaidKobo,
+        paymentMethod: paymentMethod,
+        crateDepositPaidByManufacturer: crateDepositPaidByManufacturer,
+      );
+
       if (useDomainRpc) {
         // v2 thin-intent: server mints order_items, stock_tx, payment_tx,
         // and wallet_tx ids (gen_random_uuid). _applyDomainResponse is
@@ -723,7 +740,11 @@ class OrdersDao extends DatabaseAccessor<AppDatabase>
           if (orderJson.containsKey('barcode'))
             'p_barcode': orderJson['barcode'],
           if (amountPaidKobo > 0) 'p_payment_method': paymentMethod,
-          if (walletDebitKobo > 0) 'p_wallet_amount_kobo': walletDebitKobo,
+          // The wallet ledger is client-authored on BOTH paths (invariant #3):
+          // the full double-entry is posted by _postSaleWalletLegs before this
+          // split, so the RPC's wallet branch stays a no-op — no wallet amount is
+          // forwarded. (pos_record_sale_v2's single p_wallet_amount_kobo debit
+          // cannot express a register-as-credit sale, so we never use it.)
         };
         await db.syncDao.enqueue(
           'domain:pos_record_sale_v2',
@@ -782,132 +803,8 @@ class OrdersDao extends DatabaseAccessor<AppDatabase>
         await db.syncDao.enqueueUpsert('payment_transactions', payComp);
       }
 
-      // §14.3 full wallet ledger (rule #4): every registered sale runs through
-      // the wallet. Post TWO legs — a debit for the order total (goods leave)
-      // and a credit for the amount paid at checkout (money in) — so the net
-      // (paid − total) is the customer's position: 0 when fully paid, negative
-      // when they owe. This includes fully-paid cash sales (debit total +
-      // credit total, net 0), so the wallet history is complete. The credit leg
-      // records the money against the customer's wallet. It reuses the existing
-      // top-up reference types (by method, mirroring WalletService) so no CHECK
-      // widening is needed. Walk-ins (customerId == null) never touch the wallet
-      // (rule #14).
-      //
-      // v1 path. The v2 RPC (pos_record_sale_v2) still mints only the debit via
-      // p_wallet_amount_kobo — it MUST also mint this credit leg before
-      // record_sale v2 is enabled, or cloud wallets will miss payments (R2).
-      if (customerId != null) {
-        final cid = customerId;
-        final wallet =
-            await (select(customerWallets)
-                  ..where(
-                    (w) =>
-                        whereBusiness(w) &
-                        w.customerId.equals(cid) &
-                        w.isDeleted.not(),
-                  )
-                  ..limit(1))
-                .getSingleOrNull();
-        if (wallet == null) {
-          throw StateError('Customer $cid has no wallet — cannot post sale');
-        }
-
-        // §14.3 — both legs of the sale are one event, so stamp them with the
-        // SAME created_at. The wallet history is newest-first; on this tie the
-        // DISPLAY query (WalletTransactionsDao.watchHistory) puts the order
-        // DEBIT above the payment CREDIT via signed_amount_kobo ASC, so the
-        // order charge (the last step of the sale) sits at the top. Net
-        // (paid − total) is unchanged by the timestamp/ordering.
-        final legTime = DateTime.now();
-
-        // §13.4 Ring 6 — held-deposit carve-out. The deposit actually paid at
-        // checkout (sum of the per-brand map) is refundable money the business
-        // HOLDS, not goods revenue and not spendable wallet credit. So it must
-        // not inflate the goods debt nor count as spendable. We carve it out of
-        // BOTH legs and re-post it as a single `crate_deposit` held credit:
-        //   • goods debit   = totalAmountKobo − depositHeld  (the real purchase)
-        //   • goods credit  = amountPaidKobo  − depositHeld  (cash toward goods)
-        //   • held credit   = depositHeld                    (deposit family)
-        // Net SPENDABLE = (paid − held) − (total − held) = paid − total — exactly
-        // the same position as before; only the deposit slice moves to the held
-        // bucket (excluded from the spendable balance, §5 read-side). When no
-        // deposit was paid this reduces to the original two legs unchanged.
-        // [totalAmountKobo] is the grand total (goods + deposit) the checkout
-        // passes, and the checkout guards paid ≥ deposit, so neither leg goes
-        // negative; clamp defensively anyway.
-        final depositHeldKobo = crateDepositPaidByManufacturer.values
-            .fold<int>(0, (s, v) => s + v)
-            .clamp(0, totalAmountKobo);
-        final goodsDebitKobo = totalAmountKobo - depositHeldKobo;
-        final goodsCreditKobo = (amountPaidKobo - depositHeldKobo).clamp(
-          0,
-          amountPaidKobo,
-        );
-        //
-        // Leg 1 — debit the goods total (the purchase leaves the wallet).
-        final debitComp = WalletTransactionsCompanion.insert(
-          id: Value(UuidV7.generate()),
-          businessId: requireBusinessId(),
-          walletId: wallet.id,
-          customerId: cid,
-          type: 'debit',
-          amountKobo: goodsDebitKobo,
-          signedAmountKobo: -goodsDebitKobo,
-          referenceType: 'order_payment',
-          orderId: Value(orderId),
-          performedBy: Value(staffId),
-          createdAt: Value(legTime),
-          lastUpdatedAt: Value(legTime),
-        );
-        await into(walletTransactions).insert(debitComp);
-        await db.syncDao.enqueueUpsert('wallet_transactions', debitComp);
-
-        // Leg 2 — credit the cash applied to goods (money into the wallet).
-        // Skipped when nothing is left after the deposit carve-out (pure
-        // credit / pay-from-wallet sale, or the payment only covered deposit).
-        if (goodsCreditKobo > 0) {
-          final creditComp = WalletTransactionsCompanion.insert(
-            id: Value(UuidV7.generate()),
-            businessId: requireBusinessId(),
-            walletId: wallet.id,
-            customerId: cid,
-            type: 'credit',
-            amountKobo: goodsCreditKobo,
-            signedAmountKobo: goodsCreditKobo,
-            referenceType: paymentMethod == 'cash'
-                ? 'topup_cash'
-                : 'topup_transfer',
-            orderId: Value(orderId),
-            performedBy: Value(staffId),
-            createdAt: Value(legTime),
-            lastUpdatedAt: Value(legTime),
-          );
-          await into(walletTransactions).insert(creditComp);
-          await db.syncDao.enqueueUpsert('wallet_transactions', creditComp);
-        }
-
-        // Leg 3 — the held deposit (refundable, excluded from spendable). One
-        // `crate_deposit` credit for the whole sale's paid deposit; the per-brand
-        // split lives on order_crate_lines for the return modal to settle.
-        if (depositHeldKobo > 0) {
-          final heldComp = WalletTransactionsCompanion.insert(
-            id: Value(UuidV7.generate()),
-            businessId: requireBusinessId(),
-            walletId: wallet.id,
-            customerId: cid,
-            type: 'credit',
-            amountKobo: depositHeldKobo,
-            signedAmountKobo: depositHeldKobo,
-            referenceType: 'crate_deposit',
-            orderId: Value(orderId),
-            performedBy: Value(staffId),
-            createdAt: Value(legTime),
-            lastUpdatedAt: Value(legTime),
-          );
-          await into(walletTransactions).insert(heldComp);
-          await db.syncDao.enqueueUpsert('wallet_transactions', heldComp);
-        }
-      }
+      // NOTE: the wallet double-entry was posted by _postSaleWalletLegs above,
+      // before the v1/v2 split — client-authored on both paths (invariant #3).
 
       // v1 also enqueues the updated inventory cache so the cloud converges.
       for (final item in items) {
@@ -928,6 +825,147 @@ class OrdersDao extends DatabaseAccessor<AppDatabase>
 
       return orderId;
     });
+  }
+
+  /// §14.3 full wallet ledger (rule #4): every registered sale runs through
+  /// the wallet. Post TWO legs — a debit for the order total (goods leave)
+  /// and a credit for the amount paid at checkout (money in) — so the net
+  /// (paid − total) is the customer's position: 0 when fully paid, negative
+  /// when they owe. This includes fully-paid cash sales (debit total +
+  /// credit total, net 0), so the wallet history is complete. The credit leg
+  /// records the money against the customer's wallet. It reuses the existing
+  /// top-up reference types (by method, mirroring WalletService) so no CHECK
+  /// widening is needed. Walk-ins (customerId == null) never touch the wallet
+  /// (rule #14).
+  ///
+  /// Client-authored on BOTH sync paths (invariant #3: wallet ledgers are
+  /// append-only / derived, never server-minted). `pos_record_sale_v2` owns
+  /// only the oversell-safe stock/order/items/payment and is passed NO wallet
+  /// amount — its single `p_wallet_amount_kobo` debit cannot express a
+  /// register-as-credit sale (it guards on an existing positive balance and
+  /// would reject the customer owing money), so the full double-entry lives
+  /// here for v1 and v2 alike. Must be called INSIDE the createOrder
+  /// transaction, before the path split.
+  Future<void> _postSaleWalletLegs({
+    required String? customerId,
+    required String orderId,
+    required String staffId,
+    required int totalAmountKobo,
+    required int amountPaidKobo,
+    required String paymentMethod,
+    required Map<String, int> crateDepositPaidByManufacturer,
+  }) async {
+    if (customerId == null) return;
+    final cid = customerId;
+    final wallet =
+        await (select(customerWallets)
+              ..where(
+                (w) =>
+                    whereBusiness(w) &
+                    w.customerId.equals(cid) &
+                    w.isDeleted.not(),
+              )
+              ..limit(1))
+            .getSingleOrNull();
+    if (wallet == null) {
+      throw StateError('Customer $cid has no wallet — cannot post sale');
+    }
+
+    // §14.3 — both legs of the sale are one event, so stamp them with the
+    // SAME created_at. The wallet history is newest-first; on this tie the
+    // DISPLAY query (WalletTransactionsDao.watchHistory) puts the order
+    // DEBIT above the payment CREDIT via signed_amount_kobo ASC, so the
+    // order charge (the last step of the sale) sits at the top. Net
+    // (paid − total) is unchanged by the timestamp/ordering.
+    final legTime = DateTime.now();
+
+    // §13.4 Ring 6 — held-deposit carve-out. The deposit actually paid at
+    // checkout (sum of the per-brand map) is refundable money the business
+    // HOLDS, not goods revenue and not spendable wallet credit. So it must
+    // not inflate the goods debt nor count as spendable. We carve it out of
+    // BOTH legs and re-post it as a single `crate_deposit` held credit:
+    //   • goods debit   = totalAmountKobo − depositHeld  (the real purchase)
+    //   • goods credit  = amountPaidKobo  − depositHeld  (cash toward goods)
+    //   • held credit   = depositHeld                    (deposit family)
+    // Net SPENDABLE = (paid − held) − (total − held) = paid − total — exactly
+    // the same position as before; only the deposit slice moves to the held
+    // bucket (excluded from the spendable balance, §5 read-side). When no
+    // deposit was paid this reduces to the original two legs unchanged.
+    // [totalAmountKobo] is the grand total (goods + deposit) the checkout
+    // passes, and the checkout guards paid ≥ deposit, so neither leg goes
+    // negative; clamp defensively anyway.
+    final depositHeldKobo = crateDepositPaidByManufacturer.values
+        .fold<int>(0, (s, v) => s + v)
+        .clamp(0, totalAmountKobo);
+    final goodsDebitKobo = totalAmountKobo - depositHeldKobo;
+    final goodsCreditKobo = (amountPaidKobo - depositHeldKobo).clamp(
+      0,
+      amountPaidKobo,
+    );
+    //
+    // Leg 1 — debit the goods total (the purchase leaves the wallet).
+    final debitComp = WalletTransactionsCompanion.insert(
+      id: Value(UuidV7.generate()),
+      businessId: requireBusinessId(),
+      walletId: wallet.id,
+      customerId: cid,
+      type: 'debit',
+      amountKobo: goodsDebitKobo,
+      signedAmountKobo: -goodsDebitKobo,
+      referenceType: 'order_payment',
+      orderId: Value(orderId),
+      performedBy: Value(staffId),
+      createdAt: Value(legTime),
+      lastUpdatedAt: Value(legTime),
+    );
+    await into(walletTransactions).insert(debitComp);
+    await db.syncDao.enqueueUpsert('wallet_transactions', debitComp);
+
+    // Leg 2 — credit the cash applied to goods (money into the wallet).
+    // Skipped when nothing is left after the deposit carve-out (pure
+    // credit / pay-from-wallet sale, or the payment only covered deposit).
+    if (goodsCreditKobo > 0) {
+      final creditComp = WalletTransactionsCompanion.insert(
+        id: Value(UuidV7.generate()),
+        businessId: requireBusinessId(),
+        walletId: wallet.id,
+        customerId: cid,
+        type: 'credit',
+        amountKobo: goodsCreditKobo,
+        signedAmountKobo: goodsCreditKobo,
+        referenceType: paymentMethod == 'cash'
+            ? 'topup_cash'
+            : 'topup_transfer',
+        orderId: Value(orderId),
+        performedBy: Value(staffId),
+        createdAt: Value(legTime),
+        lastUpdatedAt: Value(legTime),
+      );
+      await into(walletTransactions).insert(creditComp);
+      await db.syncDao.enqueueUpsert('wallet_transactions', creditComp);
+    }
+
+    // Leg 3 — the held deposit (refundable, excluded from spendable). One
+    // `crate_deposit` credit for the whole sale's paid deposit; the per-brand
+    // split lives on order_crate_lines for the return modal to settle.
+    if (depositHeldKobo > 0) {
+      final heldComp = WalletTransactionsCompanion.insert(
+        id: Value(UuidV7.generate()),
+        businessId: requireBusinessId(),
+        walletId: wallet.id,
+        customerId: cid,
+        type: 'credit',
+        amountKobo: depositHeldKobo,
+        signedAmountKobo: depositHeldKobo,
+        referenceType: 'crate_deposit',
+        orderId: Value(orderId),
+        performedBy: Value(staffId),
+        createdAt: Value(legTime),
+        lastUpdatedAt: Value(legTime),
+      );
+      await into(walletTransactions).insert(heldComp);
+      await db.syncDao.enqueueUpsert('wallet_transactions', heldComp);
+    }
   }
 
   /// §13.4 Ring 5 — settle a MONEY-TRACK brand's deposit when its crates come

--- a/lib/shared/services/orders/order_commands.dart
+++ b/lib/shared/services/orders/order_commands.dart
@@ -135,7 +135,6 @@ class OrderCommands {
       totalAmountKobo: totalAmountKobo,
       staffId: staffId,
       storeId: storeId,
-      walletDebitKobo: walletDebitKobo,
       paymentMethod: _resolvePaymentMethod(paymentSubType),
       crateDepositPaidByManufacturer: crateDepositPaidByManufacturer,
     );

--- a/test/orders/pr_4c_test.dart
+++ b/test/orders/pr_4c_test.dart
@@ -204,7 +204,6 @@ void main() {
         totalAmountKobo: 100000,
         staffId: s.staffId,
         storeId: s.storeId,
-        walletDebitKobo: 100000,
       );
 
       final wallet = await db.select(db.walletTransactions).get();

--- a/test/sync/dispatch/record_sale_dispatch_test.dart
+++ b/test/sync/dispatch/record_sale_dispatch_test.dart
@@ -145,8 +145,8 @@ void main() {
     });
 
     test(
-        'flag ON: one envelope, only order header + inventory mirrored '
-        'locally, thin item shape', () async {
+        'flag ON: envelope + client wallet legs; order_items/stock/payment '
+        'wait for the RPC; thin item shape; no p_wallet_amount_kobo', () async {
       await setFlag(db, 'feature.domain_rpcs_v2.record_sale', on: true);
       final s = await _seedSaleFixtures(db, businessId);
       // Drain the customers + customer_wallets enqueues from addCustomer
@@ -164,8 +164,9 @@ void main() {
         paymentMethod: 'cash',
       );
 
-      // Local: order header + inventory deduction. NOT order_items, stock_tx,
-      // or payment_tx — those land via _applyDomainResponse from the RPC.
+      // Local: order header + inventory deduction + the client-authored wallet
+      // double-entry. NOT order_items, stock_tx, or payment_tx — those land via
+      // _applyDomainResponse from the RPC (server mints their ids).
       expect((await db.select(db.orders).getSingle()).id, orderId);
       expect(await db.select(db.orderItems).get(), isEmpty,
           reason: 'order_items wait for the RPC response (server mints ids)');
@@ -174,11 +175,31 @@ void main() {
       final inv = await db.select(db.inventory).getSingle();
       expect(inv.quantity, 8, reason: 'inventory still deducted on v2 path');
 
-      final pending = await getPendingQueue(db);
-      expect(pending, hasLength(1));
-      expect(pending.first.actionType, 'domain:pos_record_sale_v2');
+      // §14.3 wallet legs are client-authored on BOTH paths (invariant #3) —
+      // pos_record_sale_v2 is passed NO wallet amount. A fully-paid registered
+      // sale posts a goods debit (−total) and a cash credit (+paid).
+      final wallet = await db.select(db.walletTransactions).get();
+      expect(wallet, hasLength(2));
+      expect(
+        wallet.where((w) => w.type == 'debit' && w.signedAmountKobo == -200000),
+        hasLength(1),
+      );
+      expect(
+        wallet.where((w) => w.type == 'credit' && w.signedAmountKobo == 200000),
+        hasLength(1),
+      );
 
-      final payload = decodePayload(pending.first);
+      // The pending queue: exactly one domain envelope + the two wallet legs.
+      final pending = await getPendingQueue(db);
+      final domainRows =
+          pending.where((r) => r.actionType == 'domain:pos_record_sale_v2');
+      final walletRows =
+          pending.where((r) => r.actionType == 'wallet_transactions:upsert');
+      expect(domainRows, hasLength(1));
+      expect(walletRows, hasLength(2));
+      expect(pending, hasLength(3));
+
+      final payload = decodePayload(domainRows.single);
       expect(payload['p_business_id'], businessId);
       expect(payload['p_actor_id'], s.staffId);
       expect(payload['p_order_id'], orderId);
@@ -189,6 +210,8 @@ void main() {
       expect(payload['p_amount_paid_kobo'], 200000);
       expect(payload['p_customer_id'], s.customerId);
       expect(payload['p_status'], 'completed');
+      // The RPC's wallet branch stays a no-op — the legs above own the ledger.
+      expect(payload.containsKey('p_wallet_amount_kobo'), isFalse);
 
       final items = payload['p_items'] as List;
       expect(items, hasLength(1));
@@ -248,38 +271,61 @@ void main() {
       expect((await db.select(db.inventory).getSingle()).quantity, 10);
     });
 
-    test('flag ON (wallet portion): payload carries p_wallet_amount_kobo',
+    test(
+        'flag ON (register-as-credit): wallet legs client-authored, envelope '
+        'carries NO p_wallet_amount_kobo — the RPC cannot reject a debt sale',
         () async {
       await setFlag(db, 'feature.domain_rpcs_v2.record_sale', on: true);
       final s = await _seedSaleFixtures(db, businessId);
       await db.delete(db.syncQueue).go();
 
-      // Topup the wallet so the v1-style local guard would pass; on v2
-      // the server is authoritative for the balance check, but the local
-      // DAO still requires a customer wallet to exist for the OFF path
-      // to compile. For dispatch-shape testing, we only care that the
-      // envelope carries the wallet portion.
-      final wallet = await (db.select(db.customerWallets)
-            ..where((t) => t.customerId.equals(s.customerId)))
-          .getSingle();
-      expect(wallet, isNotNull);
-
+      // A register-as-credit sale: pay part now, owe the rest. On the OLD v2
+      // path this set p_wallet_amount_kobo and pos_record_sale_v2 rejected it
+      // (insufficient_wallet_balance — the customer's balance is 0, cannot be
+      // debited). Now the double-entry is posted client-side and the RPC is
+      // passed no wallet amount, so the sale is never gated by the balance —
+      // exactly the regression Option ① fixes.
       await db.ordersDao.createOrder(
-        order: _orderCompanion(s, businessId, orderNumber: 'ORD-WAL'),
+        order: _orderCompanion(
+          s,
+          businessId,
+          orderNumber: 'ORD-CREDIT',
+          amountPaidKobo: 50000,
+        ),
         items: [_itemCompanion(s, businessId)],
         customerId: s.customerId,
-        amountPaidKobo: 200000,
+        amountPaidKobo: 50000,
         totalAmountKobo: 200000,
         staffId: s.staffId,
         storeId: s.storeId,
-        walletDebitKobo: 50000,
         paymentMethod: 'cash',
       );
 
+      // Two legs: a −200000 goods debit and a +50000 cash credit, netting to
+      // −150000 — the customer now owes 150000 (the RPC never sees this).
+      final wallet = await db.select(db.walletTransactions).get();
+      expect(wallet, hasLength(2));
+      expect(
+        wallet.where((w) => w.type == 'debit' && w.signedAmountKobo == -200000),
+        hasLength(1),
+      );
+      expect(
+        wallet.where((w) => w.type == 'credit' && w.signedAmountKobo == 50000),
+        hasLength(1),
+      );
+      expect(
+        await db.walletTransactionsDao.getBalanceKobo(s.customerId),
+        -150000,
+      );
+
+      // The envelope carries the customer + amount paid, but NO wallet amount.
       final pending = await getPendingQueue(db);
-      final payload = decodePayload(pending.first);
-      expect(payload['p_wallet_amount_kobo'], 50000);
+      final domainRow =
+          pending.firstWhere((r) => r.actionType == 'domain:pos_record_sale_v2');
+      final payload = decodePayload(domainRow);
       expect(payload['p_customer_id'], s.customerId);
+      expect(payload['p_amount_paid_kobo'], 50000);
+      expect(payload.containsKey('p_wallet_amount_kobo'), isFalse);
     });
   });
 }

--- a/test/sync/exactly_once_stock_integrity_test.dart
+++ b/test/sync/exactly_once_stock_integrity_test.dart
@@ -4,32 +4,41 @@
 //
 // The headline defect: two tills sell the SAME last unit while briefly out of
 // sync. Each runs its LOCAL stock guard (both pass against a stale on-hand of
-// 1), both decrement to 0, and both push the ABSOLUTE `inventory.quantity = 0`
-// row. `inventory` restore is an LWW natural-key cache (sync_registry.dart:
-// isCache: true) — last-write-wins keeps a single row at quantity 0, so the
-// cloud reads 0 on hand yet TWO units were sold from a stock of 1. No error is
-// raised anywhere; the oversell is silent.
+// 1), both decrement to 0, and both push. On the current v1 path both push the
+// ABSOLUTE `inventory.quantity = 0` row; the natural-key LWW cache
+// (sync_registry.dart: isCache: true) keeps a single row at 0 — so the cloud
+// reads 0 on hand yet TWO units were sold from a stock of 1. No error is raised;
+// the oversell is silent.
 //
-// A-S1 (this file, RED first): reproduce that silent oversell on the CURRENT v1
-// path (flag OFF) — documents the bug. A-S3 flips the fixed behaviour in
-// alongside it (the v2 guarded-RPC path rejects the second sale).
+// Two groups here, one per path:
+//   • A-S1 (v1, flag OFF): reproduces the silent oversell — a documentation +
+//     regression guard so the defect cannot come back unnoticed.
+//   • A-S3 (v2, flag ON): the FIX — mobile checkout routes through the guarded
+//     `pos_record_sale_v2` (server `SELECT … FOR UPDATE` + relative decrement +
+//     `quantity >= n` reject + `ON CONFLICT (id) DO NOTHING`). The server
+//     serializes the two sales, accepts the first and REJECTS the second; the
+//     loser orphans visibly (Invariant #12) and on-hand never goes below 0.
+
+import 'dart:convert';
 
 import 'package:drift/drift.dart';
 import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:supabase_flutter/supabase_flutter.dart' show PostgrestException;
 
 import 'package:reebaplus_pos/core/database/app_database.dart';
 import 'package:reebaplus_pos/core/database/uuid_v7.dart';
+import 'package:reebaplus_pos/core/services/supabase_sync_service.dart';
 
 import '../helpers/dispatch_test_utils.dart';
 import '../helpers/in_memory_cloud_transport.dart';
 
 /// Shared ids so two devices agree on the same business / store / product /
 /// inventory row — exactly as they would after pulling them from one cloud.
-/// The shared `inventoryId` is load-bearing: the absolute-cache push upserts on
-/// the natural key `(business_id, product_id, store_id)`, so both devices'
-/// pushes collapse onto the SAME cloud row (LWW), which is the merge that hides
-/// the oversell.
+/// The shared `inventoryId` is load-bearing on the v1 path: the absolute-cache
+/// push upserts on the natural key `(business_id, product_id, store_id)`, so
+/// both devices' pushes collapse onto the SAME cloud row (LWW), which is the
+/// merge that hides the oversell.
 class _Fixture {
   _Fixture()
       : businessId = UuidV7.generate(),
@@ -46,7 +55,8 @@ class _Fixture {
 }
 
 /// A device: a fresh in-memory Drift DB seeded with the shared fixtures and a
-/// starting on-hand of [startQty] for the shared product.
+/// starting on-hand of [startQty] for the shared product. Flag-agnostic — each
+/// group sets `feature.domain_rpcs_v2.record_sale` itself.
 Future<AppDatabase> _bootDevice(_Fixture f, {required int startQty}) async {
   final db = AppDatabase.forTesting(NativeDatabase.memory());
   db.businessIdResolver = () => f.businessId;
@@ -144,6 +154,10 @@ Future<void> _drainToCloud(
   }
 }
 
+// Deterministic timestamps for the modelled cloud rows.
+const String _t0 = '2026-07-08T10:00:00.000Z';
+const String _t1 = '2026-07-08T10:00:01.000Z';
+
 void main() {
   // Two devices = two AppDatabase instances by design; silence the shared-executor
   // heuristic (each has its own in-memory executor, so there is no real race).
@@ -207,5 +221,208 @@ void main() {
         reason: '2 sales committed against 1 unit of stock — the oversell',
       );
     });
+  });
+
+  group('A-S3 — v2 guarded RPC rejects the concurrent oversell', () {
+    late _Fixture f;
+    late AppDatabase deviceA;
+    late AppDatabase deviceB;
+    late InMemoryCloudTransport cloud;
+    late SupabaseSyncService syncA;
+    late SupabaseSyncService syncB;
+
+    setUp(() async {
+      f = _Fixture();
+      deviceA = await _bootDevice(f, startQty: 1);
+      deviceB = await _bootDevice(f, startQty: 1);
+      await setFlag(deviceA, 'feature.domain_rpcs_v2.record_sale', on: true);
+      await setFlag(deviceB, 'feature.domain_rpcs_v2.record_sale', on: true);
+
+      cloud = InMemoryCloudTransport(authUserId: 'user-1');
+      // The shared cloud inventory both devices last pulled: on-hand 1.
+      cloud.seed('inventory', [
+        {
+          'id': f.inventoryId,
+          'business_id': f.businessId,
+          'product_id': f.productId,
+          'store_id': f.storeId,
+          'quantity': 1,
+          'last_updated_at': _t0,
+        },
+      ]);
+
+      // Faithful model of pos_record_sale_v2's server-authoritative guard
+      // against the SHARED cloud inventory: for each line, lock+read the row,
+      // reject on shortfall (P0001 insufficient_stock / inventory_row_missing),
+      // else relative-decrement. The order is inserted only after every line
+      // passes — a rejected sale rolls the whole RPC transaction back, so no
+      // order (and no movement) persists. Idempotent on p_order_id. The RPC's
+      // own SQL is verified separately at Tier-2 (pos_record_sale_v2_test.dart);
+      // here we prove the CLIENT routes through it and handles the rejection.
+      cloud.stubRpc('pos_record_sale_v2', (params) {
+        final storeId = params['p_store_id'] as String;
+        final orderId = params['p_order_id'] as String;
+        final items = (params['p_items'] as List).cast<Map<String, dynamic>>();
+
+        // Replay path: order already present → return without re-decrementing.
+        final existing = cloud
+            .rowsOf('orders')
+            .where((o) => o['id'] == orderId)
+            .toList();
+        if (existing.isNotEmpty) {
+          return {'inventory_after': <Map<String, dynamic>>[], 'replayed': true};
+        }
+
+        final invAfter = <Map<String, dynamic>>[];
+        for (final it in items) {
+          final pid = it['product_id'] as String?;
+          if (pid == null) continue; // quick-sale line: bypass inventory
+          final qty = it['quantity'] as int;
+          final match = cloud
+              .rowsOf('inventory')
+              .where((r) => r['product_id'] == pid && r['store_id'] == storeId)
+              .toList();
+          if (match.isEmpty) {
+            throw const PostgrestException(
+              message: 'inventory_row_missing',
+              code: 'P0001',
+            );
+          }
+          final available = match.single['quantity'] as int;
+          if (available < qty) {
+            throw const PostgrestException(
+              message: 'insufficient_stock',
+              code: 'P0001',
+            );
+          }
+          final newQty = available - qty;
+          cloud.seed('inventory', [
+            {...match.single, 'quantity': newQty, 'last_updated_at': _t1},
+          ]);
+          invAfter.add({
+            'product_id': pid,
+            'store_id': storeId,
+            'quantity': newQty,
+            'last_updated_at': _t1,
+          });
+        }
+        // ON CONFLICT (id) DO NOTHING — reached only when all lines passed.
+        cloud.seed('orders', [
+          {
+            'id': orderId,
+            'business_id': f.businessId,
+            'last_updated_at': _t1,
+          },
+        ]);
+        return {'inventory_after': invAfter, 'replayed': false};
+      });
+
+      syncA = SupabaseSyncService(deviceA, cloud)..isOnline.value = true;
+      syncB = SupabaseSyncService(deviceB, cloud)..isOnline.value = true;
+    });
+
+    tearDown(() async {
+      await cloud.dispose();
+      await deviceA.close();
+      await deviceB.close();
+    });
+
+    test(
+        'two offline tills both sell 1; the server accepts the first and '
+        'REJECTS the second → cloud never below 0, the loser orphans visibly',
+        () async {
+      // Both pass their LOCAL pre-check against the stale on-hand of 1 and
+      // enqueue a domain:pos_record_sale_v2 envelope.
+      final orderA = await _sellOneUnit(deviceA, f, orderNumber: 'ORD-A');
+      final orderB = await _sellOneUnit(deviceB, f, orderNumber: 'ORD-B');
+
+      // Device A reconnects and flushes first — the server accepts it (1 → 0).
+      await syncA.flushSale(orderA);
+
+      // Device B flushes — the server's FOR UPDATE + quantity>=qty guard now
+      // sees 0 on hand and REJECTS. flushSale surfaces the rejection instead of
+      // printing a receipt for a sale the cloud refused.
+      Object? caught;
+      try {
+        await syncB.flushSale(orderB);
+      } catch (e) {
+        caught = e;
+      }
+      expect(caught, isA<SaleSyncException>());
+      expect(
+        (caught! as SaleSyncException).errorMessage,
+        contains('insufficient_stock'),
+      );
+
+      // On-hand went 1 → 0 exactly once and never below zero.
+      expect(cloud.rowsOf('inventory').single['quantity'], 0);
+
+      // Exactly ONE order reached the cloud ledger — device A's. Device B's
+      // sale created no cloud order (the guarded RPC rolled back).
+      final cloudOrders = cloud.rowsOf('orders');
+      expect(cloudOrders, hasLength(1));
+      expect(cloudOrders.single['id'], orderA);
+
+      // Device B's rejected envelope is ORPHANED — visible + exportable on the
+      // Sync Issues screen (Invariant #12), never silently dropped…
+      final orphansB = await deviceB.select(deviceB.syncQueueOrphans).get();
+      expect(orphansB, hasLength(1));
+      expect(orphansB.single.actionType, 'domain:pos_record_sale_v2');
+      expect(orphansB.single.reason, contains('insufficient_stock'));
+
+      // …and it left the live queue (moved out, never left as a phantom
+      // pending row that could re-push).
+      final pendingB = await getPendingQueue(deviceB);
+      expect(
+        pendingB.where((r) => r.actionType == 'domain:pos_record_sale_v2'),
+        isEmpty,
+      );
+    });
+
+    test(
+        'lost-ack replay: re-flushing an already-accepted sale is idempotent — '
+        'no second decrement (exactly-once)', () async {
+      final orderA = await _sellOneUnit(deviceA, f, orderNumber: 'ORD-A');
+
+      // First flush accepts the sale (1 → 0) and marks the envelope done.
+      await syncA.flushSale(orderA);
+      expect(cloud.rowsOf('inventory').single['quantity'], 0);
+
+      // Simulate a lost ack: the row is re-enqueued and flushed again. The RPC
+      // is idempotent on p_order_id (ON CONFLICT DO NOTHING), so the replay
+      // must NOT decrement a second time.
+      await deviceA.syncDao.enqueue(
+        'domain:pos_record_sale_v2',
+        // Rebuild the same envelope shape flushSale looks up by p_order_id.
+        _envelopeFor(f, orderId: orderA),
+      );
+      await syncA.flushSale(orderA);
+
+      expect(
+        cloud.rowsOf('inventory').single['quantity'],
+        0,
+        reason: 'replay is a no-op — on-hand stays 0, never -1',
+      );
+      expect(cloud.rowsOf('orders'), hasLength(1));
+    });
+  });
+}
+
+/// Minimal `domain:pos_record_sale_v2` payload matching what `createOrder`
+/// enqueues, used to re-inject a lost-ack replay in the idempotency test.
+String _envelopeFor(_Fixture f, {required String orderId}) {
+  return jsonEncode({
+    'p_business_id': f.businessId,
+    'p_actor_id': f.staffId,
+    'p_order_id': orderId,
+    'p_order_number': 'ORD-A',
+    'p_store_id': f.storeId,
+    'p_payment_type': 'cash',
+    'p_items': [
+      {'product_id': f.productId, 'quantity': 1, 'unit_price_kobo': 100000},
+    ],
+    'p_status': 'completed',
+    'p_amount_paid_kobo': 100000,
+    'p_payment_method': 'cash',
   });
 }

--- a/test/sync/exactly_once_stock_integrity_test.dart
+++ b/test/sync/exactly_once_stock_integrity_test.dart
@@ -1,0 +1,211 @@
+// exactly_once_stock_integrity_test.dart
+//
+// Workstream A (#100) — exactly-once stock integrity.
+//
+// The headline defect: two tills sell the SAME last unit while briefly out of
+// sync. Each runs its LOCAL stock guard (both pass against a stale on-hand of
+// 1), both decrement to 0, and both push the ABSOLUTE `inventory.quantity = 0`
+// row. `inventory` restore is an LWW natural-key cache (sync_registry.dart:
+// isCache: true) — last-write-wins keeps a single row at quantity 0, so the
+// cloud reads 0 on hand yet TWO units were sold from a stock of 1. No error is
+// raised anywhere; the oversell is silent.
+//
+// A-S1 (this file, RED first): reproduce that silent oversell on the CURRENT v1
+// path (flag OFF) — documents the bug. A-S3 flips the fixed behaviour in
+// alongside it (the v2 guarded-RPC path rejects the second sale).
+
+import 'package:drift/drift.dart';
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:reebaplus_pos/core/database/app_database.dart';
+import 'package:reebaplus_pos/core/database/uuid_v7.dart';
+
+import '../helpers/dispatch_test_utils.dart';
+import '../helpers/in_memory_cloud_transport.dart';
+
+/// Shared ids so two devices agree on the same business / store / product /
+/// inventory row — exactly as they would after pulling them from one cloud.
+/// The shared `inventoryId` is load-bearing: the absolute-cache push upserts on
+/// the natural key `(business_id, product_id, store_id)`, so both devices'
+/// pushes collapse onto the SAME cloud row (LWW), which is the merge that hides
+/// the oversell.
+class _Fixture {
+  _Fixture()
+      : businessId = UuidV7.generate(),
+        storeId = UuidV7.generate(),
+        staffId = UuidV7.generate(),
+        productId = UuidV7.generate(),
+        inventoryId = UuidV7.generate();
+
+  final String businessId;
+  final String storeId;
+  final String staffId;
+  final String productId;
+  final String inventoryId;
+}
+
+/// A device: a fresh in-memory Drift DB seeded with the shared fixtures and a
+/// starting on-hand of [startQty] for the shared product.
+Future<AppDatabase> _bootDevice(_Fixture f, {required int startQty}) async {
+  final db = AppDatabase.forTesting(NativeDatabase.memory());
+  db.businessIdResolver = () => f.businessId;
+  await db.into(db.businesses).insert(
+        BusinessesCompanion.insert(id: Value(f.businessId), name: 'Biz'),
+      );
+  await db.into(db.stores).insert(
+        StoresCompanion.insert(
+          id: Value(f.storeId),
+          businessId: f.businessId,
+          name: 'Main',
+        ),
+      );
+  await db.into(db.users).insert(
+        UsersCompanion.insert(
+          id: Value(f.staffId),
+          businessId: f.businessId,
+          name: 'Cashier',
+          pin: '0000',
+        ),
+      );
+  await db.into(db.products).insert(
+        ProductsCompanion.insert(
+          id: Value(f.productId),
+          businessId: f.businessId,
+          name: 'Last Beer',
+          retailerPriceKobo: const Value(100000),
+        ),
+      );
+  await db.into(db.inventory).insert(
+        InventoryCompanion.insert(
+          id: Value(f.inventoryId),
+          businessId: f.businessId,
+          productId: f.productId,
+          storeId: f.storeId,
+          quantity: Value(startQty),
+        ),
+      );
+  return db;
+}
+
+/// A walk-in (no customer) cash sale of one unit of the shared product. Walk-in
+/// keeps the sale a pure stock movement — no wallet legs — so the test isolates
+/// the on-hand oversell.
+Future<String> _sellOneUnit(
+  AppDatabase db,
+  _Fixture f, {
+  required String orderNumber,
+}) {
+  return db.ordersDao.createOrder(
+    order: OrdersCompanion.insert(
+      businessId: f.businessId,
+      orderNumber: orderNumber,
+      totalAmountKobo: 100000,
+      netAmountKobo: 100000,
+      amountPaidKobo: const Value(100000),
+      paymentType: 'cash',
+      status: 'completed',
+      staffId: Value(f.staffId),
+      storeId: Value(f.storeId),
+    ),
+    items: [
+      OrderItemsCompanion.insert(
+        businessId: f.businessId,
+        orderId: 'placeholder', // overwritten by createOrder
+        productId: Value(f.productId),
+        storeId: f.storeId,
+        quantity: 1,
+        unitPriceKobo: 100000,
+        totalKobo: 100000,
+      ),
+    ],
+    amountPaidKobo: 100000,
+    totalAmountKobo: 100000,
+    staffId: f.staffId,
+    storeId: f.storeId,
+    paymentMethod: 'cash',
+  );
+}
+
+/// Push a device's enqueued rows for [tables] to the shared [cloud] exactly as
+/// `SupabaseSyncService.pushPending` does: one `upsert` per table payload. The
+/// fake keys stored rows by `id`, so the two devices' inventory rows (which
+/// share `inventoryId`) collapse to one — modelling the natural-key LWW merge
+/// the real cloud performs on `onConflict (business_id, product_id, store_id)`.
+Future<void> _drainToCloud(
+  AppDatabase db,
+  InMemoryCloudTransport cloud, {
+  required Set<String> tables,
+}) async {
+  for (final row in await getPendingQueue(db)) {
+    final table = row.actionType.split(':').first;
+    if (!tables.contains(table)) continue;
+    await cloud.upsertRows(table, [decodePayload(row)]);
+  }
+}
+
+void main() {
+  // Two devices = two AppDatabase instances by design; silence the shared-executor
+  // heuristic (each has its own in-memory executor, so there is no real race).
+  driftRuntimeOptions.dontWarnAboutMultipleDatabases = true;
+
+  group('A-S1 — v1 (flag OFF) silently oversells the last unit', () {
+    late _Fixture f;
+    late AppDatabase deviceA;
+    late AppDatabase deviceB;
+    late InMemoryCloudTransport cloud;
+
+    setUp(() async {
+      f = _Fixture();
+      // Both tills booted with the shared, stale on-hand of 1.
+      deviceA = await _bootDevice(f, startQty: 1);
+      deviceB = await _bootDevice(f, startQty: 1);
+      await setFlag(deviceA, 'feature.domain_rpcs_v2.record_sale', on: false);
+      await setFlag(deviceB, 'feature.domain_rpcs_v2.record_sale', on: false);
+      cloud = InMemoryCloudTransport(authUserId: 'user-1');
+    });
+
+    tearDown(() async {
+      await cloud.dispose();
+      await deviceA.close();
+      await deviceB.close();
+    });
+
+    test(
+        'two offline tills both sell 1, both push quantity=0 → cloud LWW keeps '
+        'one row at 0 with TWO orders: 2 sold from a stock of 1, silently',
+        () async {
+      // Each till's LOCAL guard passes against the stale on-hand of 1.
+      final orderA = await _sellOneUnit(deviceA, f, orderNumber: 'ORD-A');
+      final orderB = await _sellOneUnit(deviceB, f, orderNumber: 'ORD-B');
+      expect(orderA, isNotEmpty);
+      expect(orderB, isNotEmpty);
+
+      // Locally each device deducted to 0 with no error.
+      expect((await deviceA.select(deviceA.inventory).getSingle()).quantity, 0);
+      expect((await deviceB.select(deviceB.inventory).getSingle()).quantity, 0);
+
+      // Both reconnect and push their absolute inventory row + order.
+      await _drainToCloud(deviceA, cloud, tables: {'inventory', 'orders'});
+      await _drainToCloud(deviceB, cloud, tables: {'inventory', 'orders'});
+
+      // The cloud kept a SINGLE inventory row (natural-key LWW) at quantity 0…
+      final cloudInventory = cloud.rowsOf('inventory');
+      expect(cloudInventory, hasLength(1));
+      expect(
+        cloudInventory.single['quantity'],
+        0,
+        reason: 'LWW collapsed both pushes onto one quantity=0 row',
+      );
+
+      // …yet TWO orders were accepted. 2 units sold from a stock of 1, and the
+      // cloud has no way to know: the mutable balance simply reads 0. This is
+      // the silent oversell A-S3 makes impossible-to-absorb.
+      expect(
+        cloud.rowsOf('orders'),
+        hasLength(2),
+        reason: '2 sales committed against 1 unit of stock — the oversell',
+      );
+    });
+  });
+}

--- a/test/sync/stock_reprocess_idempotency_test.dart
+++ b/test/sync/stock_reprocess_idempotency_test.dart
@@ -1,0 +1,184 @@
+// stock_reprocess_idempotency_test.dart
+//
+// Workstream A (#100), A-S5(c): the append-only ledgers are the truth and the
+// balances they feed (`inventory`, `*_crate_balances`) are caches. Reprocessing
+// an already-applied economic event — the pull that reflects the till's OWN
+// just-pushed sale, or a retry, or a broadcast-triggered re-pull — must be a
+// NO-OP, never a second decrement.
+//
+// This pins the property the whole exactly-once story leans on: because the
+// stock ledger row is id-keyed (append-only) and the inventory cache is pushed
+// as an ABSOLUTE value (not a delta), restoring the same rows again cannot move
+// the balance. (A-S3's lost-ack test pins the same idempotency on the PUSH
+// side, via the RPC's `ON CONFLICT (id) DO NOTHING`; this pins the PULL side.)
+
+import 'package:drift/drift.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:reebaplus_pos/core/database/app_database.dart';
+import 'package:reebaplus_pos/core/database/uuid_v7.dart';
+import 'package:reebaplus_pos/core/services/supabase_sync_service.dart';
+
+import '../helpers/dispatch_test_utils.dart';
+import '../helpers/in_memory_cloud_transport.dart';
+
+void main() {
+  late AppDatabase db;
+  late String businessId;
+  late InMemoryCloudTransport transport;
+  late SupabaseSyncService sync;
+  late String storeId;
+  late String productId;
+  late String staffId;
+
+  setUp(() async {
+    final boot = await bootstrapTestDb();
+    db = boot.db;
+    businessId = boot.businessId;
+    transport = InMemoryCloudTransport(authUserId: 'user-1');
+    sync = SupabaseSyncService(db, transport);
+
+    storeId = UuidV7.generate();
+    await db.into(db.stores).insert(
+          StoresCompanion.insert(
+            id: Value(storeId),
+            businessId: businessId,
+            name: 'Main',
+          ),
+        );
+    staffId = UuidV7.generate();
+    await db.into(db.users).insert(
+          UsersCompanion.insert(
+            id: Value(staffId),
+            businessId: businessId,
+            name: 'Cashier',
+            pin: '0000',
+          ),
+        );
+    productId = UuidV7.generate();
+    await db.into(db.products).insert(
+          ProductsCompanion.insert(
+            id: Value(productId),
+            businessId: businessId,
+            name: 'Beer',
+            retailerPriceKobo: const Value(100000),
+          ),
+        );
+    await db.into(db.inventory).insert(
+          InventoryCompanion.insert(
+            businessId: businessId,
+            productId: productId,
+            storeId: storeId,
+            quantity: const Value(5),
+          ),
+        );
+    // v1 path so the sale writes local order_items / stock_transactions /
+    // inventory rows that a pull would later bring back to the same device.
+    await setFlag(db, 'feature.domain_rpcs_v2.record_sale', on: false);
+  });
+
+  tearDown(() async {
+    await transport.dispose();
+    await db.close();
+  });
+
+  test(
+      "reprocessing the till's own just-pushed sale (inventory cache + stock "
+      'ledger) does not double-decrement', () async {
+    // Sell 1 → inventory 5 → 4, one append-only stock_transactions row (−1).
+    final orderId = await db.ordersDao.createOrder(
+      order: OrdersCompanion.insert(
+        businessId: businessId,
+        orderNumber: 'ORD-1',
+        totalAmountKobo: 100000,
+        netAmountKobo: 100000,
+        amountPaidKobo: const Value(100000),
+        paymentType: 'cash',
+        status: 'completed',
+        staffId: Value(staffId),
+        storeId: Value(storeId),
+      ),
+      items: [
+        OrderItemsCompanion.insert(
+          businessId: businessId,
+          orderId: 'placeholder',
+          productId: Value(productId),
+          storeId: storeId,
+          quantity: 1,
+          unitPriceKobo: 100000,
+          totalKobo: 100000,
+        ),
+      ],
+      amountPaidKobo: 100000,
+      totalAmountKobo: 100000,
+      staffId: staffId,
+      storeId: storeId,
+      paymentMethod: 'cash',
+    );
+    expect((await db.select(db.inventory).getSingle()).quantity, 4);
+    final stockRow = (await db.select(db.stockTransactions).get()).single;
+    final inv = await db.select(db.inventory).getSingle();
+
+    // Simulate "already pushed": drain the outbox so the Invariant #12
+    // clobber-guard no longer shields these rows (it protects only UNconfirmed
+    // rows) — the pull that follows a confirmed push is what we're modelling.
+    await db.delete(db.syncQueue).go();
+
+    // The pull brings the device's OWN rows back (identical ids + values), just
+    // as `_restoreTableData` applies a page. The inventory cache is absolute,
+    // the ledger row is id-keyed.
+    Map<String, dynamic> stockCloudRow() => {
+          'id': stockRow.id,
+          'business_id': businessId,
+          'product_id': productId,
+          'location_id': storeId,
+          'quantity_delta': -1,
+          'movement_type': 'sale',
+          'order_id': orderId,
+          'performed_by': staffId,
+          'created_at': stockRow.createdAt.toIso8601String(),
+          'last_updated_at': stockRow.lastUpdatedAt.toIso8601String(),
+        };
+    await sync.restoreTableDataForTesting('inventory', [
+      {
+        'id': inv.id,
+        'business_id': businessId,
+        'product_id': productId,
+        'store_id': storeId,
+        'quantity': 4,
+        'created_at': inv.createdAt.toIso8601String(),
+        'last_updated_at': inv.lastUpdatedAt.toIso8601String(),
+      },
+    ]);
+    await sync.restoreTableDataForTesting('stock_transactions', [
+      stockCloudRow(),
+    ]);
+
+    // No second decrement: on-hand stays 4, the ledger stays one row.
+    expect(
+      (await db.select(db.inventory).getSingle()).quantity,
+      4,
+      reason: 'reprocessing the pushed inventory cache is a no-op',
+    );
+    expect(
+      await db.select(db.stockTransactions).get(),
+      hasLength(1),
+      reason: 'the id-keyed ledger row re-restores without a duplicate',
+    );
+
+    // Reprocess AGAIN (a second pull / a broadcast-triggered re-pull) — still
+    // idempotent: the event is applied exactly once.
+    await sync.restoreTableDataForTesting('stock_transactions', [
+      stockCloudRow(),
+    ]);
+    expect(await db.select(db.stockTransactions).get(), hasLength(1));
+    expect((await db.select(db.inventory).getSingle()).quantity, 4);
+
+    // And the on-hand equals opening + SUM(ledger deltas) — the balance is a
+    // faithful projection of the append-only ledger, not an independent counter
+    // that can drift under reprocessing.
+    final deltaSum = (await db.select(db.stockTransactions).get())
+        .fold<int>(0, (s, r) => s + r.quantityDelta);
+    expect(5 + deltaSum, 4);
+  });
+}

--- a/test/wallet/credit_ledger_logic_test.dart
+++ b/test/wallet/credit_ledger_logic_test.dart
@@ -86,7 +86,6 @@ void main() {
       amountPaidKobo: 0,
       totalAmountKobo: 4000,
       staffId: 'staff1',
-      walletDebitKobo: 4000,
     );
 
     final balance = await db.walletTransactionsDao.getBalanceKobo(customerId);
@@ -111,7 +110,6 @@ void main() {
       amountPaidKobo: 0,
       totalAmountKobo: 3000,
       staffId: 'staff1',
-      walletDebitKobo: 3000,
     );
 
     expect(await db.walletTransactionsDao.getBalanceKobo(customerId),


### PR DESCRIPTION
Closes #100.

Workstream A of the live-sync / exactly-once loop (PRD:
`context/specs/brief-live-sync-signal-and-exactly-once.md`). Ships **first**, fully, before
Workstream B.

## The defect

Stock of a product is **1**. Till A and Till B both sell it while briefly out of sync. Each
device runs its **local** stock guard (`inventory.quantity >= qty`), both pass, both decrement
to 0, and both push the **absolute** `inventory.quantity = 0` row. `inventory` restore is an
LWW natural-key cache, so last-write-wins keeps one row at 0 — the cloud reads **0** on hand,
yet **2 units were sold from 1**. No error is raised anywhere. The oversell is silent.

## The fix (Option ①)

Route mobile checkout through the already-existing, oversell-safe **`pos_record_sale_v2`** RPC,
whose stock write is a server-authoritative `SELECT … FOR UPDATE` + **relative**
`quantity = quantity - n WHERE quantity >= n` + `insufficient_stock` / `inventory_row_missing`
(P0001) + `ON CONFLICT (id) DO NOTHING`. Two concurrent sales of the last unit now **serialize
server-side**: the first is accepted, the second is **rejected** and **orphaned visibly**, and
on-hand never goes below 0.

**Why not just flip the flag** (the committed A1-flag path): verified against the live DB, the
RPC's stock write is exactly right and has no schema drift, but its **wallet model is
incompatible** with the live path — it posts only a single `p_wallet_amount_kobo` debit, so a
blanket flip would drop wallet history on cash sales and **reject register-as-credit sales**
(`insufficient_wallet_balance` — it has no debt/negative path). So instead:

- `OrdersDao.createOrder` now posts the §14.3 wallet double-entry via a new
  `_postSaleWalletLegs` helper called **before** the v1/v2 split, so the legs are
  **client-authored on both paths** (invariant #3 — wallet ledgers are append-only/derived,
  never server-minted).
- The v2 envelope is passed **no** `p_wallet_amount_kobo` (the RPC's wallet branch stays a
  no-op); the now-dead v2-only `walletDebitKobo` param is removed from `createOrder`.
- The local pre-check is kept for fast offline UX, but the **server decision is authoritative**.

This also **removes a latent v2 split-brain**: the old v2 path minted a server-only wallet
debit with no local mirror (which would have broken cancel/refund/reports on v2). v2's wallet
rows are now byte-identical to v1's, so every downstream flow already tested on v1 holds on v2.

## Invariants honoured (by name)

- **#1 Drift is the source of truth** — checkout still commits to Drift first; nothing blocks
  the UI on the network; the RPC runs at push time, not at render.
- **#3 wallet & supplier ledgers append-only/derived** — the wallet double-entry is
  client-authored on both paths; balances remain `SUM(signed_amount_kobo)`.
- **#4 every cloud write goes through the outbox** — the sale is a `domain:pos_record_sale_v2`
  outbox envelope; the wallet/crate legs are ordinary outbox upserts (a sanctioned domain RPC).
- **#12 the outbox is sacred** — a server-rejected sale is **moved to `sync_queue_orphans`**
  (visible + exportable on Sync Issues), never silently dropped; the lost-ack replay is a no-op.

## Test matrix (red-before / green-after)

- **Two devices race the last unit** — the 2nd offline sale is rejected server-side, on-hand
  never below 0, the loser orphans visibly (`exactly_once_stock_integrity_test.dart`, v2 group).
- **v1 silent-oversell regression guard** — documents the current absolute-LWW bug so it can't
  come back unnoticed (same file, v1 group).
- **Lost-ack retry (exactly-once)** — re-flushing an accepted sale replays `ON CONFLICT DO
  NOTHING`, no second decrement.
- **Offline-then-reconnect reprocess** — restoring the till's own just-pushed inventory cache +
  append-only stock ledger is a no-op; on-hand == opening + SUM(ledger deltas)
  (`stock_reprocess_idempotency_test.dart`).
- Updated `record_sale_dispatch_test` (v2 legs + a register-as-credit case),
  `credit_ledger_logic_test`, `pr_4c_test`.

## A-S6 — audit of every mutable-balance (`isCache`) table

| Cache table | Movement write | Push shape | Backing ledger | Verdict |
|---|---|---|---|---|
| `inventory` | relative pre-check | absolute LWW | `stock_transactions` | **FIXED** — guarded RPC authoritative |
| `customer_crate_balances` | relative (`balance+δ`) | absolute LWW | `crate_ledger` (append-only) | mitigated → follow-up |
| `manufacturer_crate_balances` | relative | absolute LWW | `crate_ledger` | mitigated → follow-up |
| `store_crate_balances` | relative (+ intentional `setBalance` override) | absolute LWW | `crate_ledger` | mitigated → follow-up |
| `supplier_crate_balances` | relative | absolute LWW | `supplier_crate_ledger` | mitigated → follow-up |

The four crate caches share inventory's push-absolute-LWW shape, so concurrent **offline** crate
movements to the same owner can drift the cache — but they're **ledger-backed** (both movements
survive, id-keyed), write **relative** movements, and are **recomputable**
(`verifyCrateReconciliation`). Lower severity than the stock oversell (a deposit tally
reconciliation fixes, not silent money-for-nothing). Not a #100 gap.

## Decisions for the reviewer / follow-ups (not built here)

1. **Go-live flag flip (ops).** This PR leaves `feature.domain_rpcs_v2.record_sale` **off** — the
   code is correct on both states. Flipping it is a per-environment, production-wide runtime
   change that activates the dormant v2 path; recommend a controlled, monitored flip (one
   reversible `system_config` update), **not** bundled into the code merge. The fix is inert
   until flipped.
2. **Orphan-UX recovery flow (product).** When the server rejects the 2nd sale on the
   **background reconnect** path (vs. the foreground `flushSale`, which already
   compensates + surfaces), the envelope orphans visibly but the local order stays `pending`.
   The cashier recovery flow (auto-cancel? notify? re-ring/refund/restock?) is undefined product
   behaviour — **logged, not invented**. Suggest a separate feature-scoped issue.
3. **Crate-cache reconciliation (follow-up).** `verifyCrateReconciliation` is not auto-wired;
   auto-schedule it, or derive crate balances from the ledger on read, or route crate movements
   through a server-guarded RPC mirroring `pos_record_sale_v2`.
4. **Offline v2 FK-defer (minor).** An offline registered/crate sale's wallet/crate legs
   FK-reference the RPC-minted order, so on reconnect they FK-defer once and converge on retry
   (the online path front-runs this via `flushSale`). Matches existing crate behaviour; a cheap
   follow-up could flush a sale's envelope before its child legs.

## DoD

`flutter analyze` clean. `flutter test` green except the pre-existing, unrelated
`who_is_working_screen_test` (0 references to this diff; fails on a `deleted_businesses`
network 400 — documented failing on `main`). No migration in this PR (Option ① is
config-gated). `context/progress-tracker.md` + `BUILD_LOG.md` updated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stock protection during offline sales to prevent inventory from falling below zero.
  * Added safeguards against duplicate sales and repeated processing.
  * Preserved rejected sales for recovery while clearing them from active processing.

* **Improvements**
  * Wallet payments and credits are now recorded consistently as balanced ledger entries.
  * Partial-payment checkout handling is more reliable.
  * Added coverage for cross-device sales, replayed requests, and wallet transactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->