### PR TITLE
feat(staff): self-resign & admin-removed device offboarding (#117)

### DIFF
--- a/lib/core/providers/stream_providers.dart
+++ b/lib/core/providers/stream_providers.dart
@@ -1392,14 +1392,15 @@ final currentUserRoleProvider = Provider<RoleData?>((ref) {
   return ref.watch(userRoleProvider(userId));
 });
 
-/// The current user's membership status ('active' | 'suspended') for the bound
-/// business, or null when logged out / not yet resolved locally. Reactive: a
-/// suspension performed on another device arrives via the `user_businesses`
-/// realtime channel, flips the local row, and re-emits here. Drives the live
-/// suspend → sign-out guard in main.dart (master plan §9.5 / §8.3): when this
-/// turns 'suspended' for an active session, the device drops to the Who's
-/// Working picker (which hides suspended staff, so they can't re-select
-/// themselves).
+/// The current user's membership status ('active' | 'suspended' | 'removed')
+/// for the bound business, or null when logged out / not yet resolved locally.
+/// Reactive: a suspension or removal performed on another device arrives via the
+/// `user_businesses` realtime channel, flips the local row, and re-emits here.
+/// Drives the live membership guard in main.dart (master plan §9.5 / §8.3 +
+/// #117): 'suspended' drops the device to the Who's Working picker (which hides
+/// suspended staff, so they can't re-select themselves); 'removed' (an admin ran
+/// `remove_staff_member`) runs the offboarding gate → logout, wiping local data
+/// only when they were the sole member on this device.
 final currentUserMembershipStatusProvider = Provider<String?>((ref) {
   final user = ref.watch(authProvider).currentUser;
   if (user == null) return null;

--- a/lib/features/auth/membership_status_reaction.dart
+++ b/lib/features/auth/membership_status_reaction.dart
@@ -1,0 +1,32 @@
+/// How the running app must react when the CURRENT user's own membership status
+/// changes underneath them (a shared-till peer or an admin acts on another
+/// device, the `user_businesses` row is pulled / broadcast in, and the local
+/// mirror flips). Consumed by the live guard in `main.dart`.
+///
+/// Kept as a pure mapping (no Flutter / provider dependency) so the branching is
+/// unit-testable without a live Supabase session.
+enum MembershipStatusReaction {
+  /// `active` (or an unresolved / unknown status) — do nothing.
+  none,
+
+  /// `suspended` (master plan §9.5 / §8.3) — drop to the Who's Working picker,
+  /// which hides suspended staff so they can't re-select themselves. UI-only
+  /// lock: the Supabase session and local data are kept.
+  lockToPicker,
+
+  /// `removed` (#117 staff offboarding) — the user was removed by an admin (the
+  /// `remove_staff_member` RPC) or resigned elsewhere. Run the same offboarding
+  /// the drawer logout uses: the unsynced-data gate → log out, wiping local
+  /// business data only if they were the sole member on this device.
+  offboard,
+}
+
+/// Maps a raw `user_businesses.status` value to the device reaction. `status`
+/// is stringly-typed (the column is a free-text CHECK, not a Dart enum), so a
+/// default arm is required and correct for `active` / null / any future value.
+MembershipStatusReaction membershipStatusReaction(String? status) =>
+    switch (status) {
+      'suspended' => MembershipStatusReaction.lockToPicker,
+      'removed' => MembershipStatusReaction.offboard,
+      _ => MembershipStatusReaction.none,
+    };

--- a/lib/features/profile/screens/profile_screen.dart
+++ b/lib/features/profile/screens/profile_screen.dart
@@ -10,9 +10,14 @@ import 'package:reebaplus_pos/core/providers/stream_providers.dart';
 import 'package:reebaplus_pos/core/utils/number_format.dart';
 import 'package:reebaplus_pos/shared/models/order_status.dart';
 import 'package:reebaplus_pos/shared/utils/role_display.dart';
+import 'package:reebaplus_pos/core/utils/notifications.dart';
+import 'package:reebaplus_pos/core/settings/delete_business_screen.dart';
 import 'package:reebaplus_pos/features/profile/widgets/edit_profile_sheet.dart';
 import 'package:reebaplus_pos/features/profile/widgets/profile_ui.dart';
+import 'package:reebaplus_pos/features/profile/self_resign.dart';
 import 'package:reebaplus_pos/features/subscription/subscription_access.dart';
+import 'package:reebaplus_pos/features/sync/widgets/resolve_unsynced_data_dialog.dart';
+import 'package:reebaplus_pos/shared/services/auth_service.dart';
 import 'package:reebaplus_pos/shared/widgets/shared_scaffold.dart';
 import 'package:reebaplus_pos/shared/widgets/app_bar_header.dart';
 import 'package:reebaplus_pos/shared/widgets/app_button.dart';
@@ -189,6 +194,31 @@ class _ProfileScreenState extends ConsumerState<ProfileScreen> {
               _openEditProfileSheet(u);
             },
           ),
+          // Offboarding (#117). The OWNER has no resign path — their exit is
+          // Delete Business (the existing danger-zone flow). Every other staff
+          // member can leave & delete their own account (no permission needed).
+          // Both hidden while the role is still resolving (hide-don't-block).
+          if (isOwnerRole(role)) ...[
+            SizedBox(height: context.getRSize(16)),
+            AppButton(
+              text: 'Delete Business',
+              variant: AppButtonVariant.danger,
+              icon: FontAwesomeIcons.triangleExclamation.data,
+              onPressed: () => Navigator.of(context).push(
+                MaterialPageRoute<void>(
+                  builder: (_) => const DeleteBusinessScreen(),
+                ),
+              ),
+            ),
+          ] else if (canSelfResign(role)) ...[
+            SizedBox(height: context.getRSize(16)),
+            AppButton(
+              text: 'Leave / delete my account',
+              variant: AppButtonVariant.danger,
+              icon: FontAwesomeIcons.rightFromBracket.data,
+              onPressed: _confirmAndResign,
+            ),
+          ],
           SizedBox(height: context.getRSize(100)),
         ],
       ),
@@ -224,6 +254,86 @@ class _ProfileScreenState extends ConsumerState<ProfileScreen> {
         color: const Color(0xFFA855F7),
       ),
     ];
+  }
+
+  /// #117 self-resign. Confirms, then hands off to
+  /// [AuthService.resignOwnMembership] (server-authoritative detach + free the
+  /// email). The device side reuses the sole-user wipe gate, so the two-tier
+  /// unsynced-data outcome is surfaced exactly as the drawer logout does —
+  /// retryable rows → an error ("connect and sync first"); orphans only → the
+  /// Resolve-unsynced-data flow (here with `isResign: true`, whose terminal also
+  /// completes the server detach). On success, main.dart routes to Welcome (sole
+  /// member) or the Who's Working picker (shared till).
+  Future<void> _confirmAndResign() async {
+    final auth = ref.read(authProvider);
+    final db = ref.read(databaseProvider);
+    final user = auth.currentUser;
+    if (user == null) return;
+
+    // Sole member on this device → the resign wipes local data (as a sole-user
+    // logout); otherwise only this user is removed from the shared till. Used to
+    // word the confirmation honestly.
+    final deviceStaffCount =
+        await db.userBusinessesDao.countDeviceStaffForBusiness(user.businessId);
+    final isSoleUser = deviceStaffCount <= 1;
+    if (!mounted) return;
+
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Leave and delete your account?'),
+        content: Text(
+          isSoleUser
+              ? 'You will be signed out and removed from this business. Your '
+                  'email is freed so you can start a new business with it '
+                  'later.\n\nYou are the only user on this device, so all local '
+                  'data will be erased. You can re-download it after signing in '
+                  'to another business.'
+              : 'You will be signed out and removed from this business. Your '
+                  'email is freed so you can start a new business with it '
+                  'later.\n\nOther staff on this device keep their data and '
+                  'stay signed in.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(false),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(true),
+            child: const Text('Leave'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true) return;
+
+    try {
+      await auth.resignOwnMembership();
+    } on LogoutBlockedByUnsyncedDataException catch (e) {
+      // Orphans only (sole member): route to export → typed-confirm discard,
+      // whose terminal (isResign) also completes the server-side detach.
+      if (mounted) {
+        await showResolveUnsyncedDataDialog(
+          context,
+          ref,
+          pendingCount: e.pendingCount,
+          orphanCount: e.orphanCount,
+          isResign: true,
+        );
+      }
+    } on LogoutWipeException catch (e) {
+      if (mounted) AppNotification.showError(context, e.message);
+    } on StaffResignException catch (e) {
+      if (mounted) AppNotification.showError(context, e.message);
+    } catch (e) {
+      if (mounted) {
+        AppNotification.showError(
+          context,
+          'An unexpected error occurred while leaving your account.',
+        );
+      }
+    }
   }
 
   /// Self-service edit of the logged-in user's own name + avatar colour.

--- a/lib/features/profile/self_resign.dart
+++ b/lib/features/profile/self_resign.dart
@@ -1,0 +1,19 @@
+import 'package:reebaplus_pos/core/database/app_database.dart';
+
+/// Whether the current user may self-resign (#117 staff offboarding). Any
+/// non-owner staff member can "Leave / delete my account" from Profile — no
+/// permission is required. The business OWNER (the CEO — one owner per business,
+/// CLAUDE.md) can NOT: their exit is Delete Business (the `delete_business` RPC
+/// flow), so the Profile action for them is Delete Business instead.
+///
+/// Returns `false` while the role is still resolving (`null`) so the resign
+/// action never flashes on screen before ownership is known — the server RPC
+/// rejects the owner regardless (`cannot_resign_owner`), this is the UI belt to
+/// that server suspenders.
+bool canSelfResign(RoleData? role) => role != null && role.slug != 'ceo';
+
+/// Whether the Profile screen should offer the owner's Delete Business action
+/// instead of the resign action. True only once the role has resolved to the
+/// CEO (owner); false while unresolved so nothing flashes before ownership is
+/// known.
+bool isOwnerRole(RoleData? role) => role != null && role.slug == 'ceo';

--- a/lib/features/sync/widgets/resolve_unsynced_data_dialog.dart
+++ b/lib/features/sync/widgets/resolve_unsynced_data_dialog.dart
@@ -14,11 +14,18 @@ import 'package:reebaplus_pos/core/utils/responsive.dart';
 ///
 /// Returns `true` if the user discarded + logged out (the caller should treat
 /// the session as gone), `false` if they cancelled.
+///
+/// [isResign] switches the terminal action from a plain logout
+/// ([AuthService.discardUnsyncedAndLogout]) to a self-resign
+/// ([AuthService.discardUnsyncedAndResign], #117), which additionally detaches
+/// the caller's membership server-side (frees their email). Same export → typed
+/// discard UX; only the confirmed terminal + button copy differ.
 Future<bool> showResolveUnsyncedDataDialog(
   BuildContext context,
   WidgetRef ref, {
   required int pendingCount,
   required int orphanCount,
+  bool isResign = false,
 }) async {
   final result = await showDialog<bool>(
     context: context,
@@ -26,6 +33,7 @@ Future<bool> showResolveUnsyncedDataDialog(
     builder: (ctx) => _ResolveUnsyncedDataDialog(
       pendingCount: pendingCount,
       orphanCount: orphanCount,
+      isResign: isResign,
     ),
   );
   return result ?? false;
@@ -35,10 +43,12 @@ class _ResolveUnsyncedDataDialog extends ConsumerStatefulWidget {
   const _ResolveUnsyncedDataDialog({
     required this.pendingCount,
     required this.orphanCount,
+    required this.isResign,
   });
 
   final int pendingCount;
   final int orphanCount;
+  final bool isResign;
 
   @override
   ConsumerState<_ResolveUnsyncedDataDialog> createState() =>
@@ -99,12 +109,22 @@ class _ResolveUnsyncedDataDialogState
   Future<void> _discardAndLogout() async {
     setState(() => _discarding = true);
     try {
-      await ref.read(authProvider).discardUnsyncedAndLogout();
+      final auth = ref.read(authProvider);
+      if (widget.isResign) {
+        await auth.discardUnsyncedAndResign();
+      } else {
+        await auth.discardUnsyncedAndLogout();
+      }
       if (mounted) Navigator.of(context).pop(true);
     } catch (e) {
       if (mounted) {
         setState(() => _discarding = false);
-        AppNotification.showError(context, 'Could not complete logout: $e');
+        AppNotification.showError(
+          context,
+          widget.isResign
+              ? 'Could not leave your account: $e'
+              : 'Could not complete logout: $e',
+        );
       }
     }
   }
@@ -144,7 +164,7 @@ class _ResolveUnsyncedDataDialogState
             Text(
               _hasExported
                   ? 'Type $_confirmWord to permanently discard these records '
-                      'and log out.'
+                      '${widget.isResign ? "and leave your account." : "and log out."}'
                   : 'Export the records to unlock discard.',
               style: theme.textTheme.bodySmall,
             ),
@@ -179,7 +199,7 @@ class _ResolveUnsyncedDataDialogState
                   height: context.getRSize(18),
                   child: const CircularProgressIndicator(strokeWidth: 2),
                 )
-              : const Text('Discard & log out'),
+              : Text(widget.isResign ? 'Discard & leave' : 'Discard & log out'),
         ),
       ],
     );

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -28,6 +28,8 @@ import 'package:reebaplus_pos/shared/widgets/main_layout.dart';
 import 'package:reebaplus_pos/shared/widgets/auto_lock_wrapper.dart';
 import 'package:reebaplus_pos/shared/widgets/force_update_wrapper.dart';
 import 'package:reebaplus_pos/shared/services/auth_service.dart';
+import 'package:reebaplus_pos/features/auth/membership_status_reaction.dart';
+import 'package:reebaplus_pos/features/sync/widgets/resolve_unsynced_data_dialog.dart';
 import 'package:reebaplus_pos/features/auth/screens/success_dashboard_entry_screen.dart';
 import 'package:reebaplus_pos/features/auth/screens/access_granted_screen.dart';
 import 'package:reebaplus_pos/features/diagnostics/screens/schema_error_screen.dart';
@@ -160,6 +162,11 @@ class _ReebaplusPosAppState extends ConsumerState<ReebaplusPosApp> {
   /// removed; only these informational badges depend on the tick now.)
   Timer? _subscriptionClockTimer;
 
+  /// Re-entrancy guard for the admin-removed offboarding (#117). The membership
+  /// listener can re-emit `removed` while the gate is mid-flight; without this
+  /// the offboarding could stack (double dialogs / double wipe).
+  bool _handlingSelfRemoved = false;
+
   @override
   void initState() {
     super.initState();
@@ -249,6 +256,43 @@ class _ReebaplusPosAppState extends ConsumerState<ReebaplusPosApp> {
     }
   }
 
+  /// Admin-removed offboarding (#117). Runs when the current user's own
+  /// membership flips to `removed` (an admin ran `remove_staff_member` on
+  /// another device; the change arrives via the next pull / broadcast). Reuses
+  /// [AuthService.logOutCurrentUser] — the exact drawer-logout path — so the
+  /// unsynced-data gate runs and local business data is wiped ONLY when they
+  /// were the sole member on this device (otherwise just this user is dropped to
+  /// the Who's Working picker). Surfaces the gate's two-tier outcome exactly as
+  /// the drawer does: retryable rows → error toast ("connect and sync first");
+  /// orphans only → the Resolve-unsynced-data flow. The admin already detached
+  /// them server-side, so the plain (non-resign) terminals apply here.
+  Future<void> _handleSelfRemoved() async {
+    if (_handlingSelfRemoved) return;
+    _handlingSelfRemoved = true;
+    try {
+      await _auth.logOutCurrentUser();
+    } on LogoutBlockedByUnsyncedDataException catch (e) {
+      final ctx = _navigatorKey.currentContext;
+      if (ctx != null && ctx.mounted) {
+        await showResolveUnsyncedDataDialog(
+          ctx,
+          ref,
+          pendingCount: e.pendingCount,
+          orphanCount: e.orphanCount,
+        );
+      }
+    } on LogoutWipeException catch (e) {
+      final ctx = _navigatorKey.currentContext;
+      if (ctx != null && ctx.mounted) {
+        AppNotification.showError(ctx, e.message);
+      }
+    } catch (e) {
+      debugPrint('[main] _handleSelfRemoved error: $e');
+    } finally {
+      _handlingSelfRemoved = false;
+    }
+  }
+
   void _onDeviceUserChanged() {
     if (mounted) {
       setState(() {
@@ -307,16 +351,26 @@ class _ReebaplusPosAppState extends ConsumerState<ReebaplusPosApp> {
       if (ds != null) themeController.setDesignSystem(ds);
     });
 
-    // Live suspend → sign-out (master plan §9.5 / §8.3). When the signed-in
-    // user is suspended on another device, the `user_businesses` realtime
-    // update flips the local membership status; drop them to the Who's Working
-    // picker immediately. The picker hides suspended staff (§8.3), so they
-    // can't re-select themselves. lockApp() (UI-only, keeps the Supabase
-    // session) once `value` is null re-emissions are ignored — the guard below
-    // makes this fire exactly once per active session.
+    // Live membership-status reactions (master plan §9.5 / §8.3 + #117). When
+    // the signed-in user's own membership changes on another device — a peer
+    // suspends them, or an admin removes them (the `remove_staff_member` RPC) —
+    // the `user_businesses` realtime/broadcast pull flips the local status and
+    // this provider re-emits. Guard on `value != null` so a null (logged-out)
+    // re-emission is ignored.
+    //   • suspended → lockApp() (UI-only; keeps the Supabase session): drop to
+    //     the Who's Working picker, which hides suspended staff so they can't
+    //     re-select themselves.
+    //   • removed → run the SAME offboarding the drawer logout uses (unsynced-
+    //     data gate → log out; wipe only if sole member on this device).
     ref.listen(currentUserMembershipStatusProvider, (_, next) {
-      if (next == 'suspended' && _auth.value != null) {
-        _auth.lockApp();
+      if (_auth.value == null) return;
+      switch (membershipStatusReaction(next)) {
+        case MembershipStatusReaction.none:
+          break;
+        case MembershipStatusReaction.lockToPicker:
+          _auth.lockApp();
+        case MembershipStatusReaction.offboard:
+          unawaited(_handleSelfRemoved());
       }
     });
 

--- a/lib/shared/services/auth_service.dart
+++ b/lib/shared/services/auth_service.dart
@@ -48,6 +48,18 @@ class StaffRemoveException implements Exception {
   String toString() => message;
 }
 
+/// Thrown by [AuthService.resignOwnMembership] / [AuthService.discardUnsyncedAndResign]
+/// (#117 self-resign) when the server-authoritative self-removal cannot proceed
+/// (offline, the caller is the owner, or no live membership). Carries a
+/// plain-English [message] safe to show; no local state is changed when this is
+/// thrown BEFORE the wipe (a failed RPC leaves the device fully intact).
+class StaffResignException implements Exception {
+  final String message;
+  const StaffResignException(this.message);
+  @override
+  String toString() => message;
+}
+
 class LogoutWipeException implements Exception {
   final String message;
   const LogoutWipeException(this.message);
@@ -1291,49 +1303,12 @@ class AuthService extends ValueNotifier<UserData?> {
     if (isSoleUser) {
       // §3.1 wipe gate (E) / Invariant #12: a sole-user logout WIPES the device,
       // so it may never destroy a committed local row that still has an
-      // un-uploaded outbox entry. The outbox is the union of retryable pending
-      // rows (`sync_queue`) and un-pushable orphans (`sync_queue_orphans`).
-      var pendingCount = await _db.syncDao.countPending(businessId: businessId);
-      var orphanCount = await _db.syncDao.countOrphans(businessId: businessId);
-
-      if (pendingCount + orphanCount > 0) {
-        // E3: online → push-and-CONFIRM the queue is empty before wiping. A
-        // partial/failed push must not let the wipe proceed on the remainder,
-        // so we re-count AFTER the drain and decide on the confirmed state.
-        if (_sync.isOnline.value) {
-          try {
-            await _sync.pushPending();
-          } catch (e) {
-            debugPrint(
-              '[AuthService] logOutCurrentUser final push before wipe failed: $e',
-            );
-          }
-          pendingCount = await _db.syncDao.countPending(businessId: businessId);
-          orphanCount = await _db.syncDao.countOrphans(businessId: businessId);
-        }
-
-        // Two-tier resolution on whatever remains after the (possible) drain.
-        if (pendingCount > 0) {
-          // Retryable rows remain (transient — offline, or a row mid-flight, or
-          // a mix that still includes pending). Refuse and keep the user logged
-          // in; it resolves itself on reconnect / the next drain (E1).
-          throw LogoutWipeException(
-            'You have ${pendingCount + orphanCount} change'
-            '${pendingCount + orphanCount == 1 ? "" : "s"} not yet synced. '
-            'Connect to the internet and let it sync before logging out.',
-          );
-        }
-        if (orphanCount > 0) {
-          // Un-pushable orphans ONLY (the cloud is actively rejecting them).
-          // Do NOT trap the user — route to the "Resolve unsynced data" flow
-          // (export → typed-confirm discard → logout) via the dedicated
-          // exception. The wipe does not run here.
-          throw LogoutBlockedByUnsyncedDataException(
-            pendingCount: pendingCount,
-            orphanCount: orphanCount,
-          );
-        }
-      }
+      // un-uploaded outbox entry. The gate throws LogoutWipeException (retryable
+      // rows remain → "connect and sync first") or
+      // LogoutBlockedByUnsyncedDataException (only un-pushable orphans remain →
+      // the Resolve-unsynced-data flow), and returns only when the outbox is
+      // confirmed clean.
+      await _assertOutboxClearBeforeWipe(businessId);
 
       // Outbox confirmed empty — safe to wipe.
       try {
@@ -1345,11 +1320,68 @@ class AuthService extends ValueNotifier<UserData?> {
       return;
     }
 
-    // Multiple device-authenticated users: drop this user from the device set.
+    // Multiple device-authenticated users (shared till): drop this user from
+    // the device set and return to the Who's Working picker — the others keep
+    // their PINs and the till's shared data + outbox are untouched.
+    await _dropCurrentUserToPickerLocal(user);
+  }
+
+  /// §3.1 wipe gate (E) / Invariant #12. Guards any device-wiping offboard (a
+  /// sole-user logout or a sole-member self-resign): a wipe may never destroy a
+  /// committed local row that still has an un-uploaded outbox entry. The outbox
+  /// is the union of retryable pending rows (`sync_queue`) and un-pushable
+  /// orphans (`sync_queue_orphans`).
+  ///
+  /// If anything is queued and we are online, it push-and-CONFIRMS by re-counting
+  /// AFTER the drain (a partial/failed push must not let the wipe proceed on the
+  /// remainder). It then throws:
+  ///   • [LogoutWipeException] — retryable rows remain (transient: offline, or a
+  ///     row mid-flight). Refuse; it resolves itself on reconnect / next drain.
+  ///   • [LogoutBlockedByUnsyncedDataException] — ONLY un-pushable orphans remain
+  ///     (the cloud is actively rejecting them). Do NOT trap the user; the caller
+  ///     routes to the "Resolve unsynced data" flow (export → typed-confirm
+  ///     discard) via this exception.
+  /// Returns normally only when the outbox is confirmed clean (safe to wipe).
+  Future<void> _assertOutboxClearBeforeWipe(String businessId) async {
+    var pendingCount = await _db.syncDao.countPending(businessId: businessId);
+    var orphanCount = await _db.syncDao.countOrphans(businessId: businessId);
+    if (pendingCount + orphanCount == 0) return;
+
+    if (_sync.isOnline.value) {
+      try {
+        await _sync.pushPending();
+      } catch (e) {
+        debugPrint('[AuthService] pre-wipe final push failed: $e');
+      }
+      pendingCount = await _db.syncDao.countPending(businessId: businessId);
+      orphanCount = await _db.syncDao.countOrphans(businessId: businessId);
+    }
+
+    if (pendingCount > 0) {
+      throw LogoutWipeException(
+        'You have ${pendingCount + orphanCount} change'
+        '${pendingCount + orphanCount == 1 ? "" : "s"} not yet synced. '
+        'Connect to the internet and let it sync before signing out.',
+      );
+    }
+    if (orphanCount > 0) {
+      throw LogoutBlockedByUnsyncedDataException(
+        pendingCount: pendingCount,
+        orphanCount: orphanCount,
+      );
+    }
+  }
+
+  /// Shared-till teardown for a single leaving user (drawer logout OR self-resign
+  /// when other device staff remain): reset THIS user's PIN so the old PIN can't
+  /// unlock again, revoke their session, drop the Supabase/Google tokens, and
+  /// return to the Who's Working picker. It is NOT a device wipe — the business's
+  /// shared data, the sync queue, and OTHER staff's PINs are all kept.
+  Future<void> _dropCurrentUserToPickerLocal(UserData user) async {
     try {
       await clearUserPin(user.id);
     } catch (e) {
-      debugPrint('[AuthService] logOutCurrentUser clearUserPin error: $e');
+      debugPrint('[AuthService] _dropCurrentUserToPickerLocal clearUserPin error: $e');
     }
 
     final sid = currentSessionId;
@@ -1357,7 +1389,7 @@ class AuthService extends ValueNotifier<UserData?> {
       try {
         await _db.sessionsDao.revokeSession(sid);
       } catch (e) {
-        debugPrint('[AuthService] logOutCurrentUser revokeSession error: $e');
+        debugPrint('[AuthService] _dropCurrentUserToPickerLocal revokeSession error: $e');
       }
       currentSessionId = null;
     }
@@ -1365,13 +1397,13 @@ class AuthService extends ValueNotifier<UserData?> {
     try {
       await _supabase.auth.signOut(scope: SignOutScope.local);
     } catch (e) {
-      debugPrint('[AuthService] logOutCurrentUser signOut error: $e');
+      debugPrint('[AuthService] _dropCurrentUserToPickerLocal signOut error: $e');
     }
 
     try {
       await GoogleSignIn().signOut();
     } catch (e) {
-      debugPrint('[AuthService] logOutCurrentUser Google signOut error: $e');
+      debugPrint('[AuthService] _dropCurrentUserToPickerLocal Google signOut error: $e');
     }
 
     // Set picker and navigation state, return to the WhoIsWorking picker.
@@ -1408,6 +1440,145 @@ class AuthService extends ValueNotifier<UserData?> {
       debugPrint('[AuthService] discardUnsyncedAndLogout clearAllData error: $e');
     }
     await fullLogout();
+  }
+
+  /// Voluntary self-resign (#117 staff offboarding). A non-owner staff member
+  /// leaves & deletes their own account from Profile — "one action, no
+  /// permission needed". Server-authoritative via the `resign_own_membership`
+  /// SECURITY DEFINER RPC (migration 0152), which sets the caller's OWN
+  /// membership status to `removed` AND nulls their cloud `users.auth_user_id`
+  /// (freeing the email so the one-email-one-business guard passes and they can
+  /// create a brand-new business), while KEEPING the users row intact as an
+  /// attribution stub. The business owner cannot resign — the RPC rejects them
+  /// (their exit is [deleteBusinessAndAccount]).
+  ///
+  /// The device side REUSES the sole-user wipe machinery, and — crucially — the
+  /// unsynced-data gate runs BEFORE the RPC detaches us: once the RPC nulls our
+  /// auth link our JWT loses access, so any un-pushed row would orphan. Pushing
+  /// while we still have access is what keeps "no offline sale is lost" true.
+  ///   • Sole member on this device → gate (push + confirm clean) → RPC → wipe.
+  ///     If the gate finds retryable rows it throws [LogoutWipeException]; if it
+  ///     finds only orphans it throws [LogoutBlockedByUnsyncedDataException] and
+  ///     the UI routes to the Resolve-unsynced-data flow, whose terminal is
+  ///     [discardUnsyncedAndResign] (NOT the plain logout terminal). The RPC has
+  ///     not run in either throw path, so a blocked/deferred resign is a no-op.
+  ///   • Shared till (other device staff remain) → RPC → drop this user to the
+  ///     Who's Working picker (no wipe; their queued rows stay in the shared
+  ///     outbox and other members sync them).
+  ///
+  /// Online-only (like [removeStaffMember] / [deleteBusinessAndAccount]): throws
+  /// [StaffResignException] WITHOUT changing local state when offline.
+  // sync-exempt: #117 — the cloud `resign_own_membership` RPC is the
+  // authoritative writer of both the membership status and the auth-link null;
+  // the local wipe / picker-drop mirrors a server-already-applied state, so there
+  // is nothing to enqueue. No raw synced-table write leaves the device here.
+  Future<void> resignOwnMembership() async {
+    final user = value;
+    if (user == null) return;
+    final businessId = user.businessId;
+
+    // Block offline up front — the resign is server-authoritative and the gate
+    // must push before we detach; never queue it blindly.
+    if (!_sync.isOnline.value) {
+      throw const StaffResignException(
+        'You must be online to leave your account. '
+        'Connect to the internet and try again.',
+      );
+    }
+
+    final count =
+        await _db.userBusinessesDao.countDeviceStaffForBusiness(businessId);
+    final isSoleUser = count <= 1;
+
+    if (isSoleUser) {
+      // Gate BEFORE detaching (throws on retryable/orphan rows). Only when it
+      // returns cleanly do we detach server-side and wipe.
+      await _assertOutboxClearBeforeWipe(businessId);
+      await _resignViaRpc(businessId);
+      try {
+        await _db.clearAllData();
+      } catch (e) {
+        debugPrint('[AuthService] resignOwnMembership clearAllData error: $e');
+      }
+      await fullLogout();
+      return;
+    }
+
+    // Shared till: detach server-side, then drop this user to the picker.
+    await _resignViaRpc(businessId);
+    await _dropCurrentUserToPickerLocal(user);
+  }
+
+  /// §3.1 "Resolve unsynced data" terminal for a self-resign (#117). Called by
+  /// the UI ONLY after [resignOwnMembership] surfaced a
+  /// [LogoutBlockedByUnsyncedDataException] (sole member, orphans only), the user
+  /// exported the stuck records, and typed-confirmed the discard. Detaches
+  /// server-side FIRST (so a failed RPC discards nothing and leaves the device
+  /// intact), then records the loss, discards the un-pushable outbox, wipes, and
+  /// logs out — the deliberate, confirmed user action Invariant #12 permits.
+  Future<void> discardUnsyncedAndResign() async {
+    final user = value;
+    if (user == null) return;
+    final businessId = user.businessId;
+    // Detach server-side before discarding: on failure this throws
+    // StaffResignException without touching the outbox, so the user can retry.
+    await _resignViaRpc(businessId);
+    await _recordWipeLoss(businessId, 'resign:user_discarded_unsynced');
+    try {
+      final discarded =
+          await _db.syncDao.discardUnsyncedForBusiness(businessId);
+      debugPrint(
+        '[AuthService] discardUnsyncedAndResign: discarded $discarded '
+        'outbox row(s) for $businessId',
+      );
+    } catch (e) {
+      debugPrint('[AuthService] discardUnsyncedAndResign discard error: $e');
+    }
+    try {
+      await _db.clearAllData();
+    } catch (e) {
+      debugPrint('[AuthService] discardUnsyncedAndResign clearAllData error: $e');
+    }
+    await fullLogout();
+  }
+
+  /// Calls the `resign_own_membership` RPC directly (NOT via the §6 outbox), the
+  /// same shape as [removeStaffMember]'s call. Throws [StaffResignException] with
+  /// plain-English copy on any failure, leaving local state untouched.
+  Future<void> _resignViaRpc(String businessId) async {
+    try {
+      await _supabase.rpc(
+        'resign_own_membership',
+        params: {'p_business_id': businessId},
+      );
+    } on PostgrestException catch (e) {
+      debugPrint(
+        '[AuthService] resign_own_membership RPC failed: ${e.code} ${e.message}',
+      );
+      throw StaffResignException(_resignMessage(e));
+    } catch (e) {
+      debugPrint('[AuthService] resign_own_membership network error: $e');
+      throw const StaffResignException(
+        'Could not reach the server to leave your account. '
+        'Check your connection and try again.',
+      );
+    }
+  }
+
+  /// Maps a `resign_own_membership` RPC error to plain English.
+  String _resignMessage(PostgrestException e) {
+    final msg = e.message;
+    if (msg.contains('cannot_resign_owner')) {
+      return "The business owner can't leave this way. Use Delete Business instead.";
+    }
+    if (msg.contains('no_active_membership') ||
+        msg.contains('member_not_found')) {
+      return 'You are no longer a member of this business.';
+    }
+    if (msg.contains('unauthenticated') || e.code == '42501') {
+      return 'You must be signed in to leave your account.';
+    }
+    return 'Could not leave your account. Please try again.';
   }
 
   /// Returns true if [pin] matches at least one local user. The lone

--- a/supabase/migrations/0152_resign_own_membership.sql
+++ b/supabase/migrations/0152_resign_own_membership.sql
@@ -1,0 +1,139 @@
+-- 0152_resign_own_membership.sql
+--
+-- Staff offboarding — self-resign (issue #117). The companion to
+-- 0149_remove_staff_member: where 0149 lets an ADMIN remove SOMEONE ELSE (and
+-- deliberately REJECTS self-removal via `cannot_remove_self`), this lets a
+-- non-owner staff member remove THEIR OWN membership — "Leave / delete my
+-- account" from Profile. No permission is required (a person may always leave),
+-- but the business OWNER can never resign (their exit is Delete Business), so
+-- the owner is rejected here just as they are in 0149.
+--
+-- Create public.resign_own_membership(p_business_id). The app calls it DIRECTLY
+-- (supabase.rpc), NOT through the §6 sync outbox, exactly like
+-- remove_staff_member / delete_business, because it must be server-confirmed and
+-- the queue would retry it blindly. In one transaction it, for the CALLER's own
+-- identity (resolved by auth.uid()): (1) sets the membership status to `removed`,
+-- and (2) nulls users.auth_user_id so the email frees up — the
+-- one-email-one-business guard in complete_onboarding (0121) and the
+-- existing-account router current_user_linked_business (0128) both key off
+-- users.auth_user_id, so nulling it lets the freed email create a brand-new
+-- business. The users row is KEPT intact as an Attribution Stub (name / email /
+-- phone retained, NEVER hard-deleted) so every historical sale still renders the
+-- person's name — identical to 0149. The business owner is rejected.
+--
+-- Nothing else changes: the `removed` membership CHECK value and the client-side
+-- pieces already shipped with 0149 / #107. No new permission key is added
+-- (resign needs no grant).
+--
+-- NOTE: the issue references "ADR 0016", but that ADR file does not exist yet;
+-- this migration implements the acceptance criteria directly (no ADR is written
+-- here, to avoid colliding with open docs PRs), mirroring the 0149 note.
+
+BEGIN;
+
+-- =========================================================================
+-- resign_own_membership(p_business_id) — server-authoritative self-resign.
+-- =========================================================================
+CREATE OR REPLACE FUNCTION public.resign_own_membership(
+  p_business_id uuid
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+DECLARE
+  v_auth_uid   uuid := auth.uid();
+  v_owner_id   uuid;
+  v_user_id    uuid;
+  v_membership uuid;
+BEGIN
+  IF v_auth_uid IS NULL THEN
+    RAISE EXCEPTION 'unauthenticated'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  -- Resolve the CALLER's own identity within this business from auth.uid().
+  -- auth_user_id is the canonical live link (0028/0121); a caller who has
+  -- already been removed has it nulled and resolves to nothing here — treated
+  -- as an idempotent "already gone". This also enforces cross-business
+  -- isolation (architecture invariant #5): a caller with no live membership in
+  -- p_business_id resolves no user row and is rejected below.
+  SELECT id INTO v_user_id
+    FROM public.users
+   WHERE auth_user_id = v_auth_uid
+     AND business_id  = p_business_id;
+
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'no_active_membership'
+      USING ERRCODE = 'no_data_found';
+  END IF;
+
+  -- Owner protection: the business owner can NEVER resign (their exit is Delete
+  -- Business — the delete_business RPC). owner_id holds the owner's auth.uid()
+  -- (set at onboarding, backfilled by 0028); compare it to the caller's uid.
+  SELECT owner_id INTO v_owner_id
+    FROM public.businesses WHERE id = p_business_id;
+
+  IF v_owner_id IS NOT NULL AND v_owner_id = v_auth_uid THEN
+    RAISE EXCEPTION 'cannot_resign_owner'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  -- (1) Terminal membership status. Stamp last_updated_at so the incremental
+  --     pull ships it to every device the caller shares this business with (a
+  --     shared till), and so the caller's own device converges its local mirror.
+  UPDATE public.user_businesses
+     SET status = 'removed', last_updated_at = now()
+   WHERE business_id = p_business_id AND user_id = v_user_id
+  RETURNING id INTO v_membership;
+
+  IF v_membership IS NULL THEN
+    RAISE EXCEPTION 'no_active_membership'
+      USING ERRCODE = 'no_data_found';
+  END IF;
+
+  -- (2) Free the email: null the caller's own auth link. KEEP the users row
+  --     intact as an Attribution Stub — name / email / phone retained, NEVER
+  --     hard-deleted — so every historical sale still renders the person's name.
+  --     auth_user_id is cloud-RPC-set-only (off the client push whitelist), so
+  --     this definer-side null is the authoritative writer.
+  UPDATE public.users
+     SET auth_user_id = NULL, last_updated_at = now()
+   WHERE id = v_user_id AND business_id = p_business_id;
+
+  RETURN jsonb_build_object(
+    'ok', true,
+    'business_id', p_business_id,
+    'user_id', v_user_id,
+    'membership_id', v_membership
+  );
+END;
+$$;
+
+REVOKE ALL    ON FUNCTION public.resign_own_membership(uuid) FROM public;
+GRANT EXECUTE ON FUNCTION public.resign_own_membership(uuid) TO authenticated, service_role;
+
+COMMIT;
+
+-- =============================================================================
+-- Verification (run by hand after deploy):
+--
+--   1. RPC exists with the right signature:
+--      SELECT pg_get_function_arguments(oid)
+--        FROM pg_proc
+--       WHERE proname = 'resign_own_membership'
+--         AND pronamespace = 'public'::regnamespace;
+--      -- expect: p_business_id uuid
+--
+--   2. The owner is rejected, a non-owner member resigns + email freed
+--      (each run as the signed-in member in question):
+--      SELECT public.resign_own_membership('<business>');  -- as the OWNER
+--        -- expect: ERROR cannot_resign_owner
+--      SELECT public.resign_own_membership('<business>');  -- as a STAFF member
+--        -- expect: {"ok": true, ...}; then:
+--      SELECT status FROM public.user_businesses WHERE user_id = '<staff_user_id>';
+--        -- expect: removed
+--      SELECT auth_user_id, name, email FROM public.users WHERE id = '<staff_user_id>';
+--        -- expect: auth_user_id NULL; name + email still present (stub kept)
+-- =============================================================================

--- a/test/staff/self_resign_test.dart
+++ b/test/staff/self_resign_test.dart
@@ -1,0 +1,223 @@
+// self_resign_test.dart
+//
+// Staff offboarding — self-resign & admin-removed device reaction (#117).
+// Client-observable surfaces (the server RPC `resign_own_membership` is SQL and
+// validated by review against 0149, not here):
+//
+//   * canSelfResign / isOwnerRole — the OWNER (CEO) has no resign path (sees
+//     Delete Business instead); every other staff member can leave; neither
+//     flashes while the role is still resolving (null).
+//   * membershipStatusReaction — the pure mapping the main.dart live guard uses:
+//     an admin-removed membership (`removed`) → offboard (gate → logout);
+//     `suspended` → lockToPicker; everything else → none.
+//   * the local `removed` flip (markRemovedLocal, as applied by a pull) drives
+//     the offboard reaction — the admin-removed detection decision.
+//   * the sole-member wipe gate's three branches, at the DAO-signal level that
+//     resignOwnMembership / logOutCurrentUser decide on: retryable rows → block
+//     (LogoutWipeException), orphans only → Resolve-unsynced-data
+//     (LogoutBlockedByUnsyncedDataException), clean → proceed.
+
+import 'package:drift/drift.dart' hide isNull, isNotNull;
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reebaplus_pos/core/database/app_database.dart';
+import 'package:reebaplus_pos/core/database/uuid_v7.dart';
+import 'package:reebaplus_pos/features/auth/membership_status_reaction.dart';
+import 'package:reebaplus_pos/features/profile/self_resign.dart';
+import 'package:reebaplus_pos/shared/services/auth_service.dart';
+
+RoleData _role(String slug) => RoleData(
+      id: UuidV7.generate(),
+      businessId: UuidV7.generate(),
+      name: slug.toUpperCase(),
+      slug: slug,
+      isSystemDefault: true,
+      isDeleted: false,
+      createdAt: DateTime.now(),
+      lastUpdatedAt: DateTime.now(),
+    );
+
+void main() {
+  // ── Owner-exclusion predicates (AC: owner has no resign path) ────────────
+
+  group('canSelfResign / isOwnerRole', () {
+    test('the owner (CEO) cannot resign and is the Delete-Business role', () {
+      final ceo = _role('ceo');
+      expect(canSelfResign(ceo), isFalse);
+      expect(isOwnerRole(ceo), isTrue);
+    });
+
+    test('every non-owner staff role can self-resign', () {
+      for (final slug in ['manager', 'cashier', 'stock_keeper']) {
+        expect(canSelfResign(_role(slug)), isTrue, reason: '$slug may resign');
+        expect(isOwnerRole(_role(slug)), isFalse);
+      }
+    });
+
+    test('an unresolved role (null) shows neither action', () {
+      expect(canSelfResign(null), isFalse);
+      expect(isOwnerRole(null), isFalse);
+    });
+  });
+
+  // ── Membership-status reaction (AC: admin-removed → logout) ──────────────
+
+  group('membershipStatusReaction', () {
+    test('removed → offboard (admin-removed device reaction)', () {
+      expect(membershipStatusReaction('removed'),
+          MembershipStatusReaction.offboard);
+    });
+
+    test('suspended → lockToPicker', () {
+      expect(membershipStatusReaction('suspended'),
+          MembershipStatusReaction.lockToPicker);
+    });
+
+    test('active / null / unknown → none', () {
+      expect(membershipStatusReaction('active'), MembershipStatusReaction.none);
+      expect(membershipStatusReaction(null), MembershipStatusReaction.none);
+      expect(membershipStatusReaction('whatever'),
+          MembershipStatusReaction.none);
+    });
+  });
+
+  // ── Admin-removed detection: a pulled `removed` flip drives offboard ──────
+
+  group('admin-removed detection', () {
+    late AppDatabase db;
+    late String biz;
+    late String cashierRoleId;
+
+    setUp(() async {
+      db = AppDatabase.forTesting(NativeDatabase.memory());
+      biz = UuidV7.generate();
+      await db
+          .into(db.businesses)
+          .insert(BusinessesCompanion.insert(id: Value(biz), name: 'Biz'));
+      cashierRoleId = UuidV7.generate();
+      await db.into(db.roles).insert(RolesCompanion.insert(
+          id: Value(cashierRoleId),
+          businessId: biz,
+          name: 'Cashier',
+          slug: 'cashier'));
+    });
+
+    tearDown(() => db.close());
+
+    test(
+        'markRemovedLocal (the pull-applied flip) yields a `removed` status '
+        'whose reaction is offboard', () async {
+      final userId = UuidV7.generate();
+      await db.into(db.users).insert(UsersCompanion.insert(
+            id: Value(userId),
+            businessId: biz,
+            name: 'Removed Rita',
+            pin: '__HASHED__',
+          ));
+      final membershipId = UuidV7.generate();
+      await db.into(db.userBusinesses).insert(UserBusinessesCompanion.insert(
+            id: Value(membershipId),
+            businessId: biz,
+            userId: userId,
+            roleId: cashierRoleId,
+            status: const Value('active'),
+          ));
+
+      // Before removal: active → no reaction.
+      var m = await (db.select(db.userBusinesses)
+            ..where((t) => t.id.equals(membershipId)))
+          .getSingle();
+      expect(membershipStatusReaction(m.status),
+          MembershipStatusReaction.none);
+
+      // A pull applying the admin's `remove_staff_member` result flips the row.
+      await db.userBusinessesDao.markRemovedLocal(membershipId);
+
+      m = await (db.select(db.userBusinesses)
+            ..where((t) => t.id.equals(membershipId)))
+          .getSingle();
+      expect(m.status, 'removed');
+      expect(membershipStatusReaction(m.status),
+          MembershipStatusReaction.offboard,
+          reason: 'the removed device must run the offboarding gate → logout');
+    });
+  });
+
+  // ── Sole-member wipe gate — three branches (DAO signals + exceptions) ─────
+
+  group('sole-member wipe gate branches', () {
+    late AppDatabase db;
+    late String biz;
+
+    setUp(() async {
+      db = AppDatabase.forTesting(NativeDatabase.memory());
+      biz = UuidV7.generate();
+      await db
+          .into(db.businesses)
+          .insert(BusinessesCompanion.insert(id: Value(biz), name: 'Biz'));
+      db.businessIdResolver = () => biz;
+    });
+
+    tearDown(() => db.close());
+
+    Future<void> enqueuePending() async {
+      await db.into(db.syncQueue).insert(SyncQueueCompanion.insert(
+            businessId: biz,
+            actionType: 'orders:upsert',
+            payload: '{"id":"fake"}',
+          ));
+    }
+
+    Future<void> enqueueOrphan() async {
+      await db.into(db.syncQueueOrphans).insert(
+            SyncQueueOrphansCompanion.insert(
+              originalId: UuidV7.generate(),
+              actionType: 'orders:upsert',
+              payload: '{"business_id":"$biz"}',
+              reason: 'rls_denied',
+            ),
+          );
+    }
+
+    test('clean → proceed: both counts zero (safe to wipe)', () async {
+      expect(await db.syncDao.countPending(businessId: biz), 0);
+      expect(await db.syncDao.countOrphans(businessId: biz), 0);
+    });
+
+    test(
+        'retryable → block: a pending row makes countPending > 0 (caller throws '
+        'LogoutWipeException)', () async {
+      await enqueuePending();
+      expect(await db.syncDao.countPending(businessId: biz), greaterThan(0));
+
+      // The gate raises LogoutWipeException when retryable rows remain.
+      const ex = LogoutWipeException('You have 1 change not yet synced.');
+      expect(ex.message, contains('not yet synced'));
+      expect(ex.toString(), ex.message);
+    });
+
+    test(
+        'orphans only → Resolve-unsynced-data: countOrphans > 0 while '
+        'countPending == 0 (caller throws LogoutBlockedByUnsyncedDataException)',
+        () async {
+      await enqueueOrphan();
+      await enqueueOrphan();
+      expect(await db.syncDao.countPending(businessId: biz), 0);
+      expect(await db.syncDao.countOrphans(businessId: biz), 2);
+
+      // The gate raises the routing exception carrying the counts the Resolve
+      // dialog renders.
+      const ex = LogoutBlockedByUnsyncedDataException(
+          pendingCount: 0, orphanCount: 2);
+      expect(ex.pendingCount, 0);
+      expect(ex.orphanCount, 2);
+      expect(ex.totalCount, 2);
+    });
+
+    test('StaffResignException carries its plain-English message', () {
+      const ex = StaffResignException('You must be online to leave.');
+      expect(ex.message, 'You must be online to leave.');
+      expect(ex.toString(), ex.message);
+    });
+  });
+}


### PR DESCRIPTION
Closes #117.

## What

Staff offboarding, device side. A non-owner staff member can **Leave / delete my account** from Profile (one action, no permission needed), and an **admin-removed device reacts on its next pull/realtime**. In both cases the device safely logs the person out — reusing the existing unsynced-data gate so no offline sale is lost — and wipes local business data **only when they were the sole member of that business on the device**. The owner has no resign path (their exit is Delete Business).

## How

**Server — migration `0152_resign_own_membership.sql`** (mirrors `0149` `remove_staff_member`): `resign_own_membership(p_business_id)` SECURITY DEFINER RPC. The caller removes their OWN membership resolved by `auth.uid()` — sets `user_businesses.status = 'removed'` and nulls their own `users.auth_user_id` (frees the email; keeps the users row as an attribution stub) — and rejects the business owner (`cannot_resign_owner`). Called directly via `supabase.rpc`, not the outbox, exactly like `remove_staff_member`. No new permission key (resign needs no grant). Not yet deployed — validated by review against 0149; deploy on merge.

**Client**
- `AuthService.resignOwnMembership()` / `discardUnsyncedAndResign()` + `StaffResignException`. The unsynced-data gate runs **before** the RPC detaches us — pushing while we still hold access is what keeps clean rows from orphaning. The sole-user wipe gate and the shared-till teardown are **extracted** from `logOutCurrentUser` so logout and resign share one implementation (behaviour-preserving).
- **Profile**: non-owner staff see "Leave / delete my account"; the owner sees "Delete Business" (the existing `DeleteBusinessScreen` flow); neither renders while the role is still resolving.
- **Admin-removed detection**: the current user's own membership flipping to `removed` (applied by a pull) drives `membershipStatusReaction` → the same `logOutCurrentUser` offboarding, added next to the existing `suspended → lockApp` guard in `main.dart`.
- The **Resolve-unsynced-data** dialog gains an `isResign` terminal so the orphan-only path also completes the server-side detach.

## Acceptance criteria

- [x] Profile action "Leave / delete my account" (non-owner staff only) offboards the current user.
- [x] Before detaching, the unsynced-data gate runs: retryable → "connect and sync first"; orphans only → Resolve-unsynced-data (export → confirm → discard); clean → proceed.
- [x] An admin-removed device detects its own membership went `removed` on next pull/realtime and runs the same gate, then logs out. (See note.)
- [x] Shared till: only the person is removed (PIN + Who's Working card) unless they were the sole member on the device (then full wipe).
- [x] Owner sees Delete Business instead; no resign path for the owner.

## Tests

`test/staff/self_resign_test.dart` (11 cases): owner-exclusion predicates, membership reaction mapping (`removed → offboard`), pull-applied `removed` flip drives offboard, and the sole-member gate's three branches. `dart analyze` clean on all changed files.

## Note for review

Admin-removed detection relies on the device receiving the `removed` `user_businesses` row via pull/realtime **before** its RLS access is cut by the nulled `auth_user_id`. A device that is offline at removal (or whose access is cut before the row lands) may not flip locally until a further sync. A cold-start "am I still a member" backstop RPC would close that gap but is out of scope here (the AC scopes detection to pull/realtime). Flagged for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
