### PR TITLE
feat(staff): server-authoritative staff removal that frees the email (#107)

### DIFF
--- a/lib/core/database/app_database.dart
+++ b/lib/core/database/app_database.dart
@@ -1558,7 +1558,11 @@ class UserBusinesses extends Table {
 
   @override
   List<String> get customConstraints => [
-    "CHECK (status IN ('active','suspended'))",
+    // #107 staff offboarding added the terminal `removed` status. Widening this
+    // CHECK is a runtime-resolved change (customConstraints is not baked into
+    // the generated code), so no build_runner regen is needed; existing installs
+    // rebuild the table under the new CHECK via the schemaVersion 61 upgrade step.
+    "CHECK (status IN ('active','suspended','removed'))",
     'UNIQUE (user_id, business_id)',
   ];
 }
@@ -1842,7 +1846,7 @@ class AppDatabase extends _$AppDatabase {
   String? get currentAuthUserId => authUserIdResolver();
 
   @override
-  int get schemaVersion => 60;
+  int get schemaVersion => 61;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -3975,6 +3979,58 @@ class AppDatabase extends _$AppDatabase {
           await m.addColumn(syncQueue, syncQueue.heldByOrderId);
         }
       }
+      if (from < 61) {
+        // v61 (#107 staff offboarding): widen the user_businesses.status CHECK to
+        // admit the terminal `removed` state (was active/suspended only), and seed
+        // the new `staff.remove` permission key into the local catalog. Mirrors
+        // supabase/migrations/0149_remove_staff_member.sql.
+        //
+        // (1) SQLite can't ALTER a CHECK constraint, so rebuild user_businesses to
+        //     pick up the 3-value CHECK from the current Drift customConstraints.
+        //     TableMigration copies every row 1:1 — WIDENING keeps all existing
+        //     active/suspended rows valid, so the copy never fails. drift's
+        //     alterTable re-applies the table's EXISTING indexes (with their old
+        //     definitions), so DROP-then-CREATE each AFTER the rebuild to stay
+        //     idempotent (same fix as the v29 crate_ledger rebuild). Triggers are
+        //     NOT re-applied by alterTable, but DROP IF EXISTS keeps a partial
+        //     re-run (revert-then-re-upgrade migration tests) safe. The index +
+        //     trigger definitions match onCreate exactly.
+        await m.alterTable(TableMigration(userBusinesses));
+        await customStatement(
+          'DROP INDEX IF EXISTS idx_user_businesses_business_lua',
+        );
+        await customStatement(
+          'CREATE INDEX idx_user_businesses_business_lua '
+          'ON user_businesses (business_id, last_updated_at)',
+        );
+        await customStatement('DROP INDEX IF EXISTS idx_user_businesses_user');
+        await customStatement(
+          'CREATE INDEX idx_user_businesses_user ON user_businesses (user_id)',
+        );
+        await customStatement(
+          'DROP TRIGGER IF EXISTS bump_user_businesses_last_updated_at',
+        );
+        await customStatement(
+          'CREATE TRIGGER bump_user_businesses_last_updated_at '
+          'AFTER UPDATE ON user_businesses '
+          'FOR EACH ROW '
+          'WHEN OLD.last_updated_at IS NEW.last_updated_at '
+          'BEGIN '
+          "UPDATE user_businesses SET last_updated_at = CAST(strftime('%s', 'now') AS INTEGER) WHERE id = OLD.id; "
+          'END',
+        );
+
+        // (2) Seed the staff.remove permission key. CEO-only by default; the CEO
+        //     grant arrives from the cloud via pull (CEO backfill in 0149). Hidden
+        //     from nothing — it is a grantable Staff permission (the CEO can grant
+        //     it to a Manager). Idempotent — key is the PK. Mirrors the v48
+        //     settings.delete_business seed pattern.
+        await customStatement(
+          "INSERT OR IGNORE INTO permissions (key, description, category) "
+          "VALUES ('staff.remove', "
+          "'Permanently remove staff (frees their email)', 'Staff')",
+        );
+      }
     },
     beforeOpen: (details) async {
       await customStatement('PRAGMA foreign_keys = ON');
@@ -4195,7 +4251,7 @@ const List<String> _v13HotPathIndexStatements = [
 // Identical on every device and on the cloud (mirror this list in
 // supabase/migrations/0043_seed_permissions_and_backfill_businesses.sql).
 // Each row: (key, description, category). Category groups toggles in
-// the CEO Settings > Roles & Permissions sub-page. 38 keys total.
+// the CEO Settings > Roles & Permissions sub-page. 39 keys total.
 const List<List<String>> _defaultPermissionRows = [
   // Stores — rendered first on the role page (§10.2). CEO-only by default.
   ['stores.manage', 'Add, edit, and remove stores', 'Stores'],
@@ -4260,6 +4316,9 @@ const List<List<String>> _defaultPermissionRows = [
   ['staff.suspend', 'Suspend or reactivate staff', 'Staff'],
   ['staff.change_role', 'Change a staff member\'s role', 'Staff'],
   ['staff.assign_stores', 'Assign staff to stores', 'Staff'],
+  // #107 staff offboarding. CEO-only by default; cloud catalog + CEO backfill:
+  // 0149. The key exists everywhere before any grant syncs (role_permissions FK).
+  ['staff.remove', 'Permanently remove staff (frees their email)', 'Staff'],
   // System
   ['activity_logs.view', 'View activity logs', 'System'],
   ['sync.view', 'View sync issues', 'System'],

--- a/lib/core/database/daos_org.dart
+++ b/lib/core/database/daos_org.dart
@@ -186,11 +186,14 @@ class UserBusinessesDao extends DatabaseAccessor<AppDatabase>
     return rows.map((r) => r.readTable(userBusinesses).userId).toList();
   }
 
-  /// All active memberships for the current business. Drives the
-  /// Staff Management list and the Who Is Working picker.
+  /// Memberships for the current business, excluding terminally-`removed` staff
+  /// (#107). Drives the Staff Management list and the Who Is Working picker.
+  /// Keeps `active` and `suspended` (both surface in Staff Management — suspended
+  /// greyed out); `removed` staff no longer appear in any active staff list,
+  /// though their users row is retained as an attribution stub for history.
   Stream<List<UserBusinessData>> watchForCurrentBusiness() {
     return (select(userBusinesses)
-          ..where((t) => whereBusiness(t))
+          ..where((t) => whereBusiness(t) & t.status.equals('removed').not())
           ..orderBy([(t) => OrderingTerm.asc(t.status)]))
         .watch();
   }
@@ -325,8 +328,26 @@ class UserBusinessesDao extends DatabaseAccessor<AppDatabase>
     await db.syncDao.enqueueUpsert('user_businesses', row);
   }
 
+  /// Sync-exempt local mirror of a server-confirmed removal (#107 offboarding).
+  /// The authoritative write is the `remove_staff_member` SECURITY DEFINER RPC
+  /// (see [AuthService.removeStaffMember]) — it sets the membership `removed` and
+  /// nulls the identity's cloud auth link atomically. This only reflects that
+  /// confirmed terminal status into the local row so the member drops out of the
+  /// active staff list immediately; a background pull converges the rest.
+  /// Deliberately does NOT enqueue: the RPC already wrote the cloud row, and the
+  /// §6 outbox must not re-push a status the server owns.
+  Future<void> markRemovedLocal(String membershipId) async {
+    await (update(
+      userBusinesses,
+    )..where((t) => t.id.equals(membershipId))).write(
+      const UserBusinessesCompanion(status: Value('removed')),
+    );
+  }
+
   /// Suspend or reactivate a membership. [status] is `'active'` or
-  /// `'suspended'` (matches the CHECK constraint). Enqueues the updated
+  /// `'suspended'` — the two non-terminal states. The terminal `'removed'`
+  /// state is NEVER set through this outbox path; it is server-authoritative
+  /// (see [markRemovedLocal] / `remove_staff_member`). Enqueues the updated
   /// row for sync.
   Future<void> setStatus(String membershipId, String status) async {
     await (update(

--- a/lib/core/permissions/gate_registry.dart
+++ b/lib/core/permissions/gate_registry.dart
@@ -487,6 +487,20 @@ abstract final class Gates {
     rule: Gate.key('staff.suspend'),
   );
 
+  /// Permanently remove a staff member (#107 staff offboarding, `staff.remove`,
+  /// CEO-only by default) — the staff-detail "Remove" action. Terminal: it runs
+  /// the server-authoritative `remove_staff_member` RPC, which nulls the
+  /// identity's auth link (freeing the email for a fresh business) and sets the
+  /// membership status to `removed`, while KEEPING the users row as an
+  /// attribution stub so historical sales still show the person's name. Removing
+  /// the business owner is rejected. More destructive than suspend, so it is
+  /// CEO-only by default (the CEO can grant it to a Manager via the role page).
+  static const NamedGate staffRemove = NamedGate(
+    name: 'staffRemove',
+    action: 'Remove Staff',
+    rule: Gate.key('staff.remove'),
+  );
+
   /// Refund a pending order (§19.7, `sales.cancel`, CEO + Manager by default) —
   /// the Orders Pending-tab Refund action, gated at render.
   static const NamedGate refundOrder = NamedGate(
@@ -590,6 +604,7 @@ abstract final class Gates {
     assignStaffStores,
     changeStaffRole,
     suspendStaff,
+    staffRemove,
     refundOrder,
     seeOrderMoney,
     seeExtendedDateRanges,

--- a/lib/core/settings/roles_permissions_screen.dart
+++ b/lib/core/settings/roles_permissions_screen.dart
@@ -84,11 +84,11 @@ class _RoleCard extends ConsumerWidget {
             .where((g) => !kHiddenPermissionKeys.contains(g.permissionKey))
             .length;
     // Derive the denominator from the global catalogue so it never goes stale
-    // if permission keys are added. Falls back to the seed count (38 minus the
+    // if permission keys are added. Falls back to the seed count (39 minus the
     // hidden keys) for the one frame before the catalogue stream resolves.
     final allPerms = ref.watch(allPermissionsProvider).valueOrNull;
     final total = allPerms == null
-        ? 38 - kHiddenPermissionKeys.length
+        ? 39 - kHiddenPermissionKeys.length
         : allPerms.where((p) => !kHiddenPermissionKeys.contains(p.key)).length;
     // CEO is locked all-on; show the full count regardless of sync state.
     final subtitle = isCeo

--- a/lib/features/staff/screens/staff_detail_screen.dart
+++ b/lib/features/staff/screens/staff_detail_screen.dart
@@ -13,6 +13,7 @@ import 'package:reebaplus_pos/core/utils/number_format.dart';
 import 'package:reebaplus_pos/core/utils/responsive.dart';
 import 'package:reebaplus_pos/features/profile/widgets/profile_ui.dart';
 import 'package:reebaplus_pos/features/staff/screens/staff_permissions_screen.dart';
+import 'package:reebaplus_pos/shared/services/auth_service.dart';
 import 'package:reebaplus_pos/shared/utils/role_display.dart';
 import 'package:reebaplus_pos/shared/widgets/app_button.dart';
 
@@ -351,6 +352,101 @@ class _StaffDetailScreenState extends ConsumerState<StaffDetailScreen> {
     }
   }
 
+  /// Permanently remove a staff member (#107 offboarding). Server-authoritative:
+  /// runs the `remove_staff_member` RPC via [AuthService.removeStaffMember],
+  /// which nulls the identity's cloud auth link (freeing their email for a fresh
+  /// business) and sets the membership `removed`, while KEEPING the users row as
+  /// an attribution stub so historical sales still show their name. The owner
+  /// cannot be removed, and you cannot remove yourself, so this is a terminal,
+  /// permitted-roles-only action gated on [Gates.staffRemove].
+  Future<void> _removeStaff(UserBusinessData membership, UserData user) async {
+    // Defense-in-depth (hard rule #6): re-check the specific permission before
+    // running, not only at button render.
+    if (!ref.read(currentUserPermissionsProvider).contains('staff.remove')) {
+      return;
+    }
+    // Owner protection: the original business creator can never be removed by
+    // anyone — including an appointed CEO. The RPC rejects it too; this is the
+    // client-side mirror so we never even fire the call.
+    final ownerId = ref.read(currentBusinessProvider)?.ownerId;
+    if (ownerId != null &&
+        user.authUserId != null &&
+        user.authUserId == ownerId) {
+      if (mounted) {
+        AppNotification.showError(context, 'You cannot remove the business owner.');
+      }
+      return;
+    }
+    // Self-removal is out of scope for #107 (that is self-resign, #117) and would
+    // orphan the actor's own membership through the admin path — reject it.
+    final currentUser = ref.read(authProvider).currentUser;
+    if (currentUser != null && membership.userId == currentUser.id) {
+      if (mounted) {
+        AppNotification.showError(context, 'You cannot remove yourself.');
+      }
+      return;
+    }
+
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        backgroundColor: Theme.of(context).colorScheme.surface,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(16),
+        ),
+        title: const Text('Remove staff?'),
+        content: Text(
+          '${user.name} will permanently lose access to this business and their '
+          'email is freed to start their own business.\n\n'
+          'Their past sales and records are kept and still show their name. This '
+          'cannot be undone — to bring them back you must invite them again.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, false),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            style: TextButton.styleFrom(
+              foregroundColor: Theme.of(ctx).colorScheme.error,
+            ),
+            child: const Text('Remove'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true) return;
+
+    try {
+      await ref.read(authProvider).removeStaffMember(
+            businessId: membership.businessId,
+            userId: membership.userId,
+            membershipId: membership.id,
+          );
+      final db = ref.read(databaseProvider);
+      await db.activityLogDao.log(
+        action: 'staff.remove',
+        description: 'Removed staff member ${user.name}',
+        staffId: currentUser?.id,
+      );
+      if (!mounted) return;
+      // The membership is now `removed` and drops out of the active staff list,
+      // so this detail screen would render "not found" — return to the list.
+      Navigator.of(context).pop();
+      AppNotification.showSuccess(context, '${user.name} removed.');
+    } on StaffRemoveException catch (e) {
+      if (mounted) AppNotification.showError(context, e.message);
+    } catch (_) {
+      if (mounted) {
+        AppNotification.showError(
+          context,
+          'Could not remove this staff member. Please try again.',
+        );
+      }
+    }
+  }
+
   /// One-line summary of the staff member's assigned stores for the header pill.
   String _storeSummary(List<String> names) {
     if (names.isEmpty) return 'Unassigned';
@@ -647,17 +743,17 @@ class _StaffDetailScreenState extends ConsumerState<StaffDetailScreen> {
                 // Manage actions — hidden in view-only (own card). Each action
                 // has its OWN permission (§9): Change role -> staff.change_role,
                 // Suspend/Reactivate -> staff.suspend (both CEO + Manager by
-                // default; the CEO can revoke either independently). Hidden, not
-                // greyed (hard rule #7). The manageable→readOnly logic already
-                // restricts which staff a viewer can act on.
+                // default; the CEO can revoke either independently), Remove ->
+                // staff.remove (#107, CEO-only by default). Hidden, not greyed
+                // (hard rule #7). The manageable→readOnly logic already restricts
+                // which staff a viewer can act on, and the owner is never a target.
                 if (!widget.readOnly &&
-                    ((Gates.changeStaffRole.allows(ref) &&
-                            !isTargetOwner) ||
-                        (Gates.suspendStaff.allows(ref) &&
-                            !isTargetOwner))) ...[
+                    !isTargetOwner &&
+                    (Gates.changeStaffRole.allows(ref) ||
+                        Gates.suspendStaff.allows(ref) ||
+                        Gates.staffRemove.allows(ref))) ...[
                   SizedBox(height: context.getRSize(24)),
-                  if (Gates.changeStaffRole.allows(ref) &&
-                      !isTargetOwner) ...[
+                  if (Gates.changeStaffRole.allows(ref)) ...[
                     AppButton(
                       text: 'Change role',
                       icon: FontAwesomeIcons.userGear.data,
@@ -667,7 +763,7 @@ class _StaffDetailScreenState extends ConsumerState<StaffDetailScreen> {
                     ),
                     SizedBox(height: context.getRSize(12)),
                   ],
-                  if (Gates.suspendStaff.allows(ref) && !isTargetOwner)
+                  if (Gates.suspendStaff.allows(ref)) ...[
                     AppButton(
                       text: suspended ? 'Reactivate' : 'Suspend',
                       icon: suspended
@@ -677,6 +773,15 @@ class _StaffDetailScreenState extends ConsumerState<StaffDetailScreen> {
                           ? AppButtonVariant.success
                           : AppButtonVariant.danger,
                       onPressed: () => _toggleSuspend(membership),
+                    ),
+                    SizedBox(height: context.getRSize(12)),
+                  ],
+                  if (Gates.staffRemove.allows(ref))
+                    AppButton(
+                      text: 'Remove',
+                      icon: FontAwesomeIcons.userXmark.data,
+                      variant: AppButtonVariant.danger,
+                      onPressed: () => _removeStaff(membership, user),
                     ),
                 ],
               ],

--- a/lib/shared/services/auth_service.dart
+++ b/lib/shared/services/auth_service.dart
@@ -37,6 +37,17 @@ class DeleteBusinessException implements Exception {
   String toString() => message;
 }
 
+/// Thrown by [AuthService.removeStaffMember] (#107 staff offboarding) when the
+/// server-authoritative removal cannot proceed (offline, not permitted, owner
+/// target, member missing). Carries a plain-English [message] safe to show; no
+/// local state is changed when this is thrown.
+class StaffRemoveException implements Exception {
+  final String message;
+  const StaffRemoveException(this.message);
+  @override
+  String toString() => message;
+}
+
 class LogoutWipeException implements Exception {
   final String message;
   const LogoutWipeException(this.message);
@@ -1150,6 +1161,93 @@ class AuthService extends ValueNotifier<UserData?> {
       return 'Only the business owner can delete the business.';
     }
     return 'Could not delete your business. Please try again.';
+  }
+
+  /// Permanently removes a staff member (#107 staff offboarding). Server-
+  /// authoritative: the SECURITY DEFINER `remove_staff_member` RPC atomically
+  /// sets the target's membership status to `removed` AND nulls their cloud
+  /// `users.auth_user_id` — freeing the email so the one-email-one-business
+  /// guard passes and they can create a brand-new business — while KEEPING the
+  /// users row intact as an attribution stub (name / email / phone retained,
+  /// never hard-deleted) so every historical sale still shows the person's name.
+  /// The business owner cannot be removed (the RPC rejects it).
+  ///
+  /// Called DIRECTLY via `supabase.rpc`, NOT through the §6 outbox — like
+  /// [deleteBusinessAndAccount] — because the removal must be server-confirmed
+  /// and the §6 queue would retry it blindly. Online-only: it throws a
+  /// [StaffRemoveException] WITHOUT changing local state on any failure.
+  ///
+  /// On success it mirrors the confirmed `removed` status into the local
+  /// `user_businesses` row (sync-exempt, no enqueue — the RPC is the
+  /// authoritative writer, the same shape as the delete_business local wipe) so
+  /// the member drops out of the active staff list immediately, then schedules a
+  /// pull to converge the nulled auth link and any peer state.
+  // sync-exempt: §9/#107 — the cloud `remove_staff_member` RPC is the
+  // authoritative writer of both the membership status and the auth-link null;
+  // the local status mirror reflects a server-already-applied state, so there is
+  // nothing to enqueue. No raw synced-table write leaves the device here.
+  Future<void> removeStaffMember({
+    required String businessId,
+    required String userId,
+    required String membershipId,
+  }) async {
+    // Block offline up front — removal must be server-confirmed before anything
+    // local changes (mirrors [deleteBusinessAndAccount]); never queue it blindly.
+    if (!_sync.isOnline.value) {
+      throw const StaffRemoveException(
+        'You must be online to remove a staff member. '
+        'Connect to the internet and try again.',
+      );
+    }
+
+    try {
+      await _supabase.rpc(
+        'remove_staff_member',
+        params: {'p_business_id': businessId, 'p_user_id': userId},
+      );
+    } on PostgrestException catch (e) {
+      debugPrint(
+        '[AuthService] remove_staff_member RPC failed: ${e.code} ${e.message}',
+      );
+      throw StaffRemoveException(_removeStaffMessage(e));
+    } catch (e) {
+      debugPrint('[AuthService] remove_staff_member network error: $e');
+      throw const StaffRemoveException(
+        'Could not reach the server to remove this staff member. '
+        'Check your connection and try again.',
+      );
+    }
+
+    // The cloud confirmed the removal. Mirror the terminal status locally so the
+    // member drops out of the active staff list immediately (sync-exempt — no
+    // enqueue). A failure to mirror must NOT surface as an error: the
+    // authoritative removal already succeeded and the pull below still converges.
+    try {
+      await _db.userBusinessesDao.markRemovedLocal(membershipId);
+    } catch (e) {
+      debugPrint('[AuthService] removeStaffMember local mirror error: $e');
+    }
+    unawaited(_sync.pullChanges(businessId));
+  }
+
+  /// Maps a `remove_staff_member` RPC error to plain English.
+  String _removeStaffMessage(PostgrestException e) {
+    final msg = e.message;
+    if (msg.contains('cannot_remove_owner')) {
+      return 'You cannot remove the business owner.';
+    }
+    if (msg.contains('cannot_remove_self')) {
+      return 'You cannot remove yourself. Ask another manager or the owner.';
+    }
+    if (msg.contains('member_not_found')) {
+      return 'That staff member was not found.';
+    }
+    if (msg.contains('forbidden') ||
+        msg.contains('not_a_member') ||
+        e.code == '42501') {
+      return 'You do not have permission to remove this staff member.';
+    }
+    return 'Could not remove this staff member. Please try again.';
   }
 
   /// Resets a user's local PIN to setup-required so the OLD PIN can no longer

--- a/supabase/migrations/0149_remove_staff_member.sql
+++ b/supabase/migrations/0149_remove_staff_member.sql
@@ -1,0 +1,220 @@
+-- 0149_remove_staff_member.sql
+--
+-- Staff offboarding — core (issue #107). Three idempotent parts:
+--
+--   1a. Widen the public.user_businesses.status CHECK to admit the terminal
+--       `removed` state (was active/suspended only). Mirrors the client-side
+--       widening (schemaVersion 61 in lib/core/database/app_database.dart).
+--
+--   1b. Add the `staff.remove` permission to the global catalog and backfill the
+--       CEO grant for every existing business. The key MUST exist before any
+--       grant can sync (role_permissions.permission_key FK). CEO-only by default;
+--       it is a grantable Staff permission (the CEO can grant it to a Manager via
+--       the role page). New businesses get the CEO grant automatically through
+--       seed_default_roles_for_business's dynamic `SELECT key FROM permissions`,
+--       so that function needs no change (same as 0096 staff.assign_stores).
+--
+--   2.  Create public.remove_staff_member(p_business_id, p_user_id) — the
+--       server-authoritative removal. The app calls it DIRECTLY (supabase.rpc),
+--       NOT through the §6 sync outbox, exactly like delete_business, because it
+--       must be server-confirmed and the queue would retry it blindly. In one
+--       transaction it: (1) sets the membership status to `removed`, and (2) nulls
+--       the target identity's users.auth_user_id so the email frees up — the
+--       one-email-one-business guard in complete_onboarding (0121) and the
+--       existing-account router current_user_linked_business (0128) both key off
+--       users.auth_user_id, so nulling it lets the freed email create a brand-new
+--       business. The users row is KEPT intact as an Attribution Stub (name /
+--       email / phone retained, NEVER hard-deleted) so every historical sale still
+--       renders the person's name. The business owner can never be removed, and a
+--       caller cannot remove themselves (self-resign is #117, out of scope here).
+--
+-- NOTE: the issue references "ADR 0016", but that ADR file does not exist yet;
+-- this migration implements the acceptance criteria directly (no ADR is written
+-- here, to avoid colliding with open docs PRs).
+
+BEGIN;
+
+-- =========================================================================
+-- 1a. Widen the membership status CHECK: active | suspended | removed.
+--     The constraint is unnamed (inline in 0042), so drop it by its
+--     system-generated name via a catalog lookup, then re-add the widened
+--     form under a stable name. Idempotent: if a CHECK already admits
+--     `removed`, do nothing. Postgres alters a CHECK in place (no table
+--     rebuild, unlike SQLite), so there are no index/trigger concerns.
+-- =========================================================================
+DO $$
+DECLARE
+  v_conname text;
+  v_def     text;
+BEGIN
+  SELECT c.conname, pg_get_constraintdef(c.oid)
+    INTO v_conname, v_def
+    FROM pg_constraint c
+   WHERE c.conrelid = 'public.user_businesses'::regclass
+     AND c.contype  = 'c'
+     AND pg_get_constraintdef(c.oid) ILIKE '%status%'
+   LIMIT 1;
+
+  -- Already widened (idempotent re-run) — nothing to do.
+  IF v_def IS NOT NULL AND v_def ILIKE '%removed%' THEN
+    RETURN;
+  END IF;
+
+  IF v_conname IS NOT NULL THEN
+    EXECUTE format(
+      'ALTER TABLE public.user_businesses DROP CONSTRAINT %I', v_conname
+    );
+  END IF;
+
+  ALTER TABLE public.user_businesses
+    ADD CONSTRAINT user_businesses_status_check
+    CHECK (status IN ('active','suspended','removed'));
+END $$;
+
+-- =========================================================================
+-- 1b. staff.remove permission — catalog + CEO backfill. last_updated_at =
+--     now() on the grant so the incremental pull (0048) ships it to devices.
+-- =========================================================================
+INSERT INTO public.permissions (key, description, category) VALUES
+  ('staff.remove', 'Permanently remove staff (frees their email)', 'Staff')
+ON CONFLICT (key) DO NOTHING;
+
+INSERT INTO public.role_permissions (business_id, role_id, permission_key, last_updated_at)
+  SELECT business_id, id, 'staff.remove', now()
+    FROM public.roles
+   WHERE slug = 'ceo'
+ON CONFLICT (role_id, permission_key) DO NOTHING;
+
+-- =========================================================================
+-- 2. remove_staff_member(p_business_id, p_user_id) — server-authoritative.
+-- =========================================================================
+CREATE OR REPLACE FUNCTION public.remove_staff_member(
+  p_business_id uuid,
+  p_user_id     uuid
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+DECLARE
+  v_auth_uid    uuid := auth.uid();
+  v_owner_id    uuid;
+  v_target_auth uuid;
+  v_membership  uuid;
+BEGIN
+  IF v_auth_uid IS NULL THEN
+    RAISE EXCEPTION 'unauthenticated'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  -- Authority gate: the caller must hold `staff.remove` in THIS business.
+  -- caller_has_permission (0135) resolves the caller by auth.uid(), returns
+  -- true for the CEO, else checks role_permissions + user_permission_overrides.
+  -- It only ever resolves the caller's OWN active membership, so a caller with
+  -- no active membership in p_business_id gets false — this also enforces
+  -- cross-business isolation (architecture invariant #5).
+  IF NOT public.caller_has_permission(p_business_id, 'staff.remove') THEN
+    RAISE EXCEPTION 'forbidden:not_permitted_to_remove_staff'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  -- Resolve the business owner + the target's identity up front.
+  SELECT owner_id INTO v_owner_id
+    FROM public.businesses WHERE id = p_business_id;
+
+  SELECT auth_user_id INTO v_target_auth
+    FROM public.users
+   WHERE id = p_user_id AND business_id = p_business_id;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'member_not_found'
+      USING ERRCODE = 'no_data_found';
+  END IF;
+
+  -- Owner protection: the business owner can never be removed. owner_id holds
+  -- the owner's auth.uid() (set at onboarding, backfilled by 0028); compare it
+  -- to the target's (still-present) auth link.
+  IF v_owner_id IS NOT NULL AND v_target_auth IS NOT NULL
+     AND v_target_auth = v_owner_id THEN
+    RAISE EXCEPTION 'cannot_remove_owner'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  -- Self-removal is out of scope (that is self-resign, #117) and would orphan
+  -- the actor's own membership through the admin path — reject it.
+  IF v_target_auth IS NOT NULL AND v_target_auth = v_auth_uid THEN
+    RAISE EXCEPTION 'cannot_remove_self'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  -- (1) Terminal membership status. Stamp last_updated_at so the incremental
+  --     pull ships it to every device (the client also mirrors it locally).
+  UPDATE public.user_businesses
+     SET status = 'removed', last_updated_at = now()
+   WHERE business_id = p_business_id AND user_id = p_user_id
+  RETURNING id INTO v_membership;
+
+  IF v_membership IS NULL THEN
+    RAISE EXCEPTION 'member_not_found'
+      USING ERRCODE = 'no_data_found';
+  END IF;
+
+  -- (2) Free the email: null the identity's auth link. KEEP the users row
+  --     intact as an Attribution Stub — name / email / phone retained, NEVER
+  --     hard-deleted — so every historical sale still renders the person's
+  --     name. auth_user_id is cloud-RPC-set-only (off the client push
+  --     whitelist), so this definer-side null is the authoritative writer.
+  UPDATE public.users
+     SET auth_user_id = NULL, last_updated_at = now()
+   WHERE id = p_user_id AND business_id = p_business_id;
+
+  RETURN jsonb_build_object(
+    'ok', true,
+    'business_id', p_business_id,
+    'user_id', p_user_id,
+    'membership_id', v_membership
+  );
+END;
+$$;
+
+REVOKE ALL    ON FUNCTION public.remove_staff_member(uuid, uuid) FROM public;
+GRANT EXECUTE ON FUNCTION public.remove_staff_member(uuid, uuid) TO authenticated, service_role;
+
+COMMIT;
+
+-- =============================================================================
+-- Verification (run by hand after deploy):
+--
+--   1. CHECK widened:
+--      SELECT pg_get_constraintdef(c.oid)
+--        FROM pg_constraint c
+--       WHERE c.conrelid = 'public.user_businesses'::regclass
+--         AND c.contype = 'c';
+--      -- expect: CHECK (status IN ('active','suspended','removed'))
+--
+--   2. Permission seeded + CEO-only grant:
+--      SELECT COUNT(*) FROM public.permissions WHERE key = 'staff.remove'; -- 1
+--      SELECT r.slug, COUNT(*) FROM public.roles r
+--        JOIN public.role_permissions rp ON rp.role_id = r.id
+--       WHERE rp.permission_key = 'staff.remove'
+--       GROUP BY r.slug;  -- expect only ceo, one per business
+--
+--   3. RPC exists with the right signature:
+--      SELECT pg_get_function_arguments(oid)
+--        FROM pg_proc
+--       WHERE proname = 'remove_staff_member'
+--         AND pronamespace = 'public'::regnamespace;
+--      -- expect: p_business_id uuid, p_user_id uuid
+--
+--   4. Owner removal is rejected, a non-owner member is removed + email freed
+--      (as a signed-in CEO):
+--      SELECT public.remove_staff_member('<business>', '<owner_user_id>');
+--        -- expect: ERROR cannot_remove_owner
+--      SELECT public.remove_staff_member('<business>', '<staff_user_id>');
+--        -- expect: {"ok": true, ...}; then:
+--      SELECT status FROM public.user_businesses WHERE user_id = '<staff_user_id>';
+--        -- expect: removed
+--      SELECT auth_user_id, name, email FROM public.users WHERE id = '<staff_user_id>';
+--        -- expect: auth_user_id NULL; name + email still present (stub kept)
+-- =============================================================================

--- a/test/database/migration_upgrade_test.dart
+++ b/test/database/migration_upgrade_test.dart
@@ -851,4 +851,132 @@ void main() {
       );
     });
   });
+
+  group('onUpgrade v60 → v61 (staff.remove permission + `removed` status CHECK, '
+      '#107)', () {
+    Future<int> permCount(AppDatabase db) async {
+      final r = await db
+          .customSelect(
+            "SELECT COUNT(*) c FROM permissions WHERE key = 'staff.remove'",
+          )
+          .getSingle();
+      return r.read<int>('c');
+    }
+
+    Future<bool> objectExists(AppDatabase db, String type, String name) async {
+      final r = await db
+          .customSelect(
+            "SELECT 1 FROM sqlite_master WHERE type='$type' AND name='$name'",
+          )
+          .get();
+      return r.isNotEmpty;
+    }
+
+    test(
+        're-seeds staff.remove AND widens the user_businesses.status CHECK to '
+        'admit `removed` (index + bump trigger recreated)', () async {
+      final biz = UuidV7.generate();
+      final userId = UuidV7.generate();
+      final roleId = UuidV7.generate();
+
+      final db1 = await openAndInit();
+
+      // FK targets for the membership inserted after the upgrade — must survive
+      // the user_businesses revert below (only that table is dropped).
+      await db1.customStatement(
+        "INSERT INTO businesses (id, name) VALUES (?, 'Biz')",
+        [biz],
+      );
+      await db1.customStatement(
+        "INSERT INTO roles (id, business_id, name, slug) "
+        "VALUES (?, ?, 'CEO', 'ceo')",
+        [roleId, biz],
+      );
+      await db1.customStatement(
+        "INSERT INTO users (id, business_id, name, pin) "
+        "VALUES (?, ?, 'Rita', '__H__')",
+        [userId, biz],
+      );
+
+      // A fresh v61 DB already seeds staff.remove in onCreate (it's in
+      // _defaultPermissionRows) — delete it so the v61 block has work to do.
+      await db1.customStatement(
+        "DELETE FROM permissions WHERE key = 'staff.remove'",
+      );
+      expect(await permCount(db1), 0);
+
+      // Revert user_businesses to the OLD 2-value CHECK so the widening has
+      // teeth. Drop + recreate with the pre-v61 constraint; the column NAMES
+      // match the Drift schema, so the migration's TableMigration copy works.
+      await db1.customStatement('PRAGMA foreign_keys = OFF');
+      await db1.customStatement('DROP TABLE IF EXISTS user_businesses');
+      await db1.customStatement(
+        'CREATE TABLE user_businesses ('
+        'id TEXT NOT NULL PRIMARY KEY, business_id TEXT NOT NULL, '
+        'user_id TEXT NOT NULL, role_id TEXT NOT NULL, '
+        "status TEXT NOT NULL DEFAULT 'active', last_login_at INTEGER, "
+        'created_at INTEGER NOT NULL DEFAULT 0, '
+        'last_updated_at INTEGER NOT NULL DEFAULT 0, '
+        "CHECK (status IN ('active','suspended')), "
+        'UNIQUE (user_id, business_id))',
+      );
+      await db1.customStatement('PRAGMA foreign_keys = ON');
+
+      // Before the upgrade, the old 2-value CHECK rejects `removed`.
+      await expectLater(
+        db1.customStatement(
+          'INSERT INTO user_businesses '
+          '(id, business_id, user_id, role_id, status) '
+          "VALUES (?, ?, ?, ?, 'removed')",
+          [UuidV7.generate(), biz, userId, roleId],
+        ),
+        throwsA(anything),
+        reason: 'the pre-v61 2-value CHECK must reject `removed`',
+      );
+
+      await db1.customStatement('PRAGMA user_version = 60');
+      await db1.close();
+
+      // Re-open → onUpgrade(60 → 61).
+      final db2 = await openAndInit();
+      addTearDown(db2.close);
+
+      // (1) permission catalog re-seeded.
+      expect(await permCount(db2), 1, reason: 'v61 must seed staff.remove');
+
+      // (2) the widened CHECK now accepts `removed`.
+      await db2.customStatement(
+        'INSERT INTO user_businesses '
+        '(id, business_id, user_id, role_id, status) '
+        "VALUES (?, ?, ?, ?, 'removed')",
+        [UuidV7.generate(), biz, userId, roleId],
+      );
+      final row = await db2
+          .customSelect(
+            'SELECT status FROM user_businesses WHERE user_id = ?',
+            variables: [Variable<String>(userId)],
+          )
+          .getSingle();
+      expect(row.read<String>('status'), 'removed');
+
+      // (3) the rebuild recreated the sync cursor index + bump trigger, so a
+      //     fresh install (onCreate) and an upgrade converge.
+      expect(
+        await objectExists(db2, 'index', 'idx_user_businesses_business_lua'),
+        isTrue,
+        reason: 'v61 must recreate the (business_id, last_updated_at) index',
+      );
+      expect(
+        await objectExists(db2, 'index', 'idx_user_businesses_user'),
+        isTrue,
+        reason: 'v61 must recreate the user_id hot-path index',
+      );
+      expect(
+        await objectExists(
+            db2, 'trigger', 'bump_user_businesses_last_updated_at'),
+        isTrue,
+        reason: 'v61 must recreate the last_updated_at bump trigger',
+      );
+    });
+  });
 }

--- a/test/database/roles_v13_seed_test.dart
+++ b/test/database/roles_v13_seed_test.dart
@@ -2,7 +2,7 @@
 //
 // Verifies schema v13 (PIVOT_PLAN step 2):
 //   * The seven new tables exist.
-//   * The global `permissions` table is seeded with 38 rows (the live
+//   * The global `permissions` table is seeded with 39 rows (the live
 //     catalogue grows over time; the fresh-seed matrix below is a frozen
 //     v13/0043 baseline and intentionally does not track newer keys).
 //   * A fresh business gets 4 roles (with the right slugs), 65
@@ -62,10 +62,10 @@ void main() {
       );
     });
 
-    test('permissions table seeded with 38 default rows on fresh install',
+    test('permissions table seeded with 39 default rows on fresh install',
         () async {
       final perms = await db.permissionsDao.getAll();
-      expect(perms.length, equals(38));
+      expect(perms.length, equals(39));
 
       // Spot-check a few keys + categories.
       final keys = perms.map((p) => p.key).toSet();
@@ -74,6 +74,7 @@ void main() {
       expect(keys.contains('expenses.approve'), isTrue);
       expect(keys.contains('settings.manage'), isTrue);
       expect(keys.contains('settings.delete_business'), isTrue);
+      expect(keys.contains('staff.remove'), isTrue); // #107 staff offboarding
       expect(keys.contains('stores.manage'), isTrue); // §10.2
       expect(keys.contains('stores.request_transfer'), isTrue); // §16.8.2
       expect(keys.contains('stores.dispatch_transfer'), isTrue); // §16.8.2

--- a/test/settings/role_permissions_detail_test.dart
+++ b/test/settings/role_permissions_detail_test.dart
@@ -155,7 +155,7 @@ void main() {
 
     final switches =
         tester.widgetList<SwitchListTile>(find.byType(SwitchListTile)).toList();
-    expect(switches.length, 35, reason: 'all 35 permissions shown');
+    expect(switches.length, 36, reason: 'all 36 permissions shown');
     expect(
       switches.every((s) => s.onChanged == null && s.value == true),
       isTrue,

--- a/test/settings/roles_permissions_screen_test.dart
+++ b/test/settings/roles_permissions_screen_test.dart
@@ -121,8 +121,8 @@ void main() {
     expect(find.text('Cashier'), findsOneWidget);
     expect(find.text('Stock keeper'), findsOneWidget);
 
-    expect(find.text('All 35 permissions'), findsOneWidget); // CEO, locked
-    expect(find.text('2 of 35 permissions'), findsOneWidget); // Cashier
+    expect(find.text('All 36 permissions'), findsOneWidget); // CEO, locked
+    expect(find.text('2 of 36 permissions'), findsOneWidget); // Cashier
   });
 
   testWidgets('tapping a role card opens its detail', (tester) async {

--- a/test/staff/staff_removal_test.dart
+++ b/test/staff/staff_removal_test.dart
@@ -1,0 +1,153 @@
+// staff_removal_test.dart
+//
+// Staff offboarding — core (#107). Client-side behaviour of the terminal
+// `removed` membership status. The removal itself is a server-authoritative RPC
+// (remove_staff_member); these assertions cover what the client is responsible
+// for once that RPC has confirmed:
+//
+//   * the widened user_businesses.status CHECK admits `removed` (fresh onCreate
+//     builds the 3-value constraint from customConstraints);
+//   * UserBusinessesDao.watchForCurrentBusiness excludes `removed` staff while
+//     keeping `active` + `suspended` (they still surface in Staff Management);
+//   * UserBusinessesDao.markRemovedLocal mirrors the confirmed `removed` status
+//     WITHOUT enqueuing (sync-exempt — the RPC owns the cloud write), and leaves
+//     the users row intact as an attribution stub (name / email / phone kept).
+
+import 'package:drift/drift.dart';
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reebaplus_pos/core/database/app_database.dart';
+import 'package:reebaplus_pos/core/database/uuid_v7.dart';
+
+void main() {
+  late AppDatabase db;
+  late String biz;
+  late String ceoRoleId;
+  late String cashierRoleId;
+
+  setUp(() async {
+    db = AppDatabase.forTesting(NativeDatabase.memory());
+    biz = UuidV7.generate();
+    await db.into(db.businesses).insert(
+          BusinessesCompanion.insert(id: Value(biz), name: 'Biz'),
+        );
+    ceoRoleId = UuidV7.generate();
+    cashierRoleId = UuidV7.generate();
+    await db.into(db.roles).insert(RolesCompanion.insert(
+        id: Value(ceoRoleId), businessId: biz, name: 'CEO', slug: 'ceo'));
+    await db.into(db.roles).insert(RolesCompanion.insert(
+        id: Value(cashierRoleId),
+        businessId: biz,
+        name: 'Cashier',
+        slug: 'cashier'));
+  });
+
+  tearDown(() => db.close());
+
+  Future<String> addUser(
+    String name, {
+    String? email,
+    String? phone,
+  }) async {
+    final id = UuidV7.generate();
+    await db.into(db.users).insert(UsersCompanion.insert(
+          id: Value(id),
+          businessId: biz,
+          name: name,
+          pin: '__HASHED__',
+          email: Value(email),
+          phone: Value(phone),
+        ));
+    return id;
+  }
+
+  Future<String> addMembership(
+    String userId,
+    String roleId, {
+    String status = 'active',
+  }) async {
+    final id = UuidV7.generate();
+    await db.into(db.userBusinesses).insert(UserBusinessesCompanion.insert(
+          id: Value(id),
+          businessId: biz,
+          userId: userId,
+          roleId: roleId,
+          status: Value(status),
+        ));
+    return id;
+  }
+
+  test('the widened status CHECK admits `removed` (and rejects bogus values)',
+      () async {
+    final u = await addUser('Removed Rita');
+    // Accepts the new terminal state on a fresh (onCreate) schema.
+    await addMembership(u, cashierRoleId, status: 'removed');
+    final row = await (db.select(db.userBusinesses)
+          ..where((t) => t.userId.equals(u)))
+        .getSingle();
+    expect(row.status, 'removed');
+
+    // A value outside {active, suspended, removed} is still rejected.
+    await expectLater(
+      addMembership(await addUser('Bad Status'), cashierRoleId,
+          status: 'archived'),
+      throwsA(isA<Exception>()),
+    );
+  });
+
+  test('watchForCurrentBusiness excludes `removed`, keeps active + suspended',
+      () async {
+    db.businessIdResolver = () => biz;
+
+    final active = await addUser('Active Amara');
+    final suspended = await addUser('Suspended Sade');
+    final removed = await addUser('Removed Rita');
+    await addMembership(active, ceoRoleId);
+    await addMembership(suspended, cashierRoleId, status: 'suspended');
+    await addMembership(removed, cashierRoleId, status: 'removed');
+
+    final rows = await db.userBusinessesDao.watchForCurrentBusiness().first;
+    final userIds = rows.map((r) => r.userId).toSet();
+
+    expect(userIds, containsAll(<String>[active, suspended]));
+    expect(userIds.contains(removed), isFalse,
+        reason: 'removed staff must not appear in the active staff list');
+    expect(rows, hasLength(2));
+  });
+
+  test(
+      'markRemovedLocal sets `removed`, keeps the users attribution stub, and '
+      'does NOT enqueue (sync-exempt)', () async {
+    final u = await addUser('Removed Rita',
+        email: 'rita@example.com', phone: '08030000000');
+    final membershipId = await addMembership(u, cashierRoleId);
+
+    // A raw insert does not enqueue, so the outbox starts empty.
+    expect(await _syncQueueCount(db), 0);
+
+    await db.userBusinessesDao.markRemovedLocal(membershipId);
+
+    final membership = await (db.select(db.userBusinesses)
+          ..where((t) => t.id.equals(membershipId)))
+        .getSingle();
+    expect(membership.status, 'removed');
+
+    // Attribution stub: the users row is retained with name / email / phone.
+    final user =
+        await (db.select(db.users)..where((t) => t.id.equals(u))).getSingle();
+    expect(user.name, 'Removed Rita');
+    expect(user.email, 'rita@example.com');
+    expect(user.phone, '08030000000');
+
+    // Sync-exempt: the RPC is the authoritative writer, so nothing is queued.
+    expect(await _syncQueueCount(db), 0,
+        reason: 'markRemovedLocal must not enqueue a sync_queue row');
+  });
+}
+
+Future<int> _syncQueueCount(AppDatabase db) async {
+  final r = await db
+      .customSelect('SELECT COUNT(*) c FROM sync_queue')
+      .getSingle();
+  return r.read<int>('c');
+}


### PR DESCRIPTION
## Issue #107 — Staff offboarding: core + admin Remove (frees email, keeps attribution)

Adds staff offboarding: a terminal `removed` membership status and a server-authoritative `remove_staff_member` RPC that frees the person's email for a brand-new business while preserving their name on every historical record.

> **ADR note:** the issue references "ADR 0016", but that file does **not** exist in `docs/adr/`. Implemented directly from the acceptance criteria; **no ADR markdown file was written** (to avoid colliding with open docs PRs).

> **Migration number used: `0149`** (`supabase/migrations/0149_remove_staff_member.sql`) — verified free before use (highest existing was 0148). **Not yet deployed** — it deploys on merge via the normal `supabase db push` flow.

### Acceptance criteria

- ✅ **New terminal status `removed` on client + cloud (checks widened to active/suspended/removed).** Client: `UserBusinesses.customConstraints` widened + a `schemaVersion` 61 `onUpgrade` step rebuilds the table via `m.alterTable(TableMigration(...))` (customConstraints is runtime-resolved, so no `build_runner` regen). Cloud: 0149 drops the old inline CHECK and re-adds `CHECK (status IN ('active','suspended','removed'))`.
- ✅ **Server-authoritative op nulls the auth link + sets `removed` atomically; not routed through the outbox.** `remove_staff_member(p_business_id, p_user_id)` is a single-transaction `SECURITY DEFINER` RPC. `AuthService.removeStaffMember` calls it directly via `supabase.rpc(...)` (online-only, like `delete_business`), then mirrors the confirmed status locally (sync-exempt, no enqueue) and pulls.
- ✅ **Freed email can create a brand-new business (one-email-one-business passes).** The RPC nulls `public.users.auth_user_id`, which is exactly the key the `complete_onboarding` guard (0121) and the `current_user_linked_business` router (0128) test — so the guard passes and the existing-account router no longer detects a link.
- ✅ **Historical records still show the removed person's name (Attribution Stub).** The RPC keeps the `users` row intact (name/email/phone retained; `auth_user_id` set NULL only) and never hard-deletes it, so `orders.staff_id → users.id` still resolves the name.
- ✅ **New `staff.remove` gate; admin "Remove" shows only for permitted roles; removing the owner is rejected.** `Gates.staffRemove` (key `staff.remove`); gated Remove action in `staff_detail_screen.dart`. `staff.remove` seeded into the cloud `permissions` catalog + CEO-only backfill in 0149 (FK-safe) and the local `_defaultPermissionRows` + a v61 seed. Server authority = `caller_has_permission(business, 'staff.remove')` (CEO-true, else role_permissions + overrides). Owner removal is rejected in the RPC (`cannot_remove_owner`) and mirrored client-side; self-removal is rejected too (self-resign is #117).
- ✅ **Removed staff no longer appear in active staff lists.** `UserBusinessesDao.watchForCurrentBusiness()` (drives Staff Management + the `userBusinessesProvider`) now excludes `status == 'removed'` while keeping `active` + `suspended`. All other staff-list queries already filter `status == 'active'`.

### Files changed

- `lib/core/database/app_database.dart` — widen `UserBusinesses` status CHECK; `schemaVersion` 60→61 + v61 onUpgrade (TableMigration rebuild + `staff.remove` seed); add `staff.remove` to `_defaultPermissionRows`.
- `lib/core/database/daos_org.dart` — `watchForCurrentBusiness` excludes `removed`; new sync-exempt `markRemovedLocal`.
- `lib/shared/services/auth_service.dart` — `removeStaffMember` RPC call + `StaffRemoveException`.
- `lib/features/staff/screens/staff_detail_screen.dart` — gated "Remove" action (owner/self rejected).
- `lib/core/permissions/gate_registry.dart` — `Gates.staffRemove` (+ registry list).
- `lib/core/settings/roles_permissions_screen.dart` — seed-count fallback 38→39.
- `supabase/migrations/0149_remove_staff_member.sql` — cloud CHECK widen + `staff.remove` catalog/backfill + `remove_staff_member` RPC.
- Tests: `test/staff/staff_removal_test.dart` (new), `test/database/migration_upgrade_test.dart` (v60→v61 group), `test/database/roles_v13_seed_test.dart` (38→39), `test/settings/roles_permissions_screen_test.dart` + `role_permissions_detail_test.dart` (35→36 visible).

### Verification

- `dart analyze` on all 6 changed lib files: **No issues found.**
- `flutter test test/staff test/permissions test/database test/settings test/sync/sync_registry_golden_test.dart test/sync/dispatch/staff_dao_dispatch_test.dart`: **173 passed, 0 failed.** The new v60→v61 migration group also exercises the user_businesses rebuild inside every existing revert-then-re-upgrade scenario — all green.
- One unrelated pre-existing failure: `test/auth/who_is_working_screen_test.dart` (a network-dependent widget test) fails **identically on `origin/main`** (same `deleted_businesses check failed` `PostgrestException(400)` in the offline sandbox) — not touched by this change.
