### PR TITLE
feat(inventory): press-and-hold-to-edit discoverability hint (#110)

### DIFF
--- a/lib/features/inventory/screens/inventory_screen.dart
+++ b/lib/features/inventory/screens/inventory_screen.dart
@@ -73,10 +73,19 @@ class _InventoryScreenState extends ConsumerState<InventoryScreen>
   // Products-tab header search (§16.4, amended — reuses the POS toggle pattern).
   bool _showSearch = false;
   // Discoverability banner (issue #110): "press and hold to edit". Seeded from
-  // the UI-hint service in initState (shown a couple of times, per staff member,
-  // local-only); the render also checks Gates.editProductPrice so it only
-  // reaches users who can actually long-press-edit.
+  // the UI-hint service in initState (per staff member, local-only); the render
+  // also checks Gates.editProductPrice so it only reaches users who can actually
+  // long-press-edit. Dismissing it retires the banner permanently for that user.
   bool _showLongPressHint = false;
+  // The banner's dismissal is "per staff member" (issue #110 AC), so scope the
+  // shared UI-hint key to the current device user. Falls back to the bare key
+  // when no user is resolved (not expected on this authenticated screen).
+  String get _longPressHintKey {
+    final userId = ref.read(deviceUserIdProvider).value;
+    return userId == null || userId.isEmpty
+        ? UiHintService.hintInventoryLongpress
+        : '${UiHintService.hintInventoryLongpress}_$userId';
+  }
   String _searchQuery = '';
   final _searchCtrl = TextEditingController();
   int _totalCrateAssetsSum = 0;
@@ -208,7 +217,7 @@ class _InventoryScreenState extends ConsumerState<InventoryScreen>
     // Issue #110: surface the "press and hold to edit" banner a couple of times
     // per staff member. Visibility is further gated on Gates.editProductPrice at
     // render time, so it only reaches users who can use the gesture.
-    uiHintService.shouldShow(UiHintService.hintInventoryLongpress).then((show) {
+    uiHintService.shouldShow(_longPressHintKey).then((show) {
       if (show && mounted) setState(() => _showLongPressHint = true);
     });
 
@@ -731,7 +740,8 @@ class _InventoryScreenState extends ConsumerState<InventoryScreen>
         // Issue #110: press-and-hold-to-edit discoverability banner. Shown only
         // to staff the price-edit gate lets long-press-edit (matching the
         // gesture's own guard on `_buildProductRow`), only while there are
-        // products to hold, and only until dismissed / view-count exhausted.
+        // products to hold, and only until this staff member dismisses it
+        // (which retires it permanently for them).
         if (_showLongPressHint &&
             list.isNotEmpty &&
             Gates.editProductPrice.allows(ref))
@@ -741,7 +751,7 @@ class _InventoryScreenState extends ConsumerState<InventoryScreen>
                 ' to edit it.',
             onDismiss: () {
               setState(() => _showLongPressHint = false);
-              uiHintService.markShown(UiHintService.hintInventoryLongpress);
+              uiHintService.markDismissed(_longPressHintKey);
             },
           ),
         Expanded(

--- a/lib/features/inventory/screens/inventory_screen.dart
+++ b/lib/features/inventory/screens/inventory_screen.dart
@@ -43,6 +43,7 @@ import 'package:reebaplus_pos/features/sync/controllers/first_load_overlay_contr
 import 'package:reebaplus_pos/shared/widgets/skeletons/first_load_skeletons.dart';
 import 'package:reebaplus_pos/core/providers/first_run_surface_state.dart';
 import 'package:reebaplus_pos/shared/widgets/first_run_empty_state.dart';
+import 'package:reebaplus_pos/shared/services/ui_hint_service.dart';
 
 class InventoryScreen extends ConsumerStatefulWidget {
   const InventoryScreen({super.key});
@@ -71,6 +72,11 @@ class _InventoryScreenState extends ConsumerState<InventoryScreen>
   String? _selectedCategoryId;
   // Products-tab header search (§16.4, amended — reuses the POS toggle pattern).
   bool _showSearch = false;
+  // Discoverability banner (issue #110): "press and hold to edit". Seeded from
+  // the UI-hint service in initState (shown a couple of times, per staff member,
+  // local-only); the render also checks Gates.editProductPrice so it only
+  // reaches users who can actually long-press-edit.
+  bool _showLongPressHint = false;
   String _searchQuery = '';
   final _searchCtrl = TextEditingController();
   int _totalCrateAssetsSum = 0;
@@ -198,6 +204,13 @@ class _InventoryScreenState extends ConsumerState<InventoryScreen>
     super.initState();
     _tabController = TabController(length: _tabKeys.length, vsync: this);
     _tabController.addListener(_onTabChanged);
+
+    // Issue #110: surface the "press and hold to edit" banner a couple of times
+    // per staff member. Visibility is further gated on Gates.editProductPrice at
+    // render time, so it only reaches users who can use the gesture.
+    uiHintService.shouldShow(UiHintService.hintInventoryLongpress).then((show) {
+      if (show && mounted) setState(() => _showLongPressHint = true);
+    });
 
     // Defer all DB stream subscriptions until after the first frame so the
     // shimmer skeleton renders immediately without competing with 8+ SQL
@@ -715,6 +728,22 @@ class _InventoryScreenState extends ConsumerState<InventoryScreen>
       children: [
         if (_showSearch) _buildSearchField(context),
         _buildSupplierFilter(context),
+        // Issue #110: press-and-hold-to-edit discoverability banner. Shown only
+        // to staff the price-edit gate lets long-press-edit (matching the
+        // gesture's own guard on `_buildProductRow`), only while there are
+        // products to hold, and only until dismissed / view-count exhausted.
+        if (_showLongPressHint &&
+            list.isNotEmpty &&
+            Gates.editProductPrice.allows(ref))
+          _buildInlineHint(
+            message: 'Press and hold a '
+                '${ref.watch(industryLexiconProvider).itemLower}'
+                ' to edit it.',
+            onDismiss: () {
+              setState(() => _showLongPressHint = false);
+              uiHintService.markShown(UiHintService.hintInventoryLongpress);
+            },
+          ),
         Expanded(
           child: list.isEmpty
               // Genuinely empty catalogue (not a filter/search miss) hands off
@@ -742,6 +771,58 @@ class _InventoryScreenState extends ConsumerState<InventoryScreen>
                 ),
         ),
       ],
+    );
+  }
+
+  // Inline dismissible hint shown at the top of the Products list (first couple
+  // of visits). Mirrors the POS home screen's "tap and hold to edit" banner
+  // (issue #110); view-counted under UiHintService.hintInventoryLongpress.
+  Widget _buildInlineHint({
+    required String message,
+    required VoidCallback onDismiss,
+  }) {
+    final primary = Theme.of(context).colorScheme.primary;
+    return Container(
+      margin: EdgeInsets.fromLTRB(
+        context.getRSize(16),
+        context.getRSize(8),
+        context.getRSize(16),
+        0,
+      ),
+      padding: EdgeInsets.all(context.getRSize(12)),
+      decoration: BoxDecoration(
+        color: primary.withValues(alpha: 0.1),
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Row(
+        children: [
+          Icon(
+            FontAwesomeIcons.circleInfo.data,
+            size: context.getRSize(16),
+            color: primary,
+          ),
+          SizedBox(width: context.getRSize(12)),
+          Expanded(
+            child: Text(
+              message,
+              style: TextStyle(
+                fontSize: context.getRFontSize(13),
+                color: primary,
+              ),
+            ),
+          ),
+          IconButton(
+            icon: Icon(
+              FontAwesomeIcons.xmark.data,
+              size: context.getRSize(16),
+              color: primary,
+            ),
+            onPressed: onDismiss,
+            padding: EdgeInsets.zero,
+            constraints: const BoxConstraints(),
+          ),
+        ],
+      ),
     );
   }
 

--- a/lib/shared/services/ui_hint_service.dart
+++ b/lib/shared/services/ui_hint_service.dart
@@ -17,6 +17,11 @@ class UiHintService {
   // staff member, stored locally, never synced.
   static const hintInventoryLongpress = 'hint_inventory_longpress';
 
+  // A hint stops surfacing once its stored view-count reaches this threshold —
+  // whether it got there by repeated views (markShown) or a deliberate
+  // dismissal (markDismissed).
+  static const _retireAfter = 2;
+
   Future<int> viewCount(String hintKey) async {
     final prefs = await SharedPreferences.getInstance();
     return prefs.getInt(hintKey) ?? 0;
@@ -24,13 +29,21 @@ class UiHintService {
 
   Future<bool> shouldShow(String hintKey) async {
     final count = await viewCount(hintKey);
-    return count < 2;
+    return count < _retireAfter;
   }
 
   Future<void> markShown(String hintKey) async {
     final prefs = await SharedPreferences.getInstance();
     final count = (prefs.getInt(hintKey) ?? 0) + 1;
     await prefs.setInt(hintKey, count);
+  }
+
+  /// Permanently retires a hint (e.g. the user dismissed it deliberately),
+  /// regardless of how many times it has been shown. Uses the same local store
+  /// as [markShown] — no new persistence mechanism.
+  Future<void> markDismissed(String hintKey) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setInt(hintKey, _retireAfter);
   }
 }
 

--- a/lib/shared/services/ui_hint_service.dart
+++ b/lib/shared/services/ui_hint_service.dart
@@ -11,6 +11,11 @@ class UiHintService {
   // (issue #32 / ADR 0006): "tap a product to add it to the cart". Only shown
   // when the POS grid actually has products to tap.
   static const hintPosTapAdd = 'hint_pos_tap_add';
+  // Discoverability banner on the Inventory Products list (issue #110): "press
+  // and hold a product to edit it". Only surfaced to staff the price-edit gate
+  // (Gates.editProductPrice) lets long-press-edit; dismissal is permanent per
+  // staff member, stored locally, never synced.
+  static const hintInventoryLongpress = 'hint_inventory_longpress';
 
   Future<int> viewCount(String hintKey) async {
     final prefs = await SharedPreferences.getInstance();

--- a/test/shared/services/ui_hint_service_test.dart
+++ b/test/shared/services/ui_hint_service_test.dart
@@ -41,5 +41,23 @@ void main() {
       expect(await service.shouldShow(UiHintService.hintPosLongpress), true);
       expect(await service.viewCount(UiHintService.hintPosLongpress), 0);
     });
+
+    test('inventory long-press hint is view-counted independently (#110)',
+        () async {
+      // The Inventory "press and hold to edit" banner reuses the shared hint
+      // service under its own key: dismissing it twice hides it permanently for
+      // that staff member without touching the POS banners' view counts.
+      await service.markShown(UiHintService.hintInventoryLongpress);
+      expect(await service.shouldShow(UiHintService.hintInventoryLongpress),
+          true);
+
+      await service.markShown(UiHintService.hintInventoryLongpress);
+      expect(await service.shouldShow(UiHintService.hintInventoryLongpress),
+          false);
+
+      // POS keys are untouched by the inventory dismissal.
+      expect(await service.shouldShow(UiHintService.hintPosLongpress), true);
+      expect(await service.shouldShow(UiHintService.hintPosTapAdd), true);
+    });
   });
 }

--- a/test/shared/services/ui_hint_service_test.dart
+++ b/test/shared/services/ui_hint_service_test.dart
@@ -42,22 +42,32 @@ void main() {
       expect(await service.viewCount(UiHintService.hintPosLongpress), 0);
     });
 
-    test('inventory long-press hint is view-counted independently (#110)',
-        () async {
-      // The Inventory "press and hold to edit" banner reuses the shared hint
-      // service under its own key: dismissing it twice hides it permanently for
-      // that staff member without touching the POS banners' view counts.
-      await service.markShown(UiHintService.hintInventoryLongpress);
+    test('inventory long-press hint retires permanently on first dismissal '
+        '(#110)', () async {
+      // AC #3: dismissing the Inventory "press and hold to edit" banner hides
+      // it permanently for that staff member — one dismissal is enough, unlike
+      // the twice-shown POS banners. Reuses the shared service under its own
+      // key.
       expect(await service.shouldShow(UiHintService.hintInventoryLongpress),
           true);
 
-      await service.markShown(UiHintService.hintInventoryLongpress);
+      await service.markDismissed(UiHintService.hintInventoryLongpress);
       expect(await service.shouldShow(UiHintService.hintInventoryLongpress),
           false);
 
       // POS keys are untouched by the inventory dismissal.
       expect(await service.shouldShow(UiHintService.hintPosLongpress), true);
       expect(await service.shouldShow(UiHintService.hintPosTapAdd), true);
+    });
+
+    test('markDismissed retires any hint in a single call', () async {
+      // markDismissed is the "permanent" counterpart to the view-counted
+      // markShown — one call pushes the stored count to the retire threshold.
+      const key = UiHintService.hintPosLongpress;
+      expect(await service.shouldShow(key), true);
+
+      await service.markDismissed(key);
+      expect(await service.shouldShow(key), false);
     });
   });
 }


### PR DESCRIPTION
## What this does

Adds a dismissible discoverability banner at the top of the **Inventory → Products** list telling staff they can **press and hold a product to edit it**. The long-press-to-edit gesture already exists on each product row but isn't discoverable; this surfaces it.

## Behaviour (issue #110 ACs)

- **Banner** appears above the products list, mirroring the POS home screen's "tap and hold to edit" banner (same `_buildInlineHint` shape — info icon + dismiss ✕).
- **Visibility matches the gesture's own guard** — it renders only when `Gates.editProductPrice.allows(ref)` (the same gate that enables the row long-press) and only while the list has products to hold, so it reaches exactly the staff who can use it.
- **Per staff member** — the hint key is scoped to `deviceUserIdProvider`, so on a shared till each staff member sees (and dismisses) it independently rather than one dismissal hiding it for everyone.
- **Dismissal is permanent** — dismissing calls the new `UiHintService.markDismissed`, which latches the hint off on the **first** dismiss (unlike the twice-shown POS banners). Stored locally in SharedPreferences, never synced — no new persistence mechanism.

## Acceptance criteria

- [x] Banner appears at the top of the Inventory Products list.
- [x] Shown only when the price-edit gate allows the long-press for this user, and not yet dismissed.
- [x] Dismissing hides it permanently for that user on that device.
- [x] Reuses the existing UI-hint service (no new persistence mechanism).

## Tests

- `test/shared/services/ui_hint_service_test.dart` — the #110 case now locks **permanent-on-first-dismissal** and independence from the POS banner keys; a second case covers `markDismissed` directly. `dart analyze` clean on all changed files; the full `ui_hint_service_test.dart` passes.
- No widget test for the banner itself: the per-user key composition is a private `State` getter that reads `ref` (not unit-pumpable without scope-expanding the large `InventoryScreen`), matching the calibrated test bar on this batch (analyzer + service-level unit tests + pattern parity with the shipped POS/receive banners). Final visual confirmation is on-emulator.

Closes #110


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an inline inventory tip explaining that product prices can be edited by pressing and holding a product.
  * The tip appears when applicable to staff with editing access and available products.
  * Tips are tailored per device user and can be permanently dismissed.

* **Bug Fixes**
  * Improved hint management so dismissing one tip does not affect other product-related tips.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->