### PR TITLE
feat(pos): always-visible search bar, remove search toggle (#111)

### DIFF
--- a/lib/features/pos/controllers/pos_controller.dart
+++ b/lib/features/pos/controllers/pos_controller.dart
@@ -17,7 +17,6 @@ class PosController extends ChangeNotifier {
   String selectedManufacturerId = 'All';
   PriceTier selectedGroup = PriceTier.retailer;
   String searchQuery = '';
-  bool isSearching = false;
   String? currentStoreName;
 
   /// The concrete store POS sells from when the global active store is "All
@@ -162,14 +161,6 @@ class PosController extends ChangeNotifier {
 
   void selectGroup(PriceTier group) {
     selectedGroup = group;
-    notifyListeners();
-  }
-
-  void toggleSearch() {
-    isSearching = !isSearching;
-    if (!isSearching) {
-      searchQuery = '';
-    }
     notifyListeners();
   }
 

--- a/lib/features/pos/screens/pos_home_screen.dart
+++ b/lib/features/pos/screens/pos_home_screen.dart
@@ -256,8 +256,10 @@ class _PosHomeScreenState extends ConsumerState<PosHomeScreen> {
                   subtextCol,
                   borderCol,
                 ),
-                if (_controller!.isSearching)
-                  _buildSearchField(surfaceCol, cardCol, textCol, subtextCol),
+                // #111: the search field is always visible in its position
+                // between the price/manufacturer dropdowns and the category
+                // chips — no show/hide toggle, no app-bar search icon.
+                _buildSearchField(surfaceCol, cardCol, textCol, subtextCol),
                 _controller!.isLoading
                     ? const SizedBox.shrink()
                     : CategoryFilterBar(
@@ -499,19 +501,6 @@ class _PosHomeScreenState extends ConsumerState<PosHomeScreen> {
           ),
           onPressed: _showViewSelectorModal,
         ),
-        IconButton(
-          icon: Icon(
-            _controller!.isSearching
-                ? FontAwesomeIcons.xmark.data
-                : FontAwesomeIcons.magnifyingGlass.data,
-            size: 17,
-            color: subtextCol,
-          ),
-          onPressed: () {
-            _controller!.toggleSearch();
-            if (!_controller!.isSearching) _searchController.clear();
-          },
-        ),
         const NotificationBell(),
         SizedBox(width: context.getRSize(16)),
       ],
@@ -675,7 +664,9 @@ class _PosHomeScreenState extends ConsumerState<PosHomeScreen> {
       ),
       child: AppInput(
         controller: _searchController,
-        autofocus: true,
+        // #111: the field is now always visible, so it must not steal focus
+        // and pop the keyboard every time POS opens — the cashier taps it when
+        // they want to search.
         onChanged: (v) => _controller!.updateSearch(v),
         hintText:
             'Search ${ref.watch(industryLexiconProvider).itemPluralLower}...',


### PR DESCRIPTION
Closes #111.

## What changed
The POS search field is now **always visible** in its existing position — between the price/manufacturer dropdowns and the category chips. The show/hide toggle and the app-bar search icon are gone.

- `pos_home_screen.dart`: render `_buildSearchField(...)` unconditionally; remove the app-bar search `IconButton`; drop `autofocus` so the persistent field no longer pops the keyboard on every POS open (the cashier taps it to search).
- `pos_controller.dart`: delete the now-unused `isSearching` field and `toggleSearch()` method.

Filtering behaviour is unchanged — `updateSearch()` / `filteredProducts` are untouched, so searching filters the grid exactly as before.

## Acceptance criteria
- [x] Search field renders unconditionally in its existing position.
- [x] The app-bar search icon is removed; the toggle state is gone.
- [x] Searching filters the grid exactly as before.

## Verification
- `dart analyze` on both changed files — no issues.
- `flutter test test/pos/` — all 30 tests pass.