### PR TITLE
feat(inventory): product barcode field + lookup (#113)

### DIFF
--- a/lib/core/database/daos_catalog.dart
+++ b/lib/core/database/daos_catalog.dart
@@ -329,6 +329,25 @@ class CatalogDao extends DatabaseAccessor<AppDatabase>
         .getSingleOrNull();
   }
 
+  /// Look up a product by its [barcode] (#113 — foundation for scanning, #118).
+  /// Returns the first business-scoped, non-deleted match, or null. Barcodes are
+  /// softly unique (no DB UNIQUE — that would jam the offline outbox), so a
+  /// collision is possible; callers that need to warn on one compare the match's
+  /// id to the product being edited. An empty [barcode] never matches.
+  Future<ProductData?> findProductByBarcode(String barcode) {
+    final trimmed = barcode.trim();
+    if (trimmed.isEmpty) return Future.value(null);
+    return (select(products)
+          ..where(
+            (t) =>
+                t.barcode.equals(trimmed) &
+                whereBusiness(t) &
+                t.isDeleted.not(),
+          )
+          ..limit(1))
+        .getSingleOrNull();
+  }
+
   Future<void> softDeleteProduct(String productId) async {
     // Soft-delete: flip is_deleted and push it as an UPSERT, never a hard
     // tombstone. A `products:delete` makes the cloud run `DELETE FROM products`,
@@ -377,6 +396,11 @@ class CatalogDao extends DatabaseAccessor<AppDatabase>
     Object? supplierId = _unset,
     Object? size = _unset,
     Object? expiryDate = _unset,
+    // Optional product barcode (#113). Sentinel-defaulted like the cosmetic
+    // fields above: omit to leave the column untouched. A concrete String (or
+    // null to clear locally) is written; a set value pushes because the partial
+    // companion enqueued below serializes present, non-null values.
+    Object? barcode = _unset,
   }) async {
     final now = DateTime.now();
     final comp = ProductsCompanion(
@@ -421,6 +445,9 @@ class CatalogDao extends DatabaseAccessor<AppDatabase>
       expiryDate: identical(expiryDate, _unset)
           ? const Value.absent()
           : Value(expiryDate as DateTime?),
+      barcode: identical(barcode, _unset)
+          ? const Value.absent()
+          : Value(barcode as String?),
       lastUpdatedAt: Value(now),
     );
     await (update(

--- a/lib/features/inventory/models/fast_add_product_model.dart
+++ b/lib/features/inventory/models/fast_add_product_model.dart
@@ -60,6 +60,7 @@ class FastAddInput {
     this.emptyCrateValue = '',
     this.hasManufacturer = false,
     this.selectedStoreId,
+    this.barcode = '',
   });
 
   /// Product name (required). Trimmed by the model.
@@ -98,6 +99,11 @@ class FastAddInput {
   /// The chosen store for a multi-store business. Ignored (resolved silently)
   /// for a single-store business.
   final String? selectedStoreId;
+
+  /// Optional product barcode (#113). Blank ⇒ no barcode (null). Never blocks
+  /// the save; a soft collision warning is surfaced by the screen, not here (a
+  /// lookup is a DB call, which this pure model does not do).
+  final String barcode;
 }
 
 /// The outcome of validating + shaping a Fast-Add submission.
@@ -136,6 +142,7 @@ final class FastAddIntent extends FastAddResult {
     required this.lowStockThreshold,
     required this.initialStock,
     required this.storeId,
+    this.barcode,
   });
 
   final String name;
@@ -157,6 +164,9 @@ final class FastAddIntent extends FastAddResult {
   final int lowStockThreshold;
   final int initialStock;
   final String storeId;
+
+  /// Optional product barcode (#113); null when the field was left blank.
+  final String? barcode;
 
   /// A product saved with no buying price is Uncosted (ADR 0006 / CONTEXT.md
   /// §Inventory & Costing): reports exclude it from COGS and count it
@@ -254,6 +264,10 @@ FastAddResult resolveFastAdd(FastAddInput input, FastAddContext context) {
 
   final lowStockThreshold = int.tryParse(input.lowStock.trim()) ?? 5;
 
+  // Optional barcode: a blank field is no barcode (null), never a save blocker.
+  final barcodeRaw = input.barcode.trim();
+  final barcode = barcodeRaw.isEmpty ? null : barcodeRaw;
+
   return FastAddIntent(
     name: name,
     retailerPriceKobo: retailerPriceKobo,
@@ -265,6 +279,7 @@ FastAddResult resolveFastAdd(FastAddInput input, FastAddContext context) {
     lowStockThreshold: lowStockThreshold,
     initialStock: quantity,
     storeId: storeId,
+    barcode: barcode,
   );
 }
 

--- a/lib/features/inventory/screens/add_product_screen.dart
+++ b/lib/features/inventory/screens/add_product_screen.dart
@@ -60,6 +60,11 @@ class _AddProductScreenState extends ConsumerState<AddProductScreen> {
   final _supplierCtrl = TextEditingController();
   final _manufacturerCtrl = TextEditingController();
   final _categoryCtrl = TextEditingController();
+  final _barcodeCtrl = TextEditingController();
+
+  /// The name of another product already using the typed barcode (#113). Non-
+  /// null ⇒ a soft collision the form warns about; it never blocks the save.
+  String? _barcodeCollisionName;
 
   String _unit = 'Bottle';
   bool _trackEmpties = true; // defaults true when unit is Bottle
@@ -178,7 +183,32 @@ class _AddProductScreenState extends ConsumerState<AddProductScreen> {
     _supplierCtrl.dispose();
     _manufacturerCtrl.dispose();
     _categoryCtrl.dispose();
+    _barcodeCtrl.dispose();
     super.dispose();
+  }
+
+  /// Soft barcode-collision check (#113): looks up the typed barcode and, if a
+  /// DIFFERENT product already uses it, records that product's name so the field
+  /// can warn. Never blocks — barcodes are only softly unique (no DB UNIQUE, to
+  /// avoid jamming the offline outbox).
+  Future<void> _onBarcodeChanged(String value) async {
+    final trimmed = value.trim();
+    if (trimmed.isEmpty) {
+      if (_barcodeCollisionName != null) {
+        setState(() => _barcodeCollisionName = null);
+      }
+      return;
+    }
+    final db = ref.read(databaseProvider);
+    final match = await db.catalogDao.findProductByBarcode(trimmed);
+    if (!mounted) return;
+    final collision =
+        (match != null && match.id != _selectedExistingProduct?.id)
+        ? match.name
+        : null;
+    if (collision != _barcodeCollisionName) {
+      setState(() => _barcodeCollisionName = collision);
+    }
   }
 
   void _onSupplierChanged(String query) {
@@ -297,9 +327,11 @@ class _AddProductScreenState extends ConsumerState<AddProductScreen> {
         ? (product.emptyCrateValueKobo / 100).toStringAsFixed(2)
         : '';
     _lowStockCtrl.text = product.lowStockThreshold.toString();
+    _barcodeCtrl.text = product.barcode ?? '';
 
     setState(() {
       _selectedExistingProduct = product;
+      _barcodeCollisionName = null;
       _unit = product.unit;
       _size = product.size;
       _trackEmpties = product.trackEmpties;
@@ -344,8 +376,10 @@ class _AddProductScreenState extends ConsumerState<AddProductScreen> {
     _manufacturerCtrl.clear();
     _supplierCtrl.clear();
     _categoryCtrl.clear();
+    _barcodeCtrl.clear();
     setState(() {
       _selectedExistingProduct = null;
+      _barcodeCollisionName = null;
       _unit = _lexicon.unit;
       _size = null;
       _expiryDate = null;
@@ -627,6 +661,9 @@ class _AddProductScreenState extends ConsumerState<AddProductScreen> {
           supplierId: _selectedSupplier?.id,
           size: _size,
           expiryDate: _expiryDate,
+          barcode: _barcodeCtrl.text.trim().isEmpty
+              ? null
+              : _barcodeCtrl.text.trim(),
         );
 
         // Persist the crate value at the manufacturer level (§16.5).
@@ -814,6 +851,9 @@ class _AddProductScreenState extends ConsumerState<AddProductScreen> {
           colorHex: drift.Value(_colorHex),
           size: drift.Value(_size),
           expiryDate: drift.Value(_expiryDate),
+          barcode: drift.Value(
+            _barcodeCtrl.text.trim().isEmpty ? null : _barcodeCtrl.text.trim(),
+          ),
           lowStockThreshold: drift.Value(lowStock),
           manufacturerId: drift.Value(_selectedManufacturer?.id),
           supplierId: drift.Value(_selectedSupplier?.id),
@@ -886,6 +926,7 @@ class _AddProductScreenState extends ConsumerState<AddProductScreen> {
         hasManufacturer: _selectedManufacturer != null ||
             _manufacturerCtrl.text.trim().isNotEmpty,
         selectedStoreId: _selectedStore?.id,
+        barcode: _barcodeCtrl.text,
       ),
       FastAddContext(
         tracksCrates: _isCrateBusiness,
@@ -970,6 +1011,7 @@ class _AddProductScreenState extends ConsumerState<AddProductScreen> {
           colorHex: drift.Value(_colorHex),
           size: drift.Value(_size),
           expiryDate: drift.Value(_expiryDate),
+          barcode: drift.Value(intent.barcode),
           lowStockThreshold: drift.Value(intent.lowStockThreshold),
           manufacturerId: drift.Value(_selectedManufacturer?.id),
           supplierId: drift.Value(_selectedSupplier?.id),
@@ -1321,6 +1363,9 @@ class _AddProductScreenState extends ConsumerState<AddProductScreen> {
                   labelText: 'Description / Subtitle *',
                   hintText: _descriptionHint,
                 ),
+                const SizedBox(height: 14),
+                // ── BARCODE (optional) ─────────────────────────────────
+                _barcodeField(),
                 const SizedBox(height: 14),
                 Row(
                   children: [
@@ -1796,6 +1841,10 @@ class _AddProductScreenState extends ConsumerState<AddProductScreen> {
       ),
       const SizedBox(height: 14),
 
+      // ── BARCODE (optional) ──────────────────────────────────────────────
+      _barcodeField(),
+      const SizedBox(height: 14),
+
       // ── WHOLESALER PRICE (optional; mirrors selling on save) ────────────
       AppInput(
         controller: _wholesalePriceCtrl,
@@ -1943,6 +1992,40 @@ class _AddProductScreenState extends ConsumerState<AddProductScreen> {
     padding: const EdgeInsets.only(top: 6, left: 4),
     child: Text(text, style: TextStyle(fontSize: 11, color: subtext)),
   );
+
+  /// Optional barcode field (#113) with a live soft-collision warning. Shared by
+  /// the Fast-Add and classic layouts. Typing runs [_onBarcodeChanged], which
+  /// warns (never blocks) if another product already uses the code.
+  Widget _barcodeField() {
+    final error = Theme.of(context).colorScheme.error;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        AppInput(
+          controller: _barcodeCtrl,
+          labelText: 'Barcode (optional)',
+          hintText: 'Type or scan the product barcode',
+          onChanged: _onBarcodeChanged,
+        ),
+        if (_barcodeCollisionName != null)
+          Padding(
+            padding: const EdgeInsets.only(top: 6, left: 4),
+            child: Row(
+              children: [
+                Icon(Icons.warning_amber_rounded, size: 14, color: error),
+                const SizedBox(width: 6),
+                Expanded(
+                  child: Text(
+                    'Already used by "$_barcodeCollisionName". You can still save.',
+                    style: TextStyle(fontSize: 11, color: error),
+                  ),
+                ),
+              ],
+            ),
+          ),
+      ],
+    );
+  }
 
   Widget _moreDetailsHeader(Color subtext, Color textColor) => InkWell(
     onTap: () => setState(() => _showMoreDetails = !_showMoreDetails),

--- a/lib/features/inventory/widgets/update_product_sheet.dart
+++ b/lib/features/inventory/widgets/update_product_sheet.dart
@@ -53,6 +53,11 @@ class _UpdateProductSheetState extends ConsumerState<UpdateProductSheet> {
   late final TextEditingController _supplierCtrl;
   late final TextEditingController _manufacturerCtrl;
   late final TextEditingController _categoryCtrl;
+  late final TextEditingController _barcodeCtrl;
+
+  /// The name of another product already using the typed barcode (#113). Non-
+  /// null ⇒ a soft collision the sheet warns about; it never blocks the save.
+  String? _barcodeCollisionName;
 
   late String _unit;
   late bool _trackEmpties;
@@ -164,6 +169,7 @@ class _UpdateProductSheetState extends ConsumerState<UpdateProductSheet> {
     // Manufacturer name is populated in _loadData() via FK lookup.
     _manufacturerCtrl = TextEditingController();
     _categoryCtrl = TextEditingController();
+    _barcodeCtrl = TextEditingController(text: p.barcode ?? '');
     _imagePath = p.imagePath;
 
     _unit = p.unit;
@@ -261,7 +267,31 @@ class _UpdateProductSheetState extends ConsumerState<UpdateProductSheet> {
     _supplierCtrl.dispose();
     _manufacturerCtrl.dispose();
     _categoryCtrl.dispose();
+    _barcodeCtrl.dispose();
     super.dispose();
+  }
+
+  /// Soft barcode-collision check (#113): looks up the typed barcode and, if a
+  /// DIFFERENT product already uses it, records that product's name so the field
+  /// can warn. Never blocks — barcodes are only softly unique (no DB UNIQUE, to
+  /// avoid jamming the offline outbox).
+  Future<void> _onBarcodeChanged(String value) async {
+    final trimmed = value.trim();
+    if (trimmed.isEmpty) {
+      if (_barcodeCollisionName != null) {
+        setState(() => _barcodeCollisionName = null);
+      }
+      return;
+    }
+    final db = ref.read(databaseProvider);
+    final match = await db.catalogDao.findProductByBarcode(trimmed);
+    if (!mounted) return;
+    final collision = (match != null && match.id != widget.product.id)
+        ? match.name
+        : null;
+    if (collision != _barcodeCollisionName) {
+      setState(() => _barcodeCollisionName = collision);
+    }
   }
 
   void _onSupplierChanged(String query) {
@@ -555,6 +585,9 @@ class _UpdateProductSheetState extends ConsumerState<UpdateProductSheet> {
         supplierId: _selectedSupplier?.id,
         size: _size,
         expiryDate: _expiryDate,
+        barcode: _barcodeCtrl.text.trim().isEmpty
+            ? null
+            : _barcodeCtrl.text.trim(),
       );
 
       // Patch the cloud image URL (separate minimal upsert) so the photo
@@ -970,6 +1003,10 @@ class _UpdateProductSheetState extends ConsumerState<UpdateProductSheet> {
                       labelText: 'Description / Subtitle',
                       hintText: _lexicon.itemDescriptionHint,
                     ),
+                    const SizedBox(height: 14),
+
+                    // ── BARCODE (optional) ───────────────────────────────────
+                    _barcodeField(),
                     const SizedBox(height: 14),
 
                     // ── PRICES ───────────────────────────────────────────────
@@ -1421,6 +1458,40 @@ class _UpdateProductSheetState extends ConsumerState<UpdateProductSheet> {
       letterSpacing: 0.8,
     ),
   );
+
+  /// Optional barcode field (#113) with a live soft-collision warning. Typing
+  /// runs [_onBarcodeChanged], which warns (never blocks) when another product
+  /// already uses the code.
+  Widget _barcodeField() {
+    final error = Theme.of(context).colorScheme.error;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        AppInput(
+          controller: _barcodeCtrl,
+          labelText: 'Barcode (optional)',
+          hintText: 'Type or scan the product barcode',
+          onChanged: _onBarcodeChanged,
+        ),
+        if (_barcodeCollisionName != null)
+          Padding(
+            padding: const EdgeInsets.only(top: 6, left: 4),
+            child: Row(
+              children: [
+                Icon(Icons.warning_amber_rounded, size: 14, color: error),
+                const SizedBox(width: 6),
+                Expanded(
+                  child: Text(
+                    'Already used by "$_barcodeCollisionName". You can still save.',
+                    style: TextStyle(fontSize: 11, color: error),
+                  ),
+                ),
+              ],
+            ),
+          ),
+      ],
+    );
+  }
 
   Widget _suggestionList({
     required List<Widget> children,

--- a/supabase/migrations/0150_products_barcode.sql
+++ b/supabase/migrations/0150_products_barcode.sql
@@ -1,0 +1,27 @@
+-- 0150_products_barcode.sql
+--
+-- #113 (ADR 0017, unwritten — implemented from the issue ACs) — optional
+-- product barcode, the foundation for barcode scanning (#118).
+--
+-- Adds public.products.barcode: an optional, human-typed (later scanned) code
+-- that identifies a product. The client column already exists (Drift schema
+-- v18); this lands the cloud half so the value converges cross-device through
+-- the normal outbox -> upsert -> pull path. `products` is a pass-through push
+-- table (no push-column whitelist in sync_registry.dart), so the column rides
+-- sync as soon as it exists on both sides — no RPC or whitelist change needed.
+--
+-- NULLABLE and additive: barcode-less products stay NULL, existing rows are
+-- untouched.
+--
+-- NO UNIQUE constraint (deliberate): uniqueness is enforced softly in the app
+-- (the Add/Edit form warns on a collision but still allows the save). A DB
+-- UNIQUE would reject a colliding offline write on push and permanently jam the
+-- outbox — the exact failure mode this issue is required to avoid.
+--
+-- Deploy-ordering: this must land on the cloud BEFORE any client pushes a
+-- product upsert carrying a non-null barcode, or the upsert would reference an
+-- unknown column and jam the outbox. No shipped client sets barcode yet, so
+-- deploying this alongside the feature PR is safe.
+
+ALTER TABLE public.products
+  ADD COLUMN IF NOT EXISTS barcode text;

--- a/test/inventory/product_barcode_lookup_test.dart
+++ b/test/inventory/product_barcode_lookup_test.dart
@@ -1,0 +1,116 @@
+// product_barcode_lookup_test.dart
+//
+// #113 — product barcode field + lookup (foundation for scanning, #118).
+//
+// Covers the CatalogDao surface added for the barcode feature:
+//   - findProductByBarcode returns the first business-scoped, non-deleted match
+//   - it returns null when no product carries the code
+//   - it ignores soft-deleted products
+//   - a collision resolves to a DIFFERENT product (the id the form compares
+//     against to decide whether to warn)
+//   - the barcode rides the push payload (products is a pass-through push
+//     table), on both create and edit, so it converges cross-device once the
+//     cloud column exists (migration 0150).
+
+import 'package:drift/drift.dart' show Value;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reebaplus_pos/core/database/app_database.dart';
+
+import '../helpers/dispatch_test_utils.dart';
+
+void main() {
+  late AppDatabase db;
+  late String businessId;
+
+  setUp(() async {
+    final boot = await bootstrapTestDb();
+    db = boot.db;
+    businessId = boot.businessId;
+  });
+
+  tearDown(() => db.close());
+
+  Future<String> insertProduct(String name, {String? barcode}) {
+    return db.catalogDao.insertProduct(
+      ProductsCompanion.insert(
+        businessId: businessId,
+        name: name,
+        barcode: Value(barcode),
+      ),
+    );
+  }
+
+  test('findProductByBarcode returns the matching product', () async {
+    final id = await insertProduct('Star Lager', barcode: 'BC-001');
+
+    final match = await db.catalogDao.findProductByBarcode('BC-001');
+    expect(match, isNotNull);
+    expect(match!.id, id);
+    expect(match.name, 'Star Lager');
+    expect(match.barcode, 'BC-001');
+  });
+
+  test('findProductByBarcode returns null when absent', () async {
+    await insertProduct('Star Lager', barcode: 'BC-001');
+
+    expect(await db.catalogDao.findProductByBarcode('NOPE-999'), isNull);
+    // An empty query never matches (and never scans).
+    expect(await db.catalogDao.findProductByBarcode('   '), isNull);
+  });
+
+  test('findProductByBarcode ignores soft-deleted products', () async {
+    final id = await insertProduct('Star Lager', barcode: 'BC-001');
+    await db.catalogDao.softDeleteProduct(id);
+
+    expect(await db.catalogDao.findProductByBarcode('BC-001'), isNull);
+  });
+
+  test('collision: findProductByBarcode finds a DIFFERENT product', () async {
+    final existingId = await insertProduct('Star Lager', barcode: 'BC-001');
+    // A second product being edited to reuse BC-001 resolves the lookup to the
+    // first product, whose id differs — the signal the form warns on.
+    final editingId = await insertProduct('Gulder', barcode: null);
+
+    final match = await db.catalogDao.findProductByBarcode('BC-001');
+    expect(match, isNotNull);
+    expect(match!.id, existingId);
+    expect(match.id == editingId, isFalse);
+  });
+
+  test('insertProduct enqueues the barcode in the push payload', () async {
+    await insertProduct('Star Lager', barcode: 'BC-001');
+
+    final pending = await getPendingQueue(db);
+    final upsert = pending
+        .where((r) => r.actionType == 'products:upsert')
+        .toList();
+    expect(upsert, isNotEmpty);
+    final payload = decodePayload(upsert.last);
+    expect(payload['barcode'], 'BC-001',
+        reason: 'products is pass-through; a set barcode must ride the push');
+  });
+
+  test('updateProductDetails enqueues the edited barcode', () async {
+    final id = await insertProduct('Star Lager', barcode: null);
+    await db.customStatement('DELETE FROM sync_queue');
+
+    await db.catalogDao.updateProductDetails(
+      id,
+      name: 'Star Lager',
+      buyingPriceKobo: 0,
+      retailerPriceKobo: 50000,
+      wholesalerPriceKobo: 50000,
+      barcode: 'BC-777',
+    );
+
+    final pending = await getPendingQueue(db);
+    final upsert = pending
+        .where((r) => r.actionType == 'products:upsert')
+        .toList();
+    expect(upsert, isNotEmpty);
+    final payload = decodePayload(upsert.last);
+    expect(payload['barcode'], 'BC-777');
+    expect(payload['name'], 'Star Lager',
+        reason: 'NOT NULL name must stay in the partial upsert payload');
+  });
+}


### PR DESCRIPTION
Closes #113.

Optional, typed **product barcode** with a soft-uniqueness warning — the foundation for barcode scanning (#118, not implemented here).

> **Note on ADR 0017:** the issue references "ADR 0017", which does **not** exist in `docs/adr/`. Implemented directly from the acceptance criteria; no ADR file was created.

## Acceptance criteria

- [x] **New nullable `products.barcode` synced (client + cloud + one sync-registry entry); no unique constraint.**
  The client Drift column already exists (`app_database.dart`, schema v18, with its `onUpgrade` `addColumn` step and generated `.g.dart`) — not re-added. The cloud column already exists too (verified: `text`, nullable, **0** unique/PK constraints, **0** indexes). `products` is already registered in `sync_registry.dart` as a **pass-through** push table (no push-column whitelist), so no new `SyncedTable` entry is needed and the column rides sync as soon as it is present on both sides. Migration `supabase/migrations/0150_products_barcode.sql` adds it with `ADD COLUMN IF NOT EXISTS ... text` (nullable, **no** UNIQUE — a DB UNIQUE would reject a colliding offline write on push and jam the outbox).
- [x] **Add/edit form has an optional barcode field (typed); warns on collision with another product.**
  A "Barcode (optional)" `AppInput` was added to `add_product_screen.dart` (both the Fast-Add "More details" section and the classic layout) and to `update_product_sheet.dart`. Typing runs a soft-collision check that looks up the barcode and, if a **different** product already uses it, shows a live inline warning ("Already used by \"X\". You can still save.") — non-blocking; the save always proceeds (soft uniqueness).
- [x] **A lookup-by-barcode data method returns the matching product (first match).**
  `CatalogDao.findProductByBarcode(String barcode)` returns the first business-scoped, non-deleted match (or null; an empty/whitespace query never matches).

## How it's wired

- `updateProductDetails` gained a sentinel-defaulted `barcode` param (same `_unset` pattern as `subtitle`/`size`/`expiryDate`), so an edited barcode is written locally and pushed in the partial `products` upsert as a concrete value.
- Create paths persist barcode via the existing `ProductsCompanion` (the same way `size`/`expiryDate` already flow) — no `insertProduct` signature change. The default create path (domain-RPC flag **off**) enqueues the full product row, so barcode syncs.
- `FastAddInput` → `FastAddIntent` thread the value through the pure form model.

## Migration

`0150_products_barcode.sql` (0149 reserved by a sibling branch). The live cloud column already exists and matches the spec, so this file is an idempotent no-op there; it lands in the repo so a fresh Supabase project built from migrations gets the column.

## Tests

`test/inventory/product_barcode_lookup_test.dart` — 6 cases: match, null-when-absent (incl. empty query), ignores soft-deleted, collision resolves to a **different** product, and barcode present in the push payload on both create and edit. Passes (9/9 with the partial-upsert regression suite); the full `test/inventory/` suite passes (49). `dart analyze` on all changed files: clean.

## Known limitation

The flag-gated `pos_create_product_v2` domain RPC (default **off**) builds a thin payload that does not forward `p_barcode`, so a create made with that flag on would not sync the barcode until the RPC is extended. Left untouched deliberately (forwarding an unknown param would fail the RPC); noted for the scanning epic.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional barcode fields when creating products, using Fast Add, or editing existing products.
  - Barcodes are saved and synchronized with product records.
  - Added barcode lookup support, including trimming and ignoring deleted products.
  - Added inline, non-blocking warnings when a barcode is already associated with another product.

- **Bug Fixes**
  - Blank or whitespace-only barcodes are handled as empty values without generating lookup results.

- **Tests**
  - Added coverage for barcode lookup, collision handling, persistence, and synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->