### PR TITLE
fix(ui): show tap-ripple on four coloured list rows (#114)

### DIFF
--- a/lib/features/auth/screens/ceo_sign_up_screen.dart
+++ b/lib/features/auth/screens/ceo_sign_up_screen.dart
@@ -1356,7 +1356,11 @@ class _CrateTrackingToggle extends StatelessWidget {
           color: onSurface.withValues(alpha: 0.12),
         ),
       ),
-      child: SwitchListTile(
+      // Transparent Material gives the switch an ink target above the
+      // surface-coloured container so its tap-ripple shows.
+      child: Material(
+        type: MaterialType.transparency,
+        child: SwitchListTile(
         value: value,
         onChanged: onChanged,
         activeThumbColor: primary,
@@ -1377,6 +1381,7 @@ class _CrateTrackingToggle extends StatelessWidget {
           ),
         ),
         contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+        ),
       ),
     );
   }

--- a/lib/features/auth/screens/login_screen.dart
+++ b/lib/features/auth/screens/login_screen.dart
@@ -1036,7 +1036,11 @@ class _UserPickerSheet extends StatelessWidget {
           ),
           const SizedBox(height: 20),
           ...users.map(
-            (u) => ListTile(
+            // Transparent Material gives the row an ink target above the
+            // surface-coloured wrapper so its tap-ripple shows (cf. cart_screen).
+            (u) => Material(
+              type: MaterialType.transparency,
+              child: ListTile(
               contentPadding: EdgeInsets.zero,
               leading: CircleAvatar(
                 backgroundColor: _hexColor(context, u.avatarColor),
@@ -1073,6 +1077,7 @@ class _UserPickerSheet extends StatelessWidget {
                 },
               ),
               onTap: () => onSelected(u),
+            ),
             ),
           ),
         ],

--- a/lib/features/inventory/screens/stock_count_screen.dart
+++ b/lib/features/inventory/screens/stock_count_screen.dart
@@ -1099,7 +1099,11 @@ class _StockCountScreenState extends ConsumerState<StockCountScreen> {
                         (n, c) => n + c.shortageCount,
                       );
 
-                      return ListTile(
+                      // Transparent Material gives the row an ink target above
+                      // the sheet's coloured fill so its tap-ripple shows.
+                      return Material(
+                        type: MaterialType.transparency,
+                        child: ListTile(
                         contentPadding: EdgeInsets.symmetric(
                           horizontal: context.getRSize(20),
                           vertical: context.getRSize(4),
@@ -1143,6 +1147,7 @@ class _StockCountScreenState extends ConsumerState<StockCountScreen> {
                           Navigator.pop(ctx);
                           _showDayDetail(context, label, dayCounts);
                         },
+                        ),
                       );
                     },
                   ),

--- a/lib/features/receiving/screens/receive_checkout_screen.dart
+++ b/lib/features/receiving/screens/receive_checkout_screen.dart
@@ -834,9 +834,14 @@ class _SupplierPickerSheetState extends ConsumerState<_SupplierPickerSheet> {
                           Divider(height: 1, color: theme.dividerColor),
                       itemBuilder: (context, index) {
                         final s = filtered[index];
-                        return ListTile(
+                        // Transparent Material gives the row an ink target above
+                        // the sheet's coloured fill so its tap-ripple shows.
+                        return Material(
+                          type: MaterialType.transparency,
+                          child: ListTile(
                           title: Text(s.name),
                           onTap: () => Navigator.pop(context, s),
+                          ),
                         );
                       },
                     ),


### PR DESCRIPTION
## Summary

Fixes the four list rows whose tap-ripple was hidden by a surface-coloured wrapper — the **login user-picker**, the **stock-count day row**, the **receive supplier-pick row**, and the **CEO sign-up crate toggle**. Each tile is now wrapped in a see-through `Material(type: MaterialType.transparency)` so the ink splash has a target above the coloured fill, with the background unchanged. This is the same pattern already shipped on the saved-carts sheet in `cart_screen.dart`.

No row sets its own tile colour, so this is ripple-only — no visual/background change.

## Acceptance criteria

- [x] Each of the four rows shows its tap-ripple, with its background unchanged
- [x] Fix matches the existing cart-screen pattern (a see-through Material above the coloured wrapper)

## Verification

- `dart analyze` on the 4 changed files: **No issues found**
- Existing tests over the touched feature areas pass (auth login isolation, receiving flow-mode + receive-stock, stock-count DAO — 26 tests green), including widget tests that render the receiving screens
- **No widget test added** — deliberate: the pattern has no test precedent (the `cart_screen` fix it mirrors shipped untested), nothing in `test/` locks it, and all four sites are private/embedded widgets (`_CrateTrackingToggle` is private) not cheaply pumpable without scope-expanding source changes. Final visual confirmation is on-emulator.

Closes #114
