### PR TITLE
feat(inventory): category rename & soft-delete + Uncategorized (#109)

### DIFF
--- a/lib/core/constants/category_filter.dart
+++ b/lib/core/constants/category_filter.dart
@@ -1,0 +1,8 @@
+/// Sentinel category-filter id for the **Uncategorized** bucket — the products
+/// whose `categoryId` is `null` (e.g. after their category was deleted, #109).
+///
+/// A distinct sentinel rather than `null` because `null` already means "All" in
+/// both the POS and Inventory category filters. This value is a UI-filter
+/// concept only: it is never written to a product row, never enqueued, and
+/// never reaches the cloud — a real `categoryId` is always a UUIDv7.
+const String kUncategorizedCategoryId = '__uncategorized__';

--- a/lib/core/database/daos_catalog.dart
+++ b/lib/core/database/daos_catalog.dart
@@ -294,6 +294,107 @@ class CatalogDao extends DatabaseAccessor<AppDatabase>
     return id;
   }
 
+  /// True if a **non-deleted** category in this business already uses [name]
+  /// (case-insensitive, trimmed), excluding [excludeId] (the category being
+  /// renamed). Backs the rename collision guard (#109 AC #1). Compared in Dart
+  /// — Drift has no `equalsInsensitive`, a business's category list is small,
+  /// and this mirrors the `_getOrCreateCategory` lower-case match already in
+  /// add_product_screen.dart.
+  Future<bool> categoryNameExists(String name, {String? excludeId}) async {
+    final target = name.trim().toLowerCase();
+    final rows = await (select(categories)
+          ..where((t) => whereBusiness(t) & t.isDeleted.not()))
+        .get();
+    return rows.any(
+      (c) => c.id != excludeId && c.name.trim().toLowerCase() == target,
+    );
+  }
+
+  /// Rename category [id] to [name] (#109 AC #1). Writes the new name, then
+  /// full-row enqueues: a partial `categories` upsert would omit the NOT NULL
+  /// name/business_id (Postgres 23502), exactly as [updateSupplier] documents.
+  /// The full re-read preserves the untouched `description`. The caller guards
+  /// against a collision via [categoryNameExists] first.
+  Future<void> renameCategory(String id, {required String name}) async {
+    await (update(categories)..where((t) => t.id.equals(id) & whereBusiness(t)))
+        .write(
+      CategoriesCompanion(
+        name: Value(name),
+        lastUpdatedAt: Value(DateTime.now()),
+      ),
+    );
+    final row = await (select(
+      categories,
+    )..where((t) => t.id.equals(id) & whereBusiness(t))).getSingleOrNull();
+    if (row != null) {
+      await db.syncDao.enqueueUpsert('categories', row.toCompanion(true));
+    }
+  }
+
+  /// How many live products sit in category [id] (this business). Drives the
+  /// delete confirmation's "N products will move to Uncategorized" (#109 AC #2).
+  Future<int> countProductsInCategory(String id) async {
+    final countCol = products.id.count();
+    final row =
+        await (selectOnly(products)
+              ..addColumns([countCol])
+              ..where(
+                products.categoryId.equals(id) &
+                    whereBusiness(products) &
+                    products.isDeleted.not(),
+              ))
+            .getSingle();
+    return row.read(countCol) ?? 0;
+  }
+
+  /// Soft-delete category [id] and move its products to Uncategorized (#109 AC
+  /// #2/#3), atomically. Never a hard delete — the tombstone (`is_deleted`)
+  /// syncs via `enqueueUpsert`, exactly like [softDeleteSupplier]. Each
+  /// reassigned product is enqueued individually (sync is per-row) with an
+  /// **explicit** `category_id: null`: a plain `toCompanion(true)` turns the
+  /// now-null FK into `Value.absent()` (dropped from the push) and the cloud
+  /// would keep the stale category, so the null is re-forced via `copyWith`.
+  /// Returns the number of products moved.
+  Future<int> softDeleteCategoryAndReassign(String id) async {
+    final now = DateTime.now();
+    return transaction(() async {
+      final affected = await (select(products)
+            ..where(
+              (t) =>
+                  t.categoryId.equals(id) &
+                  whereBusiness(t) &
+                  t.isDeleted.not(),
+            ))
+          .get();
+      for (final p in affected) {
+        final comp = p.toCompanion(true).copyWith(
+          categoryId: const Value(null),
+          lastUpdatedAt: Value(now),
+        );
+        await (update(
+          products,
+        )..where((t) => t.id.equals(p.id) & whereBusiness(t))).write(comp);
+        await db.syncDao.enqueueUpsert('products', comp);
+      }
+
+      await (update(categories)
+            ..where((t) => t.id.equals(id) & whereBusiness(t)))
+          .write(
+        CategoriesCompanion(
+          isDeleted: const Value(true),
+          lastUpdatedAt: Value(now),
+        ),
+      );
+      final catRow = await (select(
+        categories,
+      )..where((t) => t.id.equals(id) & whereBusiness(t))).getSingleOrNull();
+      if (catRow != null) {
+        await db.syncDao.enqueueUpsert('categories', catRow.toCompanion(true));
+      }
+      return affected.length;
+    });
+  }
+
   Future<List<ManufacturerData>> getAllManufacturers() {
     return (select(manufacturers)
           ..where((t) => whereBusiness(t) & t.isDeleted.not())

--- a/lib/features/inventory/screens/inventory_screen.dart
+++ b/lib/features/inventory/screens/inventory_screen.dart
@@ -31,6 +31,8 @@ import 'package:reebaplus_pos/core/theme/design_tokens.dart';
 import 'package:reebaplus_pos/core/database/app_database.dart';
 import 'package:reebaplus_pos/features/inventory/widgets/inventory_history_tab.dart';
 import 'package:reebaplus_pos/features/inventory/widgets/update_product_sheet.dart';
+import 'package:reebaplus_pos/features/inventory/widgets/manage_categories_sheet.dart';
+import 'package:reebaplus_pos/core/constants/category_filter.dart';
 import 'package:reebaplus_pos/core/utils/product_name.dart';
 import 'package:reebaplus_pos/core/utils/currency_input_formatter.dart';
 import 'package:reebaplus_pos/shared/widgets/app_refresh_wrapper.dart';
@@ -240,7 +242,20 @@ class _InventoryScreenState extends ConsumerState<InventoryScreen>
       }, onError: (e) => debugPrint('Error watching manufacturers: $e'));
 
       _categoriesSub = db.inventoryDao.watchAllCategories().listen((data) {
-        if (mounted) setState(() => _dbCategories = data);
+        if (!mounted) return;
+        setState(() {
+          _dbCategories = data;
+          // #109: a category the user had filtered on can vanish (deleted via
+          // Manage categories here, or on another device). Drop the dangling
+          // selection back to "All" so the filter doesn't strand the list on a
+          // category that no longer exists. The Uncategorized sentinel is not a
+          // real category id, so it's preserved.
+          if (_selectedCategoryId != null &&
+              _selectedCategoryId != kUncategorizedCategoryId &&
+              !data.any((c) => c.id == _selectedCategoryId)) {
+            _selectedCategoryId = null;
+          }
+        });
       }, onError: (e) => debugPrint('Error watching categories: $e'));
 
       // Per-manufacturer full/empty crate figures are read reactively in the
@@ -713,7 +728,11 @@ class _InventoryScreenState extends ConsumerState<InventoryScreen>
           .firstOrNull;
       list = list.where((p) => p.product.manufacturerId == mfrId).toList();
     }
-    if (_selectedCategoryId != null) {
+    if (_selectedCategoryId == kUncategorizedCategoryId) {
+      // The Uncategorized bucket (#109): products with no category — e.g. those
+      // orphaned when their category was deleted.
+      list = list.where((p) => p.product.categoryId == null).toList();
+    } else if (_selectedCategoryId != null) {
       list = list
           .where((p) => p.product.categoryId == _selectedCategoryId)
           .toList();
@@ -981,6 +1000,7 @@ class _InventoryScreenState extends ConsumerState<InventoryScreen>
       ),
       color: _surface,
       child: Row(
+        crossAxisAlignment: CrossAxisAlignment.end,
         children: [
           // Category dropdown (§16.4, amended): replaces the old chip row,
           // drives `_selectedCategoryId`. The store is now picked in the nav bar.
@@ -1003,6 +1023,15 @@ class _InventoryScreenState extends ConsumerState<InventoryScreen>
                             overflow: TextOverflow.ellipsis,
                             style: TextStyle(color: _text),
                           ),
+                        ),
+                      ),
+                      // #109: filter to products with no category.
+                      DropdownMenuItem(
+                        value: kUncategorizedCategoryId,
+                        child: Text(
+                          'Uncategorized',
+                          overflow: TextOverflow.ellipsis,
+                          style: TextStyle(color: _text),
                         ),
                       ),
                     ],
@@ -1036,7 +1065,36 @@ class _InventoryScreenState extends ConsumerState<InventoryScreen>
                         setState(() => _selectedManufacturer = val ?? 'all'),
                   ),
           ),
+          // #109: Manage categories (rename / delete → Uncategorized). Gated on
+          // the same permission as adding a product — product-catalogue
+          // management. Bottom-aligned with the dropdown fields.
+          if (Gates.addProduct.allows(ref)) ...[
+            SizedBox(width: context.getRSize(8)),
+            _buildManageCategoriesButton(context),
+          ],
         ],
+      ),
+    );
+  }
+
+  Widget _buildManageCategoriesButton(BuildContext context) {
+    final primary = Theme.of(context).colorScheme.primary;
+    return InkWell(
+      onTap: () => showManageCategoriesSheet(context),
+      borderRadius: BorderRadius.circular(14),
+      child: Container(
+        height: context.getRSize(52),
+        width: context.getRSize(52),
+        decoration: BoxDecoration(
+          color: primary.withValues(alpha: 0.08),
+          borderRadius: BorderRadius.circular(14),
+          border: Border.all(color: primary.withValues(alpha: 0.25)),
+        ),
+        child: Icon(
+          FontAwesomeIcons.tag.data,
+          size: context.getRSize(16),
+          color: primary,
+        ),
       ),
     );
   }

--- a/lib/features/inventory/widgets/manage_categories_sheet.dart
+++ b/lib/features/inventory/widgets/manage_categories_sheet.dart
@@ -1,0 +1,372 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+
+import 'package:reebaplus_pos/core/database/app_database.dart';
+import 'package:reebaplus_pos/core/permissions/permissions.dart';
+import 'package:reebaplus_pos/core/providers/app_providers.dart';
+import 'package:reebaplus_pos/core/providers/stream_providers.dart';
+import 'package:reebaplus_pos/core/utils/notifications.dart';
+import 'package:reebaplus_pos/core/utils/responsive.dart';
+import 'package:reebaplus_pos/shared/widgets/app_button.dart';
+import 'package:reebaplus_pos/shared/widgets/app_input.dart';
+
+/// Opens the "Manage categories" bottom sheet (#109). Gate the call site with
+/// [Gates.addProduct]; the rename/delete actions inside re-check it at their
+/// write boundary, so a session that lost the grant mid-flow can't mutate.
+Future<void> showManageCategoriesSheet(BuildContext context) {
+  return showModalBottomSheet<void>(
+    context: context,
+    isScrollControlled: true,
+    backgroundColor: Colors.transparent,
+    builder: (_) => const ManageCategoriesSheet(),
+  );
+}
+
+/// Lists the business's non-deleted categories, each with a rename (inline
+/// collision guard) and a delete (soft-delete → its products move to
+/// Uncategorized after a confirmation showing how many are affected). The list
+/// is reactive: a rename/delete updates `watchAllCategories`, so a deleted
+/// category drops out and a rename re-renders in place without a manual refresh.
+class ManageCategoriesSheet extends ConsumerWidget {
+  const ManageCategoriesSheet({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final theme = Theme.of(context);
+    final categories =
+        ref.watch(allCategoriesProvider).valueOrNull ?? const <CategoryData>[];
+
+    return Container(
+      decoration: BoxDecoration(
+        color: theme.colorScheme.surface,
+        borderRadius: const BorderRadius.vertical(top: Radius.circular(28)),
+      ),
+      padding: EdgeInsets.fromLTRB(
+        context.getRSize(20),
+        context.getRSize(12),
+        context.getRSize(20),
+        context.getRSize(20) + context.deviceBottomPadding,
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Center(
+            child: Container(
+              width: context.getRSize(40),
+              height: context.getRSize(4),
+              decoration: BoxDecoration(
+                color: theme.dividerColor,
+                borderRadius: BorderRadius.circular(2),
+              ),
+            ),
+          ),
+          SizedBox(height: context.getRSize(16)),
+          Text('Manage categories', style: theme.textTheme.titleLarge),
+          SizedBox(height: context.getRSize(4)),
+          Text(
+            'Rename a category, or delete it to move its products to '
+            'Uncategorized.',
+            style: theme.textTheme.bodySmall,
+          ),
+          SizedBox(height: context.getRSize(16)),
+          if (categories.isEmpty)
+            Padding(
+              padding: EdgeInsets.symmetric(vertical: context.getRSize(28)),
+              child: Center(
+                child: Text(
+                  'No categories yet. Add one while creating a product.',
+                  textAlign: TextAlign.center,
+                  style: theme.textTheme.bodyMedium?.copyWith(
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
+                ),
+              ),
+            )
+          else
+            Flexible(
+              child: ConstrainedBox(
+                constraints: BoxConstraints(
+                  maxHeight: MediaQuery.of(context).size.height * 0.5,
+                ),
+                child: ListView.separated(
+                  shrinkWrap: true,
+                  padding: EdgeInsets.zero,
+                  itemCount: categories.length,
+                  separatorBuilder: (_, __) => Divider(
+                    height: context.getRSize(1),
+                    color: theme.dividerColor,
+                  ),
+                  itemBuilder: (_, i) =>
+                      _CategoryRow(category: categories[i]),
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+/// One category row: name + rename + delete. A [ConsumerWidget] so each action
+/// can re-check [Gates.addProduct] at its write boundary and reach the DAO.
+class _CategoryRow extends ConsumerWidget {
+  const _CategoryRow({required this.category});
+
+  final CategoryData category;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final theme = Theme.of(context);
+    return Padding(
+      padding: EdgeInsets.symmetric(vertical: context.getRSize(6)),
+      child: Row(
+        children: [
+          Expanded(
+            child: Text(
+              category.name,
+              overflow: TextOverflow.ellipsis,
+              style: theme.textTheme.titleMedium,
+            ),
+          ),
+          _RowAction(
+            icon: FontAwesomeIcons.penToSquare.data,
+            tooltip: 'Rename',
+            color: theme.colorScheme.primary,
+            onTap: () => _rename(context, ref, category),
+          ),
+          SizedBox(width: context.getRSize(4)),
+          _RowAction(
+            icon: FontAwesomeIcons.trashCan.data,
+            tooltip: 'Delete',
+            color: theme.colorScheme.error,
+            onTap: () => _confirmDelete(context, ref, category),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _RowAction extends StatelessWidget {
+  const _RowAction({
+    required this.icon,
+    required this.tooltip,
+    required this.color,
+    required this.onTap,
+  });
+
+  final IconData icon;
+  final String tooltip;
+  final Color color;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return IconButton(
+      tooltip: tooltip,
+      onPressed: onTap,
+      icon: Icon(icon, size: context.getRSize(16), color: color),
+      splashRadius: context.getRSize(20),
+      constraints: BoxConstraints(
+        minWidth: context.getRSize(40),
+        minHeight: context.getRSize(40),
+      ),
+    );
+  }
+}
+
+/// Rename dialog with an inline collision guard (#109 AC #1). A case-only edit
+/// of the category's own name is allowed (it excludes itself); any other name
+/// already used by a live category is rejected in place.
+Future<void> _rename(
+  BuildContext context,
+  WidgetRef ref,
+  CategoryData category,
+) async {
+  final controller = TextEditingController(text: category.name);
+  String? errorText;
+
+  await showDialog<void>(
+    context: context,
+    builder: (ctx) => StatefulBuilder(
+      builder: (ctx, setLocal) => AlertDialog(
+        backgroundColor: Theme.of(ctx).colorScheme.surface,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(20),
+        ),
+        title: Text(
+          'Rename category',
+          style: Theme.of(ctx).textTheme.titleLarge,
+        ),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            AppInput(
+              controller: controller,
+              labelText: 'Category name',
+              autofocus: true,
+              onChanged: (_) {
+                if (errorText != null) setLocal(() => errorText = null);
+              },
+            ),
+            if (errorText != null) ...[
+              SizedBox(height: ctx.getRSize(8)),
+              Text(
+                errorText!,
+                style: Theme.of(ctx).textTheme.bodySmall?.copyWith(
+                  color: Theme.of(ctx).colorScheme.error,
+                ),
+              ),
+            ],
+          ],
+        ),
+        actions: [
+          AppButton(
+            text: 'Cancel',
+            variant: AppButtonVariant.ghost,
+            size: AppButtonSize.small,
+            onPressed: () => Navigator.pop(ctx),
+          ),
+          AppButton(
+            text: 'Save',
+            variant: AppButtonVariant.primary,
+            size: AppButtonSize.small,
+            onPressed: () async {
+              final name = controller.text.trim();
+              if (name.isEmpty) {
+                setLocal(() => errorText = 'Enter a name.');
+                return;
+              }
+              if (name == category.name) {
+                Navigator.pop(ctx); // no-op
+                return;
+              }
+              // Write boundary: re-check the grant before mutating.
+              if (!Gates.addProduct.allowsNow(ref)) {
+                Navigator.pop(ctx);
+                return;
+              }
+              final db = ref.read(databaseProvider);
+              final collides = await db.catalogDao.categoryNameExists(
+                name,
+                excludeId: category.id,
+              );
+              if (collides) {
+                setLocal(
+                  () => errorText = 'A category named "$name" already exists.',
+                );
+                return;
+              }
+              try {
+                await db.catalogDao.renameCategory(category.id, name: name);
+                if (ctx.mounted) Navigator.pop(ctx);
+              } catch (_) {
+                if (ctx.mounted) {
+                  AppNotification.showError(
+                    ctx,
+                    'Could not rename the category. Please try again.',
+                  );
+                }
+              }
+            },
+          ),
+        ],
+      ),
+    ),
+  );
+}
+
+/// Delete confirmation (#109 AC #2/#3): shows how many products will move to
+/// Uncategorized, then soft-deletes the category and reassigns them on confirm.
+Future<void> _confirmDelete(
+  BuildContext context,
+  WidgetRef ref,
+  CategoryData category,
+) async {
+  final db = ref.read(databaseProvider);
+  final count = await db.catalogDao.countProductsInCategory(category.id);
+  if (!context.mounted) return;
+
+  await showDialog<void>(
+    context: context,
+    builder: (ctx) {
+      final theme = Theme.of(ctx);
+      return AlertDialog(
+        backgroundColor: theme.colorScheme.surface,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(20),
+        ),
+        title: Text('Delete category', style: theme.textTheme.titleLarge),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Delete "${category.name}"?',
+              style: theme.textTheme.bodyMedium,
+            ),
+            SizedBox(height: ctx.getRSize(12)),
+            Container(
+              padding: EdgeInsets.symmetric(
+                horizontal: ctx.getRSize(12),
+                vertical: ctx.getRSize(10),
+              ),
+              decoration: BoxDecoration(
+                color: theme.colorScheme.primary.withValues(alpha: 0.08),
+                borderRadius: BorderRadius.circular(10),
+                border: Border.all(
+                  color: theme.colorScheme.primary.withValues(alpha: 0.25),
+                ),
+              ),
+              child: Text(
+                count == 0
+                    ? 'No products are in this category.'
+                    : 'This will move $count '
+                          '${count == 1 ? 'product' : 'products'} to '
+                          'Uncategorized. Nothing is deleted from your catalogue.',
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.primary,
+                ),
+              ),
+            ),
+          ],
+        ),
+        actions: [
+          AppButton(
+            text: 'Cancel',
+            variant: AppButtonVariant.ghost,
+            size: AppButtonSize.small,
+            onPressed: () => Navigator.pop(ctx),
+          ),
+          AppButton(
+            text: 'Delete',
+            variant: AppButtonVariant.danger,
+            size: AppButtonSize.small,
+            onPressed: () async {
+              Navigator.pop(ctx);
+              // Write boundary: re-check the grant before mutating.
+              if (!Gates.addProduct.allowsNow(ref)) return;
+              // Success feedback is the row vanishing from the reactive list;
+              // the confirmation above already stated the "move to Uncategorized"
+              // consequence, so no redundant toast (and the row's context is
+              // unmounted by the delete, which would silently no-op one anyway).
+              try {
+                await db.catalogDao.softDeleteCategoryAndReassign(category.id);
+              } catch (_) {
+                if (context.mounted) {
+                  AppNotification.showError(
+                    context,
+                    'Could not delete the category. Please try again.',
+                  );
+                }
+              }
+            },
+          ),
+        ],
+      );
+    },
+  );
+}

--- a/lib/features/pos/controllers/pos_controller.dart
+++ b/lib/features/pos/controllers/pos_controller.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:reebaplus_pos/core/constants/category_filter.dart';
 import 'package:reebaplus_pos/core/database/app_database.dart';
 import 'package:reebaplus_pos/shared/services/cart_service.dart';
 import 'package:reebaplus_pos/shared/services/navigation_service.dart';
@@ -73,6 +74,7 @@ class PosController extends ChangeNotifier {
       // down). Drop the now-dangling selection back to "All" so the chip-row
       // lookup in pos_home_screen can't `firstWhere` on a missing id and crash.
       if (selectedCategoryId != null &&
+          selectedCategoryId != kUncategorizedCategoryId &&
           !list.any((c) => c.id == selectedCategoryId)) {
         selectedCategoryId = null;
       }
@@ -122,7 +124,13 @@ class PosController extends ChangeNotifier {
     } else {
       currentStoreName = null;
       _productsSub = _database.inventoryDao
-          .watchProductsByCategory(selectedCategoryId)
+          .watchProductsByCategory(
+            // The Uncategorized sentinel is not a real category id — fetch all
+            // and let `filteredProducts` narrow to null-category products.
+            selectedCategoryId == kUncategorizedCategoryId
+                ? null
+                : selectedCategoryId,
+          )
           .listen((data) {
             if (_disposed) return;
             allProducts = data;
@@ -182,6 +190,9 @@ class PosController extends ChangeNotifier {
         })
         .where((item) {
           if (selectedCategoryId == null) return true;
+          if (selectedCategoryId == kUncategorizedCategoryId) {
+            return item.product.categoryId == null;
+          }
           return item.product.categoryId == selectedCategoryId;
         })
         .toList();

--- a/lib/features/pos/screens/pos_home_screen.dart
+++ b/lib/features/pos/screens/pos_home_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:reebaplus_pos/core/constants/category_filter.dart';
 import 'package:reebaplus_pos/core/database/app_database.dart';
 import 'package:reebaplus_pos/core/permissions/permissions.dart';
 import 'package:reebaplus_pos/core/providers/app_providers.dart';
@@ -266,6 +267,8 @@ class _PosHomeScreenState extends ConsumerState<PosHomeScreen> {
                         categories: [
                           'All',
                           ..._controller!.categories.map((c) => c.name),
+                          // #109: bucket for products with no category.
+                          'Uncategorized',
                         ],
                         // Defense-in-depth: the controller already resets a
                         // dangling selectedCategoryId, but never let the chip
@@ -275,6 +278,10 @@ class _PosHomeScreenState extends ConsumerState<PosHomeScreen> {
                         onCategorySelected: (name) {
                           if (name == 'All') {
                             _controller!.selectCategory(null);
+                          } else if (name == 'Uncategorized') {
+                            _controller!.selectCategory(
+                              kUncategorizedCategoryId,
+                            );
                           } else {
                             final cat = _controller!.categories.firstWhere(
                               (c) => c.name == name,
@@ -410,6 +417,7 @@ class _PosHomeScreenState extends ConsumerState<PosHomeScreen> {
   String _selectedCategoryLabel() {
     final id = _controller!.selectedCategoryId;
     if (id == null) return 'All';
+    if (id == kUncategorizedCategoryId) return 'Uncategorized';
     for (final c in _controller!.categories) {
       if (c.id == id) return c.name;
     }

--- a/test/inventory/category_manage_dao_test.dart
+++ b/test/inventory/category_manage_dao_test.dart
@@ -1,0 +1,179 @@
+import 'package:drift/drift.dart' hide isNull; // matcher's isNull wins here
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reebaplus_pos/core/database/app_database.dart';
+import 'package:reebaplus_pos/core/database/uuid_v7.dart';
+
+import '../helpers/dispatch_test_utils.dart';
+
+/// Category edit & delete (#109): rename (reject a collision), and soft-delete
+/// that moves the category's products to Uncategorized (`categoryId = null`).
+/// The data layer is CatalogDao; assertions cover the local write, the sync
+/// enqueue shape, and the reactive `watchAllCategories` read.
+void main() {
+  late AppDatabase db;
+  late String businessId;
+
+  setUp(() async {
+    final boot = await bootstrapTestDb();
+    db = boot.db;
+    businessId = boot.businessId;
+  });
+
+  tearDown(() => db.close());
+
+  Future<String> newCategory(String name) => db.catalogDao.insertCategory(
+    CategoriesCompanion.insert(name: name, businessId: businessId),
+  );
+
+  // Inserts a product directly (bypassing the sync queue) so queue assertions
+  // only observe rows the method under test enqueues.
+  Future<String> newProduct({required String name, String? categoryId}) async {
+    final id = UuidV7.generate();
+    await db.into(db.products).insert(
+      ProductsCompanion.insert(
+        id: Value(id),
+        businessId: businessId,
+        name: name,
+        categoryId: Value(categoryId),
+        retailerPriceKobo: const Value(100000),
+      ),
+    );
+    return id;
+  }
+
+  Future<ProductData> productById(String id) =>
+      (db.select(db.products)..where((p) => p.id.equals(id))).getSingle();
+
+  Future<CategoryData> categoryById(String id) =>
+      (db.select(db.categories)..where((c) => c.id.equals(id))).getSingle();
+
+  // ─── Rename ────────────────────────────────────────────────────────────────
+
+  test('renameCategory updates the local name and full-row enqueues it', () async {
+    final id = await newCategory('Sodas');
+    await newProduct(name: 'Cola', categoryId: id); // untouched by a rename
+
+    await db.catalogDao.renameCategory(id, name: 'Soft Drinks');
+
+    expect((await categoryById(id)).name, 'Soft Drinks');
+
+    final push = (await getPendingQueue(db))
+        .firstWhere((r) => r.actionType == 'categories:upsert');
+    final payload = decodePayload(push);
+    expect(payload['id'], id);
+    expect(payload['name'], 'Soft Drinks');
+    // Full-row: the NOT NULL business_id must ride along (else Postgres 23502).
+    expect(payload['business_id'], businessId);
+    expect(payload['is_deleted'], false);
+  });
+
+  test('categoryNameExists is case-insensitive, trims, and honours excludeId',
+      () async {
+    final sodas = await newCategory('Sodas');
+    await newCategory('Water');
+
+    // Collision detection (case-insensitive + trimmed).
+    expect(await db.catalogDao.categoryNameExists('sodas'), isTrue);
+    expect(await db.catalogDao.categoryNameExists('  WATER '), isTrue);
+    expect(await db.catalogDao.categoryNameExists('Juice'), isFalse);
+
+    // Renaming a category to its own (differently-cased) name is not a
+    // collision — it excludes itself.
+    expect(
+      await db.catalogDao.categoryNameExists('SODAS', excludeId: sodas),
+      isFalse,
+    );
+    // But a name owned by a *different* category still collides.
+    expect(
+      await db.catalogDao.categoryNameExists('Water', excludeId: sodas),
+      isTrue,
+    );
+  });
+
+  test('a soft-deleted category is not a collision (its name is freed)', () async {
+    final id = await newCategory('Seasonal');
+    await db.catalogDao.softDeleteCategoryAndReassign(id);
+    expect(await db.catalogDao.categoryNameExists('Seasonal'), isFalse);
+  });
+
+  // ─── Count ───────────────────────────────────────────────────────────────
+
+  test('countProductsInCategory counts only live products in that category',
+      () async {
+    final sodas = await newCategory('Sodas');
+    final water = await newCategory('Water');
+    await newProduct(name: 'Cola', categoryId: sodas);
+    await newProduct(name: 'Fanta', categoryId: sodas);
+    await newProduct(name: 'Aqua', categoryId: water); // other category
+    await newProduct(name: 'Loose', categoryId: null); // uncategorized
+
+    // A soft-deleted product in the category is excluded from the count.
+    final deletedId = await newProduct(name: 'Old', categoryId: sodas);
+    await (db.update(db.products)..where((p) => p.id.equals(deletedId)))
+        .write(const ProductsCompanion(isDeleted: Value(true)));
+
+    expect(await db.catalogDao.countProductsInCategory(sodas), 2);
+    expect(await db.catalogDao.countProductsInCategory(water), 1);
+  });
+
+  // ─── Soft-delete + reassign ────────────────────────────────────────────────
+
+  test('softDeleteCategoryAndReassign tombstones the category, moves its '
+      'products to null, leaves others alone, and returns the count', () async {
+    final sodas = await newCategory('Sodas');
+    final water = await newCategory('Water');
+    final cola = await newProduct(name: 'Cola', categoryId: sodas);
+    final fanta = await newProduct(name: 'Fanta', categoryId: sodas);
+    final aqua = await newProduct(name: 'Aqua', categoryId: water);
+
+    final moved = await db.catalogDao.softDeleteCategoryAndReassign(sodas);
+    expect(moved, 2);
+
+    // Category tombstoned locally.
+    expect((await categoryById(sodas)).isDeleted, isTrue);
+    // Its products are now Uncategorized; the other category is untouched.
+    expect((await productById(cola)).categoryId, isNull);
+    expect((await productById(fanta)).categoryId, isNull);
+    expect((await productById(aqua)).categoryId, water);
+  });
+
+  test('reassignment pushes an EXPLICIT category_id: null so the cloud clears '
+      'it (not dropped as Value.absent), plus the category tombstone', () async {
+    final sodas = await newCategory('Sodas');
+    final cola = await newProduct(name: 'Cola', categoryId: sodas);
+
+    await db.catalogDao.softDeleteCategoryAndReassign(sodas);
+
+    final queue = await getPendingQueue(db);
+
+    final productPush = queue.firstWhere(
+      (r) => r.actionType == 'products:upsert' && decodePayload(r)['id'] == cola,
+    );
+    final productPayload = decodePayload(productPush);
+    // The key must be present AND null — an absent key leaves the stale FK on
+    // the cloud (the whole point of the copyWith(Value(null)) override).
+    expect(productPayload.containsKey('category_id'), isTrue);
+    expect(productPayload['category_id'], isNull);
+    expect(productPayload['name'], 'Cola'); // NOT NULL rides along
+    expect(productPayload['business_id'], businessId);
+
+    final catPush = queue.firstWhere(
+      (r) => r.actionType == 'categories:upsert',
+    );
+    expect(decodePayload(catPush)['is_deleted'], true);
+  });
+
+  // ─── Reactive read ───────────────────────────────────────────────────────
+
+  test('watchAllCategories excludes a soft-deleted category', () async {
+    final sodas = await newCategory('Sodas');
+    final water = await newCategory('Water');
+
+    await db.catalogDao.softDeleteCategoryAndReassign(sodas);
+
+    final live = await db.inventoryDao.watchAllCategories().first;
+    final ids = live.map((c) => c.id).toList();
+    expect(ids, contains(water));
+    expect(ids, isNot(contains(sodas)));
+  });
+}


### PR DESCRIPTION
Closes #109.

Adds a **Manage categories** surface in Inventory (rename / delete) and an **Uncategorized** filter bucket in POS + Inventory.

## What changed
- **New "Manage categories" bottom sheet** (`manage_categories_sheet.dart`), opened from a gated button next to the Inventory category filter. Lists non-deleted categories; each has:
  - **Rename** — inline error if the new name collides with another category (case-insensitive). A case-only rename of a category's own name is allowed.
  - **Delete** — confirmation stating how many products will move to Uncategorized, then soft-delete + reassign.
- **`CatalogDao`** gains `renameCategory`, `categoryNameExists`, `countProductsInCategory`, `softDeleteCategoryAndReassign`.
- **Uncategorized bucket** — POS chip row + Inventory category dropdown, backed by a sentinel id (`null` already means "All"). Both filters drop a dangling selection when its category disappears.

## Acceptance criteria
- [x] Rename updates everywhere; rejects a colliding name (AC #1)
- [x] Delete shows affected-product count, soft-deletes, moves products to Uncategorized (AC #2/#3)
- [x] Category filter gains an Uncategorized bucket (AC #4)
- [x] Reuses the product-management permission — `Gates.addProduct` (AC #5)

## Notes
- **No migration.** `Categories` already has `is_deleted`; `Products.categoryId` is a nullable FK (`null` = Uncategorized); `categories` is already a synced table.
- Reassignment enqueues an **explicit `category_id: null`** per product (via `copyWith(Value(null))`) so the cloud clears the stale FK instead of dropping it as `Value.absent()`.

## Testing
- New `test/inventory/category_manage_dao_test.dart` (7 tests): rename + full-row enqueue, case-insensitive collision + `excludeId`, freed name after delete, live-only count, soft-delete/reassign/return-count, explicit-`category_id: null` push shape, `watchAllCategories` exclusion.
- `flutter analyze` clean on all changed files; `test/inventory/` + `test/pos/` green (80 tests).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an “Uncategorized” filter option in Inventory and POS.
  * Added category management controls for renaming and deleting categories.
  * Deleting a category now moves its products to “Uncategorized.”
  * Added duplicate-name validation and confirmation details showing affected product counts.
  * Category selections automatically reset when a selected category is removed.

* **Bug Fixes**
  * Improved handling of uncategorized products across filtering and synchronization.
  * Ensured category changes and product reassignment remain consistent across devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->