### PR TITLE
feat(pos): one-shot barcode scanning + remove cart FAB (#118)

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -3,6 +3,10 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
     <uses-permission android:name="android.permission.USE_BIOMETRIC"/>
 
+    <!-- Camera: product photos (image_picker) and POS barcode scanning
+         (mobile_scanner, #118). Requested at runtime on first use. -->
+    <uses-permission android:name="android.permission.CAMERA"/>
+
     <!-- Photo gallery access for product images (pre-API 33 only) -->
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"
         android:maxSdkVersion="32" />

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -61,7 +61,7 @@
 	<key>NSBluetoothPeripheralUsageDescription</key>
 	<string>Reebaplus POS uses Bluetooth to connect to thermal receipt printers.</string>
 	<key>NSCameraUsageDescription</key>
-	<string>Reebaplus POS needs camera access to take product photos.</string>
+	<string>Reebaplus POS needs camera access to take product photos and scan product barcodes.</string>
 	<key>NSFaceIDUsageDescription</key>
 	<string>Reebaplus POS uses Face ID to unlock the app.</string>
 	<key>NSPhotoLibraryUsageDescription</key>

--- a/lib/features/inventory/screens/add_product_screen.dart
+++ b/lib/features/inventory/screens/add_product_screen.dart
@@ -38,10 +38,16 @@ import 'package:reebaplus_pos/features/payments/widgets/supplier_form_sheet.dart
 class AddProductScreen extends ConsumerStatefulWidget {
   final void Function(ProductData)? onProductAdded;
   final bool receiveMode;
+
+  /// Optional barcode to pre-fill the Barcode field with (#118). Set when this
+  /// screen is opened from a POS scan of an unknown barcode, so the cashier can
+  /// catalogue the just-scanned product without retyping the code.
+  final String? prefilledBarcode;
   const AddProductScreen({
     super.key,
     this.onProductAdded,
     this.receiveMode = false,
+    this.prefilledBarcode,
   });
 
   @override
@@ -135,6 +141,10 @@ class _AddProductScreenState extends ConsumerState<AddProductScreen> {
     _unit = _lexicon.unit;
     _dynamicUnits = _lexicon.starterUnits;
     _trackEmpties = _unit.toLowerCase() == 'bottle';
+    // #118: seed the Barcode field from a POS scan of an unknown code so the
+    // cashier catalogues the just-scanned product without retyping it.
+    final prefillBarcode = widget.prefilledBarcode?.trim() ?? '';
+    if (prefillBarcode.isNotEmpty) _barcodeCtrl.text = prefillBarcode;
     _loadData();
   }
 

--- a/lib/features/pos/providers/pos_providers.dart
+++ b/lib/features/pos/providers/pos_providers.dart
@@ -1,0 +1,11 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:reebaplus_pos/features/pos/services/barcode_scanner.dart';
+import 'package:reebaplus_pos/features/pos/services/mobile_scanner_barcode_scanner.dart';
+
+/// The active barcode scanner (#118). Production resolves to the camera-backed
+/// [MobileScannerBarcodeScanner]; tests override this with a fake so the scan
+/// flow can be driven without a camera.
+final barcodeScannerProvider = Provider<BarcodeScanner>(
+  (_) => const MobileScannerBarcodeScanner(),
+);

--- a/lib/features/pos/screens/pos_home_screen.dart
+++ b/lib/features/pos/screens/pos_home_screen.dart
@@ -3,7 +3,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:reebaplus_pos/core/database/app_database.dart';
 import 'package:reebaplus_pos/core/permissions/permissions.dart';
 import 'package:reebaplus_pos/core/providers/app_providers.dart';
-import 'package:reebaplus_pos/core/widgets/app_fab.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 
 import 'package:reebaplus_pos/core/utils/responsive.dart';
@@ -19,6 +18,7 @@ import 'package:reebaplus_pos/features/pos/controllers/pos_controller.dart';
 import 'package:reebaplus_pos/features/pos/widgets/product_grid.dart';
 import 'package:reebaplus_pos/features/pos/widgets/category_filter_bar.dart';
 import 'package:reebaplus_pos/features/pos/widgets/quick_sale_modal.dart';
+import 'package:reebaplus_pos/features/pos/widgets/pos_barcode_scan_button.dart';
 import 'package:reebaplus_pos/core/utils/notifications.dart';
 import 'package:reebaplus_pos/shared/widgets/app_refresh_wrapper.dart';
 
@@ -240,7 +240,6 @@ class _PosHomeScreenState extends ConsumerState<PosHomeScreen> {
           activeRoute: 'pos',
           backgroundColor: bgCol,
           appBar: _buildAppBar(context, surfaceCol, textCol, subtextCol),
-          floatingActionButton: context.isPhone ? _buildCartFab(context) : null,
           body: SafeArea(
             top: false,
             // Pull-to-refresh wraps the WHOLE body (above the header) so the
@@ -493,6 +492,11 @@ class _PosHomeScreenState extends ConsumerState<PosHomeScreen> {
         truncateTitleWithReveal: true,
       ),
       actions: [
+        // #118: always-visible one-shot barcode scan. Not gated on the cart.
+        PosBarcodeScanButton(
+          tier: _controller!.selectedGroup,
+          loadedProducts: _controller!.allProducts,
+        ),
         IconButton(
           icon: Icon(
             _isListView ? FontAwesomeIcons.list.data : FontAwesomeIcons.borderAll.data,
@@ -600,51 +604,6 @@ class _PosHomeScreenState extends ConsumerState<PosHomeScreen> {
           color: Theme.of(context).colorScheme.primary,
         ),
       ),
-    );
-  }
-
-  Widget _buildCartFab(BuildContext context) {
-    return ValueListenableBuilder<List<Map<String, dynamic>>>(
-      valueListenable: ref.read(cartProvider),
-      builder: (context, cartItems, _) {
-        if (cartItems.isEmpty) return const SizedBox.shrink();
-
-        final double totalQty = cartItems.fold(
-          0.0,
-          (sum, item) => sum + (item['qty'] as num).toDouble(),
-        );
-        final String badgeText = totalQty == totalQty.roundToDouble()
-            ? totalQty.toInt().toString()
-            : totalQty.toStringAsFixed(1);
-
-        return AppFAB(
-          // POS is a bottom-nav tab root — the visible bottom bar already lifts
-          // the FAB above the system nav; don't add the inset.
-          reserveBottomInset: false,
-          onPressed: () {
-            ref
-                .read(navigationProvider)
-                .setIndex(8); // 8 = CartScreen (9 is Deliveries)
-          },
-          icon: FontAwesomeIcons.cartShopping.data,
-          label: 'Go to Cart',
-          trailing: Container(
-            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-            decoration: BoxDecoration(
-              color: Colors.white,
-              borderRadius: BorderRadius.circular(12),
-            ),
-            child: Text(
-              badgeText,
-              style: TextStyle(
-                color: Theme.of(context).colorScheme.primary,
-                fontWeight: FontWeight.bold,
-                fontSize: 12,
-              ),
-            ),
-          ),
-        );
-      },
     );
   }
 

--- a/lib/features/pos/services/barcode_scanner.dart
+++ b/lib/features/pos/services/barcode_scanner.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/widgets.dart';
+
+/// A thin seam over the device camera barcode scanner (#118).
+///
+/// One-shot by contract: [scanOnce] opens the camera, returns the FIRST decoded
+/// barcode, then closes the scanner. A `null` result means the user dismissed
+/// the scanner (or camera permission was denied) without a scan — callers treat
+/// it as "cancelled" and do nothing.
+///
+/// The camera lives behind this interface so widget/unit tests inject a fake
+/// (returning a canned code) instead of driving a real camera, which cannot run
+/// headless. The production implementation is [MobileScannerBarcodeScanner].
+abstract class BarcodeScanner {
+  /// Presents a one-shot camera scanner and completes with the first scanned
+  /// barcode's raw value (trimmed, non-empty), or `null` if nothing was scanned.
+  Future<String?> scanOnce(BuildContext context);
+}

--- a/lib/features/pos/services/mobile_scanner_barcode_scanner.dart
+++ b/lib/features/pos/services/mobile_scanner_barcode_scanner.dart
@@ -1,0 +1,147 @@
+import 'package:flutter/material.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+import 'package:mobile_scanner/mobile_scanner.dart';
+
+import 'package:reebaplus_pos/features/pos/services/barcode_scanner.dart';
+
+/// The production [BarcodeScanner], backed by the device camera via
+/// `mobile_scanner` (#118). Pushes a full-screen one-shot scanner page and
+/// returns the first decoded barcode (or `null` if the user closed it).
+///
+/// Camera runtime permission is requested by `mobile_scanner` itself when the
+/// preview starts; a denial surfaces through the page's error view rather than
+/// crashing. The platform manifests declare the permission (Android
+/// `CAMERA`, iOS `NSCameraUsageDescription`).
+class MobileScannerBarcodeScanner implements BarcodeScanner {
+  const MobileScannerBarcodeScanner();
+
+  @override
+  Future<String?> scanOnce(BuildContext context) {
+    return Navigator.of(context).push<String>(
+      MaterialPageRoute<String>(
+        fullscreenDialog: true,
+        builder: (_) => const BarcodeScanPage(),
+      ),
+    );
+  }
+}
+
+/// Full-screen one-shot camera scanner. Pops with the first non-empty barcode
+/// value, or `null` when the user closes it. Continuous scanning is out of
+/// scope (#118) — the page closes the moment a code is read.
+class BarcodeScanPage extends StatefulWidget {
+  const BarcodeScanPage({super.key});
+
+  @override
+  State<BarcodeScanPage> createState() => _BarcodeScanPageState();
+}
+
+class _BarcodeScanPageState extends State<BarcodeScanPage> {
+  // noDuplicates so a barcode held in-frame does not fire repeatedly before we
+  // pop; we still guard with [_handled] so the very first hit wins exactly once.
+  final MobileScannerController _controller = MobileScannerController(
+    detectionSpeed: DetectionSpeed.noDuplicates,
+  );
+  bool _handled = false;
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  void _onDetect(BarcodeCapture capture) {
+    if (_handled) return;
+    String? code;
+    for (final barcode in capture.barcodes) {
+      final value = barcode.rawValue?.trim();
+      if (value != null && value.isNotEmpty) {
+        code = value;
+        break;
+      }
+    }
+    if (code == null) return;
+    _handled = true; // one-shot: first successful read closes the scanner.
+    Navigator.of(context).pop(code);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.black,
+      appBar: AppBar(
+        backgroundColor: Colors.black,
+        foregroundColor: Colors.white,
+        elevation: 0,
+        title: const Text('Scan barcode'),
+        leading: IconButton(
+          icon: Icon(FontAwesomeIcons.xmark.data),
+          onPressed: () => Navigator.of(context).pop(),
+        ),
+      ),
+      body: MobileScanner(
+        controller: _controller,
+        onDetect: _onDetect,
+        errorBuilder: (context, error) => const _ScannerError(),
+        overlayBuilder: (context, constraints) => const _ScannerHint(),
+      ),
+    );
+  }
+}
+
+/// Shown when the camera cannot start — most commonly a denied camera
+/// permission. Keeps the flow calm (invariant #7) instead of surfacing a raw
+/// error.
+class _ScannerError extends StatelessWidget {
+  const _ScannerError();
+
+  @override
+  Widget build(BuildContext context) {
+    // Material fallback icon — font_awesome_flutter has no camera-slash glyph.
+    return const Center(
+      child: Padding(
+        padding: EdgeInsets.all(32),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.no_photography, color: Colors.white, size: 40),
+            SizedBox(height: 16),
+            Text(
+              'Camera unavailable. Allow camera access for this app in your '
+              'device settings to scan barcodes.',
+              textAlign: TextAlign.center,
+              style: TextStyle(color: Colors.white),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// A simple centred aiming frame + hint over the live preview.
+class _ScannerHint extends StatelessWidget {
+  const _ScannerHint();
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        Container(
+          width: 240,
+          height: 140,
+          decoration: BoxDecoration(
+            border: Border.all(color: Colors.white70, width: 2),
+            borderRadius: BorderRadius.circular(16),
+          ),
+        ),
+        const SizedBox(height: 20),
+        const Text(
+          'Point the camera at a barcode',
+          style: TextStyle(color: Colors.white, fontSize: 14),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/pos/widgets/pos_barcode_scan_button.dart
+++ b/lib/features/pos/widgets/pos_barcode_scan_button.dart
@@ -1,0 +1,113 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+
+import 'package:reebaplus_pos/core/database/app_database.dart';
+import 'package:reebaplus_pos/core/providers/app_providers.dart';
+import 'package:reebaplus_pos/core/utils/notifications.dart';
+import 'package:reebaplus_pos/core/utils/responsive.dart';
+import 'package:reebaplus_pos/features/customers/data/models/customer.dart';
+import 'package:reebaplus_pos/features/inventory/screens/add_product_screen.dart';
+import 'package:reebaplus_pos/features/pos/providers/pos_providers.dart';
+import 'package:reebaplus_pos/shared/widgets/slide_route.dart';
+
+/// The always-visible POS scan control (#118). It is never gated on a non-empty
+/// cart — tapping it opens the camera one-shot (via [barcodeScannerProvider]).
+///
+/// On a successful scan:
+///  - a matching product is added to the cart through the SAME add path a tap
+///    uses, so per-store stock and the active price tier apply identically;
+///  - an unknown barcode toasts and opens Add Product with the code pre-filled
+///    so the cashier can catalogue it on the spot.
+class PosBarcodeScanButton extends ConsumerWidget {
+  const PosBarcodeScanButton({
+    super.key,
+    required this.tier,
+    required this.loadedProducts,
+    this.onUnknownBarcode,
+  });
+
+  /// The active price tier (§12.2). A scanned line is priced exactly as a tap.
+  final PriceTier tier;
+
+  /// The store-scoped, stock-aware catalogue the grid is currently showing. A
+  /// scanned product is resolved against this so the cart's stock cap is the
+  /// same one a tap would apply (the normal add path).
+  final List<ProductDataWithStock> loadedProducts;
+
+  /// Test seam: when a scanned barcode matches no product this is invoked with
+  /// the code (instead of navigating). Production leaves it null and opens
+  /// [AddProductScreen] with the barcode pre-filled.
+  final void Function(BuildContext context, String barcode)? onUnknownBarcode;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return IconButton(
+      tooltip: 'Scan barcode',
+      icon: Icon(
+        FontAwesomeIcons.barcode.data,
+        size: context.getRSize(18),
+        color: Theme.of(context).colorScheme.primary,
+      ),
+      onPressed: () => _scan(context, ref),
+    );
+  }
+
+  Future<void> _scan(BuildContext context, WidgetRef ref) async {
+    final scanner = ref.read(barcodeScannerProvider);
+    final code = await scanner.scanOnce(context);
+    final trimmed = code?.trim() ?? '';
+    if (trimmed.isEmpty) return; // dismissed / nothing scanned — no-op.
+    if (!context.mounted) return;
+
+    final match = await ref
+        .read(databaseProvider)
+        .catalogDao
+        .findProductByBarcode(trimmed);
+    if (!context.mounted) return;
+
+    if (match == null) {
+      AppNotification.showError(context, 'No product matches that barcode');
+      if (onUnknownBarcode != null) {
+        onUnknownBarcode!(context, trimmed);
+      } else {
+        Navigator.of(
+          context,
+        ).push(slideDownRoute(AddProductScreen(prefilledBarcode: trimmed)));
+      }
+      return;
+    }
+
+    // FOUND — add through the normal path so stock + tier rules apply exactly
+    // as they would for a tap on the product tile.
+    final item = _resolveStock(match);
+    final accepted = ref
+        .read(cartProvider)
+        .addItem(
+          item.product,
+          qty: 1.0,
+          maxStock: item.totalStock,
+          tier: tier,
+        );
+    if (!context.mounted) return;
+    if (accepted) {
+      AppNotification.showSuccess(context, '${match.name} added to cart');
+    } else {
+      AppNotification.showError(
+        context,
+        'Stock limit reached for ${match.name}',
+      );
+    }
+  }
+
+  /// Resolve the scanned product to its store-scoped stock from the loaded grid
+  /// list, so the cart's stock cap matches a tap. A product not in the current
+  /// grid (e.g. unstocked in this store) resolves to 0 stock — the normal add
+  /// path then reports the stock limit rather than overselling.
+  ProductDataWithStock _resolveStock(ProductData match) {
+    for (final entry in loadedProducts) {
+      if (entry.product.id == match.id) return entry;
+    }
+    return ProductDataWithStock(product: match, totalStock: 0);
+  }
+}

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -13,6 +13,7 @@ import file_selector_macos
 import flutter_secure_storage_macos
 import google_sign_in_ios
 import local_auth_darwin
+import mobile_scanner
 import package_info_plus
 import print_bluetooth_thermal
 import share_plus
@@ -29,6 +30,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FlutterSecureStoragePlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStoragePlugin"))
   FLTGoogleSignInPlugin.register(with: registry.registrar(forPlugin: "FLTGoogleSignInPlugin"))
   LocalAuthPlugin.register(with: registry.registrar(forPlugin: "LocalAuthPlugin"))
+  MobileScannerPlugin.register(with: registry.registrar(forPlugin: "MobileScannerPlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
   PrintBluetoothThermalPlugin.register(with: registry.registrar(forPlugin: "PrintBluetoothThermalPlugin"))
   SharePlusMacosPlugin.register(with: registry.registrar(forPlugin: "SharePlusMacosPlugin"))

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -888,6 +888,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
+  mobile_scanner:
+    dependency: "direct main"
+    description:
+      name: mobile_scanner
+      sha256: c92c26bf2231695b6d3477c8dcf435f51e28f87b1745966b1fe4c47a286171ce
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.2.0"
   native_toolchain_c:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -87,6 +87,7 @@ dependencies:
   timezone: ^0.9.4
   device_info_plus: ^12.4.0
   package_info_plus: ^9.0.1
+  mobile_scanner: ^7.2.0
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/test/pos/barcode_scan_test.dart
+++ b/test/pos/barcode_scan_test.dart
@@ -1,0 +1,263 @@
+// barcode_scan_test.dart
+//
+// #118 — POS barcode scanning. Drives the scan flow through a FAKE scanner (no
+// camera can run headless), exercising the whole always-visible scan button:
+//   - a FOUND barcode adds the product to the cart via the normal add path, so
+//     stock + tier rules apply (priced at the active tier; a 0-stock line is
+//     rejected rather than oversold);
+//   - an UNKNOWN barcode toasts and opens Add Product with the code pre-filled;
+//   - a dismissed scan (null) is a no-op.
+//
+// The button is placed in a bare AppBar to prove it is not gated on the cart.
+
+import 'package:drift/drift.dart' show Value;
+import 'package:drift/native.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import 'package:reebaplus_pos/core/database/app_database.dart';
+import 'package:reebaplus_pos/core/database/uuid_v7.dart';
+import 'package:reebaplus_pos/core/providers/app_providers.dart';
+import 'package:reebaplus_pos/core/services/supabase_cloud_transport.dart';
+import 'package:reebaplus_pos/core/services/supabase_sync_service.dart';
+import 'package:reebaplus_pos/core/utils/notifications.dart';
+import 'package:reebaplus_pos/features/customers/data/models/customer.dart';
+import 'package:reebaplus_pos/features/pos/providers/pos_providers.dart';
+import 'package:reebaplus_pos/features/pos/services/barcode_scanner.dart';
+import 'package:reebaplus_pos/features/pos/widgets/pos_barcode_scan_button.dart';
+import 'package:reebaplus_pos/shared/services/auth_service.dart';
+import 'package:reebaplus_pos/shared/services/cart_service.dart';
+import 'package:reebaplus_pos/shared/services/navigation_service.dart';
+import 'package:reebaplus_pos/shared/services/secure_storage_service.dart';
+
+/// Test double for [BarcodeScanner]: returns a preset code without a camera and
+/// records how many times it was invoked (to prove the button is wired).
+class _FakeBarcodeScanner implements BarcodeScanner {
+  _FakeBarcodeScanner(this.code);
+  final String? code;
+  int scanCount = 0;
+
+  @override
+  Future<String?> scanOnce(BuildContext context) async {
+    scanCount++;
+    return code;
+  }
+}
+
+const int _retailerKobo = 100000; // ₦1,000.00
+const int _wholesalerKobo = 80000; // ₦800.00
+
+void main() {
+  late AppDatabase db;
+  late CartService cart;
+  late String businessId;
+
+  setUpAll(() async {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    SharedPreferences.setMockInitialValues({});
+    await Supabase.initialize(
+      url: 'https://placeholder.supabase.co',
+      anonKey: 'placeholder',
+    );
+  });
+
+  setUp(() async {
+    db = AppDatabase.forTesting(NativeDatabase.memory());
+    businessId = UuidV7.generate();
+    await db
+        .into(db.businesses)
+        .insert(
+          BusinessesCompanion.insert(id: Value(businessId), name: 'Scan Biz'),
+        );
+
+    // CartService only needs AuthService for currentUser?.id; with nobody signed
+    // in, _uid falls back to '' (a valid cart key). Constructing AuthService
+    // repoints db.businessIdResolver at value?.businessId (null), so re-point it
+    // at the seeded business afterwards for the business-scoped barcode lookup.
+    final client = Supabase.instance.client;
+    final nav = NavigationService();
+    final auth = AuthService(
+      db,
+      nav,
+      SecureStorageService(),
+      SupabaseSyncService(db, SupabaseCloudTransport(client)),
+      client,
+    );
+    cart = CartService(auth, nav);
+    db.businessIdResolver = () => businessId;
+    AppNotification.hide(); // clear any toast left over from a prior test.
+  });
+
+  tearDown(() async {
+    await db.close();
+  });
+
+  Future<ProductData> seedProduct({
+    required String name,
+    required String barcode,
+  }) async {
+    final id = UuidV7.generate();
+    await db
+        .into(db.products)
+        .insert(
+          ProductsCompanion.insert(
+            id: Value(id),
+            businessId: businessId,
+            name: name,
+            barcode: Value(barcode),
+            retailerPriceKobo: const Value(_retailerKobo),
+            wholesalerPriceKobo: const Value(_wholesalerKobo),
+          ),
+        );
+    return (db.select(db.products)..where((t) => t.id.equals(id))).getSingle();
+  }
+
+  Widget host(
+    BarcodeScanner scanner, {
+    required List<ProductDataWithStock> loaded,
+    PriceTier tier = PriceTier.retailer,
+    void Function(BuildContext, String)? onUnknown,
+  }) {
+    return ProviderScope(
+      overrides: [
+        databaseProvider.overrideWithValue(db),
+        cartProvider.overrideWith((ref) => cart),
+        barcodeScannerProvider.overrideWithValue(scanner),
+      ],
+      child: MaterialApp(
+        home: Scaffold(
+          appBar: AppBar(
+            actions: [
+              PosBarcodeScanButton(
+                tier: tier,
+                loadedProducts: loaded,
+                onUnknownBarcode: onUnknown,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  testWidgets('scan button is always visible (not gated on the cart)', (
+    tester,
+  ) async {
+    await tester.pumpWidget(host(_FakeBarcodeScanner(null), loaded: const []));
+    // Rendered with an empty cart — the button is present regardless.
+    expect(find.byType(PosBarcodeScanButton), findsOneWidget);
+    expect(cart.value, isEmpty);
+  });
+
+  testWidgets('found barcode adds the product to the cart at the active tier', (
+    tester,
+  ) async {
+    final product = await seedProduct(name: 'Star Lager', barcode: 'BC-1');
+    final scanner = _FakeBarcodeScanner('BC-1');
+    await tester.pumpWidget(
+      host(
+        scanner,
+        loaded: [ProductDataWithStock(product: product, totalStock: 10)],
+      ),
+    );
+
+    await tester.tap(find.byType(PosBarcodeScanButton));
+    await tester.pumpAndSettle();
+
+    expect(scanner.scanCount, 1);
+    expect(cart.value, hasLength(1));
+    final line = cart.value.single;
+    expect(line['id'], product.id);
+    expect(line['name'], 'Star Lager');
+    // Priced at the active (retailer) tier — the normal add path's tier rule.
+    expect(line['unitPriceKobo'], _retailerKobo);
+    expect(line['priceTier'], 'retailer');
+    expect(find.text('Star Lager added to cart'), findsOneWidget);
+
+    AppNotification.hide();
+    await tester.pumpAndSettle();
+  });
+
+  testWidgets('wholesaler tier prices the scanned line at wholesale', (
+    tester,
+  ) async {
+    final product = await seedProduct(name: 'Star Lager', barcode: 'BC-1');
+    await tester.pumpWidget(
+      host(
+        _FakeBarcodeScanner('BC-1'),
+        loaded: [ProductDataWithStock(product: product, totalStock: 10)],
+        tier: PriceTier.wholesaler,
+      ),
+    );
+
+    await tester.tap(find.byType(PosBarcodeScanButton));
+    await tester.pumpAndSettle();
+
+    expect(cart.value.single['unitPriceKobo'], _wholesalerKobo);
+    expect(cart.value.single['priceTier'], 'wholesaler');
+
+    AppNotification.hide();
+    await tester.pumpAndSettle();
+  });
+
+  testWidgets('found barcode with 0 store stock is rejected (stock rule)', (
+    tester,
+  ) async {
+    final product = await seedProduct(name: 'Gulder', barcode: 'BC-2');
+    await tester.pumpWidget(
+      host(
+        _FakeBarcodeScanner('BC-2'),
+        // Zero stock in this store → the normal add path rejects, never oversells.
+        loaded: [ProductDataWithStock(product: product, totalStock: 0)],
+      ),
+    );
+
+    await tester.tap(find.byType(PosBarcodeScanButton));
+    await tester.pumpAndSettle();
+
+    expect(cart.value, isEmpty);
+    expect(find.text('Stock limit reached for Gulder'), findsOneWidget);
+
+    AppNotification.hide();
+    await tester.pumpAndSettle();
+  });
+
+  testWidgets('unknown barcode toasts and opens Add Product pre-filled', (
+    tester,
+  ) async {
+    await seedProduct(name: 'Star Lager', barcode: 'BC-1');
+    String? openedWith;
+    await tester.pumpWidget(
+      host(
+        _FakeBarcodeScanner('NOPE-999'),
+        loaded: const [],
+        onUnknown: (_, code) => openedWith = code,
+      ),
+    );
+
+    await tester.tap(find.byType(PosBarcodeScanButton));
+    await tester.pumpAndSettle();
+
+    expect(cart.value, isEmpty);
+    expect(find.text('No product matches that barcode'), findsOneWidget);
+    // Add Product is opened with the scanned code pre-filled.
+    expect(openedWith, 'NOPE-999');
+
+    AppNotification.hide();
+    await tester.pumpAndSettle();
+  });
+
+  testWidgets('dismissed scan (null) is a no-op', (tester) async {
+    final scanner = _FakeBarcodeScanner(null);
+    await tester.pumpWidget(host(scanner, loaded: const []));
+
+    await tester.tap(find.byType(PosBarcodeScanButton));
+    await tester.pumpAndSettle();
+
+    expect(scanner.scanCount, 1);
+    expect(cart.value, isEmpty);
+  });
+}


### PR DESCRIPTION
Closes #118.

## What
An always-visible **scan** button in the POS app bar opens the camera for a **one-shot** barcode read and routes the result:
- **Found** → the product is added to the cart through the **normal add path**, so per-store stock and the active price tier apply exactly as a tap on the tile would.
- **Not found** → a toast, then **Add Product** opens with the scanned code **pre-filled**.

The redundant **cart FAB is removed**; the cart is still reached via the bottom-nav cart tab.

## How
- Added `mobile_scanner: ^7.2.0` behind a thin `BarcodeScanner` interface (`scanOnce`). Production impl `MobileScannerBarcodeScanner` pushes a full-screen one-shot scanner page (closes on first read); tests inject a fake. Wired via `barcodeScannerProvider`.
- `PosBarcodeScanButton` (POS app-bar action, not gated on the cart) reuses `CatalogDao.findProductByBarcode` (#113) and `CartService.addItem`.
- `AddProductScreen` gains an optional `prefilledBarcode`, seeded into the existing #113 barcode field.
- Runtime camera permission: Android `CAMERA` added to the manifest; iOS `NSCameraUsageDescription` broadened to cover scanning (mobile_scanner requests at first use; denial surfaces a calm in-page message).

No migration needed (barcode column already exists both sides from #113).

## Acceptance criteria
- [x] Camera scanner added with runtime camera permission (Android/iOS); scanner behind a thin interface so tests use a fake.
- [x] Always-visible scan button in the POS (not gated on a non-empty cart).
- [x] Scan → found ⇒ added to cart via the normal path (stock/tier rules apply); not found ⇒ toast + open Add Product with the barcode pre-filled.
- [x] Cart FAB removed; cart access via the cart tab is unaffected.
- [x] One-shot mode (scan one, camera closes); continuous scanning out of scope.

## Testing
- `test/pos/barcode_scan_test.dart` (6 tests, fake scanner): always-visible button, found→cart at retailer & wholesaler tiers, 0-stock rejection (stock rule), unknown→toast + Add Product opened pre-filled, dismissed (null)→no-op.
- `dart analyze lib` → No issues found. `flutter test test/pos test/inventory` → all pass (90+6).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added barcode scanning directly to the POS app bar.
  * Scanned products are added to the cart using the active pricing tier and stock limits.
  * Unknown barcodes can open product creation with the barcode pre-filled.
  * Added camera permission support and scanner guidance for Android and iOS.

* **Bug Fixes**
  * Barcode scanning now handles cancellations, empty results, and unavailable cameras safely.

* **Tests**
  * Added coverage for scanning, pricing tiers, stock restrictions, unknown products, and cancelled scans.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->