### PR TITLE
feat(receipt): manual 58/80mm paper size (#116)

### DIFF
--- a/lib/features/customers/screens/customer_detail_screen.dart
+++ b/lib/features/customers/screens/customer_detail_screen.dart
@@ -1107,6 +1107,7 @@ class _CustomerDetailScreenState extends ConsumerState<CustomerDetailScreen> {
         return;
       }
 
+      final paperSize = await ref.read(printerServiceProvider).getPaperSize();
       final bytes = await ThermalReceiptService.buildReceipt(
         orderId: order.orderNumber,
         cart: items,
@@ -1124,6 +1125,7 @@ class _CustomerDetailScreenState extends ConsumerState<CustomerDetailScreen> {
         storeAddress: storeAddress,
         businessName: ref.read(currentBusinessNameProvider),
         manufacturerNames: manufacturerNames,
+        paperSize: paperSize,
       );
 
       if (!ctx.mounted) return;

--- a/lib/features/orders/screens/orders_screen.dart
+++ b/lib/features/orders/screens/orders_screen.dart
@@ -1172,6 +1172,7 @@ class _OrdersScreenState extends ConsumerState<OrdersScreen>
       final mfrList = await db.inventoryDao.watchAllManufacturers().first;
       final manufacturerNames = {for (final m in mfrList) m.id: m.name};
 
+      final paperSize = await printer.getPaperSize();
       final bytes = await ThermalReceiptService.buildReceipt(
         orderId: order.orderNumber,
         cart: receiptMapping,
@@ -1193,6 +1194,7 @@ class _OrdersScreenState extends ConsumerState<OrdersScreen>
         storeAddress: finalStoreAddress,
         businessName: ref.read(currentBusinessNameProvider),
         manufacturerNames: manufacturerNames,
+        paperSize: paperSize,
       );
 
       if (!context.mounted) return;

--- a/lib/features/pos/screens/checkout_page.dart
+++ b/lib/features/pos/screens/checkout_page.dart
@@ -1460,6 +1460,7 @@ class _CheckoutPageState extends ConsumerState<CheckoutPage> {
         return;
       }
 
+      final paperSize = await printer.getPaperSize();
       final List<int> receiptBytes = await ThermalReceiptService.buildReceipt(
         orderId: _currentOrderId,
         cart: widget.cart,
@@ -1479,6 +1480,7 @@ class _CheckoutPageState extends ConsumerState<CheckoutPage> {
         storeAddress: _storeAddress,
         businessName: ref.read(currentBusinessNameProvider),
         manufacturerNames: _manufacturerNames,
+        paperSize: paperSize,
       );
 
       if (!mounted) return;

--- a/lib/features/pos/services/receipt_builder.dart
+++ b/lib/features/pos/services/receipt_builder.dart
@@ -6,9 +6,11 @@ import 'package:image/image.dart' as img;
 import 'package:reebaplus_pos/core/utils/number_format.dart'; // assuming fmtNumber is exported here
 import 'package:reebaplus_pos/core/utils/product_name.dart';
 import 'package:reebaplus_pos/core/utils/stock_calculator.dart';
+import 'package:reebaplus_pos/features/pos/services/receipt_paper_size.dart';
 
 class ThermalReceiptService {
-  /// Builds a byte array of ESC/POS commands formatted for 58mm (32 chars/line)
+  /// Builds a byte array of ESC/POS commands for the given [paperSize].
+  /// Defaults to 58mm (32 chars/line) so existing callers are unchanged.
   static Future<List<int>> buildReceipt({
     required String orderId,
     required List<Map<String, dynamic>> cart,
@@ -35,10 +37,13 @@ class ThermalReceiptService {
     /// converted to a monochrome raster and emitted before the business name.
     /// Falls back to name-only when null or the file is missing.
     String? logoPath,
+    /// Physical paper width. Defaults to 58mm so existing callers and the
+    /// existing 58mm output are unchanged.
+    ReceiptPaperSize paperSize = ReceiptPaperSize.mm58,
   }) async {
-    // Generate profile for 58mm printer
     final profile = await CapabilityProfile.load();
-    final generator = Generator(PaperSize.mm58, profile);
+    final generator = Generator(paperSize.escPos, profile);
+    final int charsPerLine = paperSize.charsPerLine;
     List<int> bytes = [];
 
     // --- 0. REFUND STAMP ---
@@ -91,8 +96,8 @@ class ThermalReceiptService {
         final rawBytes = await logoFile.readAsBytes();
         final decoded = img.decodeImage(rawBytes);
         if (decoded != null) {
-          // Resize to 58mm print width (≈200px at 203 DPI), convert to mono.
-          final resized = img.copyResize(decoded, width: 200);
+          // Resize to the paper's print width in dots, convert to mono.
+          final resized = img.copyResize(decoded, width: paperSize.logoWidthPx);
           img.grayscale(resized);
           bytes += generator.image(resized, align: PosAlign.center);
         }
@@ -174,21 +179,13 @@ class ThermalReceiptService {
       final String qtyStr = '${qty.toStringAsFixed(1)}x ';
       final String priceStr = formatCurrency(lineTotal).replaceAll('₦', 'N');
 
-      // Calculate max length for product name to fit in 32 characters
-      int maxNameLen =
-          32 - qtyStr.length - priceStr.length - 1; // 1 space minimum
-      String nameStr = name;
-      if (nameStr.length > maxNameLen) {
-        nameStr = nameStr.substring(0, maxNameLen);
-      }
-
-      final String leftPart = '$qtyStr$nameStr';
-      int spaceCount = 32 - leftPart.length - priceStr.length;
-      if (spaceCount < 1) spaceCount = 1;
-
-      final String spacing = ' ' * spaceCount;
       bytes += generator.text(
-        '$leftPart$spacing$priceStr',
+        formatItemLine(
+          qtyLabel: qtyStr,
+          name: name,
+          priceLabel: priceStr,
+          charsPerLine: charsPerLine,
+        ),
         styles: const PosStyles(bold: false, fontType: PosFontType.fontA),
       );
     }
@@ -229,6 +226,7 @@ class ThermalReceiptService {
       generator,
       'Subtotal',
       formatCurrency(subtotal).replaceAll('₦', 'N'),
+      charsPerLine,
     );
 
     if (crateDeposit > 0) {
@@ -236,6 +234,7 @@ class ThermalReceiptService {
         generator,
         'Crate Deposit',
         formatCurrency(crateDeposit).replaceAll('₦', 'N'),
+        charsPerLine,
       );
     }
     bytes += generator.hr();
@@ -265,6 +264,7 @@ class ThermalReceiptService {
       generator,
       'Amount Paid:',
       formatCurrency(cashReceived ?? total).replaceAll('₦', 'N'),
+      charsPerLine,
     );
 
     // §15.1 — wallet info, only when ticked at checkout. Sign conveys credit
@@ -274,6 +274,7 @@ class ThermalReceiptService {
         generator,
         'Credits Balance:',
         formatCurrency(walletBalance).replaceAll('₦', 'N'),
+        charsPerLine,
       );
     }
 
@@ -304,15 +305,58 @@ class ThermalReceiptService {
     return bytes;
   }
 
-  /// Helper to create exactly 32-character lines for 58mm
+  /// Emits a label/value row padded to [charsPerLine] characters.
   static List<int> _buildTwoColumnRow(
     Generator generator,
     String label,
     String value,
+    int charsPerLine,
   ) {
-    int spaceCount = 32 - label.length - value.length;
+    return generator.text(
+      formatTwoColumnLine(
+        label: label,
+        value: value,
+        charsPerLine: charsPerLine,
+      ),
+    );
+  }
+
+  /// Formats one item line — `"[qty]x [name]      [price]"` — to fit exactly
+  /// [charsPerLine] characters: the name is truncated when too long, and the
+  /// gap between name and price is padded (at least one space). Pure so the
+  /// 32-char (58mm) / 48-char (80mm) contract is unit-testable directly.
+  static String formatItemLine({
+    required String qtyLabel,
+    required String name,
+    required String priceLabel,
+    required int charsPerLine,
+  }) {
+    // Leave room for the qty label, the price, and at least one space.
+    final int maxNameLen = charsPerLine - qtyLabel.length - priceLabel.length - 1;
+    String nameStr = name;
+    if (maxNameLen <= 0) {
+      // Qty + price already consume the whole line; drop the name.
+      nameStr = '';
+    } else if (nameStr.length > maxNameLen) {
+      nameStr = nameStr.substring(0, maxNameLen);
+    }
+
+    final String leftPart = '$qtyLabel$nameStr';
+    int spaceCount = charsPerLine - leftPart.length - priceLabel.length;
     if (spaceCount < 1) spaceCount = 1;
-    final spacing = ' ' * spaceCount;
-    return generator.text('$label$spacing$value');
+    return '$leftPart${' ' * spaceCount}$priceLabel';
+  }
+
+  /// Formats a `"label        value"` row padded to [charsPerLine] characters
+  /// (at least one space between the two). Pure; shared by the totals and
+  /// payment rows via [_buildTwoColumnRow].
+  static String formatTwoColumnLine({
+    required String label,
+    required String value,
+    required int charsPerLine,
+  }) {
+    int spaceCount = charsPerLine - label.length - value.length;
+    if (spaceCount < 1) spaceCount = 1;
+    return '$label${' ' * spaceCount}$value';
   }
 }

--- a/lib/features/pos/services/receipt_paper_size.dart
+++ b/lib/features/pos/services/receipt_paper_size.dart
@@ -1,0 +1,41 @@
+import 'package:esc_pos_utils_plus/esc_pos_utils_plus.dart';
+
+/// Physical width of the thermal receipt paper, chosen once per device near the
+/// printer picker (#116). This is the app's own source of truth — deliberately
+/// decoupled from the print library's [PaperSize] enum and from the persisted
+/// string so a library change or a stray stored value can't reshape a receipt.
+///
+/// 58mm is the default and MUST stay byte-identical to the pre-#116 output:
+/// 32 chars/line, [PaperSize.mm58], a 200px logo raster.
+enum ReceiptPaperSize {
+  mm58,
+  mm80;
+
+  /// Monospace characters that fit on one Font-A line at this width
+  /// (≈203 DPI thermal head): 58mm ≈ 32, 80mm ≈ 48.
+  int get charsPerLine => switch (this) {
+        ReceiptPaperSize.mm58 => 32,
+        ReceiptPaperSize.mm80 => 48,
+      };
+
+  /// The print-library paper size this maps to.
+  PaperSize get escPos => switch (this) {
+        ReceiptPaperSize.mm58 => PaperSize.mm58,
+        ReceiptPaperSize.mm80 => PaperSize.mm80,
+      };
+
+  /// Logo raster width in printer dots. The 58mm print area is ≈384 dots (keep
+  /// the pre-#116 200px); the 80mm area is ≈576 dots, so 384px fills it with a
+  /// small margin. A judgment call within the sensible ~380–512 range.
+  int get logoWidthPx => switch (this) {
+        ReceiptPaperSize.mm58 => 200,
+        ReceiptPaperSize.mm80 => 384,
+      };
+
+  /// Rebuilds a value from the string persisted by `PrinterService`. Any
+  /// unknown or absent value falls back to the 58mm default.
+  static ReceiptPaperSize fromStorage(String? value) => switch (value) {
+        'mm80' => ReceiptPaperSize.mm80,
+        _ => ReceiptPaperSize.mm58,
+      };
+}

--- a/lib/shared/services/printer_service.dart
+++ b/lib/shared/services/printer_service.dart
@@ -3,9 +3,11 @@ import 'package:permission_handler/permission_handler.dart';
 import 'package:print_bluetooth_thermal/print_bluetooth_thermal.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:reebaplus_pos/core/utils/logger.dart';
+import 'package:reebaplus_pos/features/pos/services/receipt_paper_size.dart';
 
 class PrinterService {
   static const _lastMacKey = 'last_printer_mac';
+  static const _paperSizeKey = 'printer_paper_size';
 
   PrinterService();
 
@@ -107,6 +109,19 @@ class PrinterService {
   Future<void> saveLastConnectedMac(String mac) async {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setString(_lastMacKey, mac);
+  }
+
+  /// Persists the receipt paper width chosen near [PrinterPicker] (#116).
+  /// Device-local, never synced — a hardware setting per till.
+  Future<void> savePaperSize(ReceiptPaperSize size) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_paperSizeKey, size.name);
+  }
+
+  /// Reads the saved receipt paper width, defaulting to 58mm when unset.
+  Future<ReceiptPaperSize> getPaperSize() async {
+    final prefs = await SharedPreferences.getInstance();
+    return ReceiptPaperSize.fromStorage(prefs.getString(_paperSizeKey));
   }
 
   Future<bool> autoConnect() async {

--- a/lib/shared/widgets/printer_picker.dart
+++ b/lib/shared/widgets/printer_picker.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:print_bluetooth_thermal/print_bluetooth_thermal.dart';
 import 'package:reebaplus_pos/core/providers/app_providers.dart';
 import 'package:reebaplus_pos/core/utils/responsive.dart';
+import 'package:reebaplus_pos/features/pos/services/receipt_paper_size.dart';
 
 class PrinterPicker extends ConsumerStatefulWidget {
   final Function(BluetoothInfo) onSelected;
@@ -18,11 +19,24 @@ class PrinterPicker extends ConsumerStatefulWidget {
 class _PrinterPickerState extends ConsumerState<PrinterPicker> {
   bool _isLoading = true;
   List<BluetoothInfo> _devices = [];
+  ReceiptPaperSize _paperSize = ReceiptPaperSize.mm58;
 
   @override
   void initState() {
     super.initState();
+    _loadPaperSize();
     _loadDevices();
+  }
+
+  Future<void> _loadPaperSize() async {
+    final size = await ref.read(printerServiceProvider).getPaperSize();
+    if (mounted) setState(() => _paperSize = size);
+  }
+
+  void _onPaperSizeChanged(ReceiptPaperSize size) {
+    setState(() => _paperSize = size);
+    // Device-local, set-once hardware setting — applies to the next receipt.
+    ref.read(printerServiceProvider).savePaperSize(size);
   }
 
   Future<void> _loadDevices() async {
@@ -74,6 +88,47 @@ class _PrinterPickerState extends ConsumerState<PrinterPicker> {
                 IconButton(
                   icon: Icon(Icons.refresh, size: context.getRSize(20)),
                   onPressed: _loadDevices,
+                ),
+              ],
+            ),
+          ),
+          Divider(height: 1, color: border),
+          Padding(
+            padding: EdgeInsets.symmetric(
+              horizontal: context.getRSize(16),
+              vertical: context.getRSize(12),
+            ),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Text(
+                  'Paper size',
+                  style: TextStyle(
+                    color: text,
+                    fontSize: context.getRFontSize(14),
+                  ),
+                ),
+                SegmentedButton<ReceiptPaperSize>(
+                  showSelectedIcon: false,
+                  segments: [
+                    ButtonSegment(
+                      value: ReceiptPaperSize.mm58,
+                      label: Text(
+                        '58mm',
+                        style: TextStyle(fontSize: context.getRFontSize(13)),
+                      ),
+                    ),
+                    ButtonSegment(
+                      value: ReceiptPaperSize.mm80,
+                      label: Text(
+                        '80mm',
+                        style: TextStyle(fontSize: context.getRFontSize(13)),
+                      ),
+                    ),
+                  ],
+                  selected: {_paperSize},
+                  onSelectionChanged: (selection) =>
+                      _onPaperSizeChanged(selection.first),
                 ),
               ],
             ),

--- a/test/receipt_builder_test.dart
+++ b/test/receipt_builder_test.dart
@@ -1,0 +1,132 @@
+// receipt_builder_test.dart
+//
+// Covers #116 — manual 58/80mm receipt paper size. buildReceipt emits raw
+// ESC/POS bytes, so the width contract is exercised through the two pure line
+// formatters it delegates to (formatItemLine / formatTwoColumnLine) plus the
+// ReceiptPaperSize enum that is their single source of truth.
+
+import 'package:esc_pos_utils_plus/esc_pos_utils_plus.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reebaplus_pos/features/pos/services/receipt_builder.dart';
+import 'package:reebaplus_pos/features/pos/services/receipt_paper_size.dart';
+
+void main() {
+  const mm58 = ReceiptPaperSize.mm58;
+  const mm80 = ReceiptPaperSize.mm80;
+
+  group('ReceiptPaperSize', () {
+    test('58mm keeps the pre-#116 defaults (unchanged output)', () {
+      expect(mm58.charsPerLine, 32);
+      expect(mm58.escPos, PaperSize.mm58);
+      expect(mm58.logoWidthPx, 200);
+    });
+
+    test('80mm widens chars, paper size and logo', () {
+      expect(mm80.charsPerLine, 48);
+      expect(mm80.escPos, PaperSize.mm80);
+      expect(mm80.logoWidthPx, greaterThan(mm58.logoWidthPx));
+    });
+
+    test('fromStorage defaults unknown/absent values to 58mm', () {
+      expect(ReceiptPaperSize.fromStorage(null), mm58);
+      expect(ReceiptPaperSize.fromStorage(''), mm58);
+      expect(ReceiptPaperSize.fromStorage('garbage'), mm58);
+      expect(ReceiptPaperSize.fromStorage('mm58'), mm58);
+      expect(ReceiptPaperSize.fromStorage('mm80'), mm80);
+    });
+
+    test('round-trips through the persisted string (enum name)', () {
+      expect(ReceiptPaperSize.fromStorage(mm58.name), mm58);
+      expect(ReceiptPaperSize.fromStorage(mm80.name), mm80);
+    });
+  });
+
+  group('formatItemLine — AC #4: exactly N chars from the same input', () {
+    String itemLine(ReceiptPaperSize size) => ThermalReceiptService.formatItemLine(
+          qtyLabel: '2.0x ',
+          name: 'Star Lager',
+          priceLabel: 'N2,000',
+          charsPerLine: size.charsPerLine,
+        );
+
+    test('58mm renders a 32-char line', () {
+      final line = itemLine(mm58);
+      expect(line.length, 32);
+      expect(line.startsWith('2.0x Star Lager'), isTrue);
+      expect(line.endsWith('N2,000'), isTrue);
+    });
+
+    test('80mm renders a 48-char line from the identical input', () {
+      final line = itemLine(mm80);
+      expect(line.length, 48);
+      expect(line.startsWith('2.0x Star Lager'), isTrue);
+      expect(line.endsWith('N2,000'), isTrue);
+    });
+  });
+
+  group('formatItemLine — truncation & padding edges', () {
+    test('over-long name is truncated so the line still fits the width', () {
+      const longName =
+          'A Very Long Product Name That Overflows Any Receipt Line';
+      for (final size in [mm58, mm80]) {
+        final line = ThermalReceiptService.formatItemLine(
+          qtyLabel: '1.0x ',
+          name: longName,
+          priceLabel: 'N10,000',
+          charsPerLine: size.charsPerLine,
+        );
+        expect(line.length, size.charsPerLine,
+            reason: 'truncated line must be exactly ${size.charsPerLine}');
+        expect(line.startsWith('1.0x '), isTrue);
+        expect(line.endsWith('N10,000'), isTrue);
+        // A single space between the (truncated) name and the price.
+        expect(line.contains('  '), isFalse);
+      }
+    });
+
+    test('short name is padded out to the full width', () {
+      for (final size in [mm58, mm80]) {
+        final line = ThermalReceiptService.formatItemLine(
+          qtyLabel: '2.0x ',
+          name: 'Coke',
+          priceLabel: 'N500',
+          charsPerLine: size.charsPerLine,
+        );
+        expect(line.length, size.charsPerLine);
+        expect(line.startsWith('2.0x Coke'), isTrue);
+        expect(line.endsWith('N500'), isTrue);
+      }
+    });
+  });
+
+  group('formatTwoColumnLine — AC #4 for totals/payment rows', () {
+    test('pads a label/value row to exactly the width', () {
+      expect(
+        ThermalReceiptService.formatTwoColumnLine(
+          label: 'Subtotal',
+          value: 'N2,000',
+          charsPerLine: mm58.charsPerLine,
+        ).length,
+        32,
+      );
+      expect(
+        ThermalReceiptService.formatTwoColumnLine(
+          label: 'Subtotal',
+          value: 'N2,000',
+          charsPerLine: mm80.charsPerLine,
+        ).length,
+        48,
+      );
+    });
+
+    test('keeps at least one space when label + value fill the line', () {
+      final line = ThermalReceiptService.formatTwoColumnLine(
+        label: 'A' * 20,
+        value: 'B' * 20,
+        charsPerLine: mm58.charsPerLine,
+      );
+      // Overflow can't be padded down; a single separating space is kept.
+      expect(line, '${'A' * 20} ${'B' * 20}');
+    });
+  });
+}


### PR DESCRIPTION
Closes #116.

## What
Adds a device-local **receipt paper-size setting (58mm default, 80mm option)**, chosen right next to the printer picker, and parameterizes the thermal receipt builder so **58mm renders 32-char lines and 80mm renders 48-char lines** (logo raster included). Existing 58mm output is unchanged by default.

## How
- **`ReceiptPaperSize` enum** (new, beside the builder) — the app's single source of truth: `charsPerLine` 32/48, `escPos` → `PaperSize.mm58`/`.mm80`, `logoWidthPx` 200/384. Deliberately decoupled from the print library's `PaperSize` enum and from the persisted string, with a `fromStorage` that defaults any unknown/absent value back to 58mm.
- **`ThermalReceiptService.buildReceipt`** takes a new `ReceiptPaperSize paperSize = ReceiptPaperSize.mm58` param. The four hardcoded-58mm spots (generator width, logo px, item-line math, two-column-row math) now flow from the paper size. The item-line and two-column formatters were extracted into **pure, width-parameterized static helpers** (`formatItemLine` / `formatTwoColumnLine`) so the char-width contract is unit-testable.
- **`PrinterService`** gains `savePaperSize` / `getPaperSize` (SharedPreferences, key `printer_paper_size`), mirroring the existing last-printer-MAC pattern. **Device-local, not synced** — it's a per-till hardware setting.
- **`PrinterPicker`** shows a 58/80mm `SegmentedButton` under its header; loads the current value in `initState`, writes on change.
- All **three print sites** (checkout, customer detail, orders) read the saved size and pass it into `buildReceipt`.

## Design notes / decisions
1. **58mm unchanged is a hard AC.** The enum, the `buildReceipt` param, and `getPaperSize()` all default to `mm58`; the 58mm branch stays byte-identical (width 32, `PaperSize.mm58`, 200px logo). The only new code path in the item-line formatter is a guard that turns a previously-crashing degenerate case (qty+price alone overflow the line) into a graceful one — it does not change any output that rendered before.
2. **80mm logo px is a judgment call** — picked **384px** (≈576-dot 80mm print area with a small margin), within the sensible ~380–512 range. 58mm stays at 200px.
3. **Timing:** receipt bytes are built *before* the picker opens, so a size change made in the picker applies to the **next** receipt, not the one in hand. That's the right behavior for a set-once hardware setting — no rebuild-on-change path was added.
4. **Scope:** this targets the *thermal* builder (`receipt_builder.dart`). The on-screen `ReceiptWidget` preview is a Flutter widget, not monospace-width-bound, and is intentionally left alone.

## Tests
New `test/receipt_builder_test.dart` — same input yields lines of length **exactly 32 at 58mm and 48 at 80mm**, plus truncation/padding edge cases and enum/storage round-trips. Existing `test/receipt_widget_test.dart` stays green.

- `dart analyze` on all changed files: clean.
- `flutter test` receipt + touched-area suites (pos, orders, customers, shared, checkout): all green.