### PR TITLE
feat(inventory): optional product units, hidden when absent (#108)

### DIFF
--- a/lib/core/database/app_database.dart
+++ b/lib/core/database/app_database.dart
@@ -360,7 +360,13 @@ class Products extends Table {
   TextColumn get subtitle => text().nullable()();
   TextColumn get sku => text().nullable()();
   TextColumn get size => text().nullable()();
-  TextColumn get unit => text().withDefault(const Constant('Bottle'))();
+  // Nullable (#108): a product may have NO unit. When absent it renders nothing
+  // anywhere (inventory, POS grid, receipts, product/category detail) — just the
+  // name — and crate-eligibility treats it as "not a bottle". The Add/Edit form
+  // pre-fills the trade's Lexicon unit as a CLEARABLE suggestion; clearing it
+  // saves null. No DB default: absence is a real "no unit" state, never a silent
+  // 'Bottle'. See supabase/migrations/0151_products_unit_nullable.sql.
+  TextColumn get unit => text().nullable()();
   // Reebaplus pivot step 14 (schema v18): the four legacy price columns
   // (retail / bulk breaker / distributor / selling) were dropped; products
   // now hold exactly three prices — buying (already here), retailer,
@@ -410,8 +416,9 @@ class Products extends Table {
   @override
   List<String> get customConstraints => [
     "CHECK (size IS NULL OR size IN ('big','medium','small'))",
-    // Keep in lock-step with [kProductUnits] above.
-    "CHECK (unit IN ('Bottle','Can','PET','Sachet','Keg','Crate','Pack','Carton','Piece','Bag','Box','Tin','Other'))",
+    // Keep in lock-step with [kProductUnits] above. NULL allowed (#108): a
+    // product may have no unit.
+    "CHECK (unit IS NULL OR unit IN ('Bottle','Can','PET','Sachet','Keg','Crate','Pack','Carton','Piece','Bag','Box','Tin','Other'))",
   ];
 }
 
@@ -1846,7 +1853,7 @@ class AppDatabase extends _$AppDatabase {
   String? get currentAuthUserId => authUserIdResolver();
 
   @override
-  int get schemaVersion => 61;
+  int get schemaVersion => 62;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -4030,6 +4037,20 @@ class AppDatabase extends _$AppDatabase {
           "VALUES ('staff.remove', "
           "'Permanently remove staff (frees their email)', 'Staff')",
         );
+      }
+      if (from < 62) {
+        // v62 (#108 optional product units): products.unit becomes NULLABLE
+        // with a relaxed CHECK (null allowed) and no DB default — a product may
+        // have no unit. SQLite can't ALTER a column's NOT NULL / DEFAULT / CHECK
+        // in place, so rebuild the table from the current Drift schema (nullable
+        // unit, relaxed CHECK, no default) and copy every row. RELAXING keeps
+        // every existing non-null unit valid, so the 1:1 copy never fails — no
+        // backfill, existing units are unchanged. alterTable preserves the
+        // table's indexes and the bump_products_version trigger (re-creates them
+        // from sqlite_master), so nothing here needs manual recreation (same as
+        // the v24 products rebuild). Mirrors
+        // supabase/migrations/0151_products_unit_nullable.sql.
+        await m.alterTable(TableMigration(products));
       }
     },
     beforeOpen: (details) async {

--- a/lib/core/database/app_database.g.dart
+++ b/lib/core/database/app_database.g.dart
@@ -7374,10 +7374,9 @@ class $ProductsTable extends Products
   late final GeneratedColumn<String> unit = GeneratedColumn<String>(
     'unit',
     aliasedName,
-    false,
+    true,
     type: DriftSqlType.string,
     requiredDuringInsert: false,
-    defaultValue: const Constant('Bottle'),
   );
   static const VerificationMeta _retailerPriceKoboMeta = const VerificationMeta(
     'retailerPriceKobo',
@@ -7993,7 +7992,7 @@ class $ProductsTable extends Products
       unit: attachedDatabase.typeMapping.read(
         DriftSqlType.string,
         data['${effectivePrefix}unit'],
-      )!,
+      ),
       retailerPriceKobo: attachedDatabase.typeMapping.read(
         DriftSqlType.int,
         data['${effectivePrefix}retailer_price_kobo'],
@@ -8102,7 +8101,7 @@ class ProductData extends DataClass implements Insertable<ProductData> {
   final String? subtitle;
   final String? sku;
   final String? size;
-  final String unit;
+  final String? unit;
   final int retailerPriceKobo;
   final int wholesalerPriceKobo;
   final int buyingPriceKobo;
@@ -8136,7 +8135,7 @@ class ProductData extends DataClass implements Insertable<ProductData> {
     this.subtitle,
     this.sku,
     this.size,
-    required this.unit,
+    this.unit,
     required this.retailerPriceKobo,
     required this.wholesalerPriceKobo,
     required this.buyingPriceKobo,
@@ -8187,7 +8186,9 @@ class ProductData extends DataClass implements Insertable<ProductData> {
     if (!nullToAbsent || size != null) {
       map['size'] = Variable<String>(size);
     }
-    map['unit'] = Variable<String>(unit);
+    if (!nullToAbsent || unit != null) {
+      map['unit'] = Variable<String>(unit);
+    }
     map['retailer_price_kobo'] = Variable<int>(retailerPriceKobo);
     map['wholesaler_price_kobo'] = Variable<int>(wholesalerPriceKobo);
     map['buying_price_kobo'] = Variable<int>(buyingPriceKobo);
@@ -8247,7 +8248,7 @@ class ProductData extends DataClass implements Insertable<ProductData> {
           : Value(subtitle),
       sku: sku == null && nullToAbsent ? const Value.absent() : Value(sku),
       size: size == null && nullToAbsent ? const Value.absent() : Value(size),
-      unit: Value(unit),
+      unit: unit == null && nullToAbsent ? const Value.absent() : Value(unit),
       retailerPriceKobo: Value(retailerPriceKobo),
       wholesalerPriceKobo: Value(wholesalerPriceKobo),
       buyingPriceKobo: Value(buyingPriceKobo),
@@ -8301,7 +8302,7 @@ class ProductData extends DataClass implements Insertable<ProductData> {
       subtitle: serializer.fromJson<String?>(json['subtitle']),
       sku: serializer.fromJson<String?>(json['sku']),
       size: serializer.fromJson<String?>(json['size']),
-      unit: serializer.fromJson<String>(json['unit']),
+      unit: serializer.fromJson<String?>(json['unit']),
       retailerPriceKobo: serializer.fromJson<int>(json['retailerPriceKobo']),
       wholesalerPriceKobo: serializer.fromJson<int>(
         json['wholesalerPriceKobo'],
@@ -8346,7 +8347,7 @@ class ProductData extends DataClass implements Insertable<ProductData> {
       'subtitle': serializer.toJson<String?>(subtitle),
       'sku': serializer.toJson<String?>(sku),
       'size': serializer.toJson<String?>(size),
-      'unit': serializer.toJson<String>(unit),
+      'unit': serializer.toJson<String?>(unit),
       'retailerPriceKobo': serializer.toJson<int>(retailerPriceKobo),
       'wholesalerPriceKobo': serializer.toJson<int>(wholesalerPriceKobo),
       'buyingPriceKobo': serializer.toJson<int>(buyingPriceKobo),
@@ -8383,7 +8384,7 @@ class ProductData extends DataClass implements Insertable<ProductData> {
     Value<String?> subtitle = const Value.absent(),
     Value<String?> sku = const Value.absent(),
     Value<String?> size = const Value.absent(),
-    String? unit,
+    Value<String?> unit = const Value.absent(),
     int? retailerPriceKobo,
     int? wholesalerPriceKobo,
     int? buyingPriceKobo,
@@ -8421,7 +8422,7 @@ class ProductData extends DataClass implements Insertable<ProductData> {
     subtitle: subtitle.present ? subtitle.value : this.subtitle,
     sku: sku.present ? sku.value : this.sku,
     size: size.present ? size.value : this.size,
-    unit: unit ?? this.unit,
+    unit: unit.present ? unit.value : this.unit,
     retailerPriceKobo: retailerPriceKobo ?? this.retailerPriceKobo,
     wholesalerPriceKobo: wholesalerPriceKobo ?? this.wholesalerPriceKobo,
     buyingPriceKobo: buyingPriceKobo ?? this.buyingPriceKobo,
@@ -8651,7 +8652,7 @@ class ProductsCompanion extends UpdateCompanion<ProductData> {
   final Value<String?> subtitle;
   final Value<String?> sku;
   final Value<String?> size;
-  final Value<String> unit;
+  final Value<String?> unit;
   final Value<int> retailerPriceKobo;
   final Value<int> wholesalerPriceKobo;
   final Value<int> buyingPriceKobo;
@@ -8837,7 +8838,7 @@ class ProductsCompanion extends UpdateCompanion<ProductData> {
     Value<String?>? subtitle,
     Value<String?>? sku,
     Value<String?>? size,
-    Value<String>? unit,
+    Value<String?>? unit,
     Value<int>? retailerPriceKobo,
     Value<int>? wholesalerPriceKobo,
     Value<int>? buyingPriceKobo,
@@ -54983,7 +54984,7 @@ typedef $$ProductsTableCreateCompanionBuilder =
       Value<String?> subtitle,
       Value<String?> sku,
       Value<String?> size,
-      Value<String> unit,
+      Value<String?> unit,
       Value<int> retailerPriceKobo,
       Value<int> wholesalerPriceKobo,
       Value<int> buyingPriceKobo,
@@ -55020,7 +55021,7 @@ typedef $$ProductsTableUpdateCompanionBuilder =
       Value<String?> subtitle,
       Value<String?> sku,
       Value<String?> size,
-      Value<String> unit,
+      Value<String?> unit,
       Value<int> retailerPriceKobo,
       Value<int> wholesalerPriceKobo,
       Value<int> buyingPriceKobo,
@@ -56614,7 +56615,7 @@ class $$ProductsTableTableManager
                 Value<String?> subtitle = const Value.absent(),
                 Value<String?> sku = const Value.absent(),
                 Value<String?> size = const Value.absent(),
-                Value<String> unit = const Value.absent(),
+                Value<String?> unit = const Value.absent(),
                 Value<int> retailerPriceKobo = const Value.absent(),
                 Value<int> wholesalerPriceKobo = const Value.absent(),
                 Value<int> buyingPriceKobo = const Value.absent(),
@@ -56686,7 +56687,7 @@ class $$ProductsTableTableManager
                 Value<String?> subtitle = const Value.absent(),
                 Value<String?> sku = const Value.absent(),
                 Value<String?> size = const Value.absent(),
-                Value<String> unit = const Value.absent(),
+                Value<String?> unit = const Value.absent(),
                 Value<int> retailerPriceKobo = const Value.absent(),
                 Value<int> wholesalerPriceKobo = const Value.absent(),
                 Value<int> buyingPriceKobo = const Value.absent(),

--- a/lib/core/database/daos_catalog.dart
+++ b/lib/core/database/daos_catalog.dart
@@ -378,7 +378,11 @@ class CatalogDao extends DatabaseAccessor<AppDatabase>
     required int wholesalerPriceKobo,
     int? emptyCrateValueKobo,
     String? categoryId,
-    String? unit,
+    // Sentinel-defaulted (#108): omit to leave unit untouched, pass an explicit
+    // null to CLEAR it (a product with no unit), or a String to set it. A plain
+    // `null` therefore clears rather than "no change" — the edit form always
+    // passes the field's current value, so a cleared field persists as null.
+    Object? unit = _unset,
     bool? trackEmpties,
     bool? allowFractionalSales,
     int? lowStockThreshold,
@@ -414,7 +418,9 @@ class CatalogDao extends DatabaseAccessor<AppDatabase>
           ? const Value.absent()
           : Value(emptyCrateValueKobo),
       categoryId: Value(categoryId),
-      unit: unit == null ? const Value.absent() : Value(unit),
+      unit: identical(unit, _unset)
+          ? const Value.absent()
+          : Value(unit as String?),
       trackEmpties: trackEmpties == null
           ? const Value.absent()
           : Value(trackEmpties),
@@ -504,7 +510,9 @@ class CatalogDao extends DatabaseAccessor<AppDatabase>
       ..addColumns([products.unit])
       ..where(whereBusiness(products) & products.isDeleted.not());
     final rows = await query.get();
-    return rows.map((r) => r.read(products.unit)!).toList();
+    // A product may have no unit (#108) — drop the null so the form's unit
+    // suggestions never include a blank entry.
+    return rows.map((r) => r.read(products.unit)).whereType<String>().toList();
   }
 
   Future<void> updateMonthlyTarget(String productId, int targetUnits) async {

--- a/lib/core/database/daos_inventory.dart
+++ b/lib/core/database/daos_inventory.dart
@@ -1738,7 +1738,7 @@ class StockTransferDao extends DatabaseAccessor<AppDatabase>
         if (product == null) {
           throw StateError('Product ${transfer.productId} not found.');
         }
-        final isEligible = product.unit.toLowerCase() == 'bottle' && product.trackEmpties;
+        final isEligible = product.unit?.toLowerCase() == 'bottle' && product.trackEmpties;
         if (!isEligible) {
           throw StateError(
             'Product ${product.name} is not crate eligible (unit: ${product.unit}, trackEmpties: ${product.trackEmpties}).',

--- a/lib/core/database/daos_orders.dart
+++ b/lib/core/database/daos_orders.dart
@@ -646,7 +646,7 @@ class OrdersDao extends DatabaseAccessor<AppDatabase>
           if (product == null) continue;
           final mfrId = product.manufacturerId;
           if (mfrId == null) continue;
-          if (product.unit.toLowerCase() != 'bottle' || !product.trackEmpties) {
+          if (product.unit?.toLowerCase() != 'bottle' || !product.trackEmpties) {
             continue;
           }
           cratesByManufacturer.update(

--- a/lib/features/inventory/models/fast_add_product_model.dart
+++ b/lib/features/inventory/models/fast_add_product_model.dart
@@ -11,13 +11,6 @@ library;
 
 import 'package:reebaplus_pos/core/utils/currency_input_formatter.dart';
 
-/// The business-type-aware default unit (ADR 0006): `Bottle` when the business
-/// tracks crates — so empty-crate tracking auto-engages on its first product —
-/// and `Pack` otherwise. Written as an expression so later business types can
-/// supply their own default without touching call sites.
-String fastAddDefaultUnit({required bool tracksCrates}) =>
-    tracksCrates ? 'Bottle' : 'Pack';
-
 /// The business context the Fast-Add model needs, decoupled from widgets and
 /// the database. Built by the screen from the current business + role + stores.
 class FastAddContext {
@@ -154,7 +147,10 @@ final class FastAddIntent extends FastAddResult {
   /// 0 when the buying price was skipped or the role cannot edit it — an
   /// Uncosted product.
   final int buyingPriceKobo;
-  final String unit;
+
+  /// The resolved unit, or null (#108) when the clearable unit field was left
+  /// blank — a product with no unit, hidden everywhere it would render.
+  final String? unit;
 
   /// Effective track-empties (crate business AND the toggle on).
   final bool trackEmpties;
@@ -251,14 +247,16 @@ FastAddResult resolveFastAdd(FastAddInput input, FastAddContext context) {
   final wholesalerPriceKobo =
       wholesaleRaw.isEmpty ? retailerPriceKobo : _toKobo(wholesaleRaw);
 
-  // Unit + effective crate tracking.
-  final unit = (input.unit == null || input.unit!.trim().isEmpty)
-      ? fastAddDefaultUnit(tracksCrates: context.tracksCrates)
-      : input.unit!.trim();
+  // Unit + effective crate tracking. A blank/cleared unit (#108) resolves to
+  // null — no unit — not a trade default; the form pre-fills the trade's
+  // Lexicon unit as a clearable suggestion, so a non-blank value here is the
+  // user's kept choice and a blank one is a deliberate clear.
+  final unitRaw = input.unit?.trim() ?? '';
+  final String? unit = unitRaw.isEmpty ? null : unitRaw;
   final trackEmpties = context.tracksCrates && input.trackEmpties;
   final crateRaw = input.emptyCrateValue.trim();
   final int? emptyCrateValueKobo =
-      (trackEmpties && unit.toLowerCase() == 'bottle' && crateRaw.isNotEmpty)
+      (trackEmpties && unit?.toLowerCase() == 'bottle' && crateRaw.isNotEmpty)
       ? _toKobo(crateRaw)
       : null;
 

--- a/lib/features/inventory/screens/add_product_screen.dart
+++ b/lib/features/inventory/screens/add_product_screen.dart
@@ -66,7 +66,10 @@ class _AddProductScreenState extends ConsumerState<AddProductScreen> {
   /// null ⇒ a soft collision the form warns about; it never blocks the save.
   String? _barcodeCollisionName;
 
-  String _unit = 'Bottle';
+  // Nullable (#108): null = no unit. Pre-filled with the trade's Lexicon unit
+  // as a clearable suggestion (initState / _clearExistingProduct); clearing it
+  // via the dropdown's "No unit" option saves null.
+  String? _unit;
   bool _trackEmpties = true; // defaults true when unit is Bottle
   bool _allowFractionalSales = false;
   // Colour selector is deferred (master plan §16.5); products keep a default.
@@ -134,7 +137,7 @@ class _AddProductScreenState extends ConsumerState<AddProductScreen> {
     // default to a non-beverage trade.
     _unit = _lexicon.unit;
     _dynamicUnits = _lexicon.starterUnits;
-    _trackEmpties = _unit.toLowerCase() == 'bottle';
+    _trackEmpties = _unit?.toLowerCase() == 'bottle';
     _loadData();
   }
 
@@ -383,7 +386,7 @@ class _AddProductScreenState extends ConsumerState<AddProductScreen> {
       _unit = _lexicon.unit;
       _size = null;
       _expiryDate = null;
-      _trackEmpties = _unit.toLowerCase() == 'bottle';
+      _trackEmpties = _unit?.toLowerCase() == 'bottle';
       _allowFractionalSales = false;
       _selectedManufacturer = null;
       _selectedSupplier = null;
@@ -549,7 +552,7 @@ class _AddProductScreenState extends ConsumerState<AddProductScreen> {
 
   /// Empty-crate value in kobo, or null when not tracking empties / left blank.
   int? get _emptyCrateValueKobo {
-    if (!(_effectiveTrackEmpties && _unit.toLowerCase() == 'bottle')) {
+    if (!(_effectiveTrackEmpties && _unit?.toLowerCase() == 'bottle')) {
       return null;
     }
     final raw = _emptyCrateValueCtrl.text.trim();
@@ -1109,7 +1112,7 @@ class _AddProductScreenState extends ConsumerState<AddProductScreen> {
     final border = Theme.of(context).dividerColor;
     final isExisting = _selectedExistingProduct != null;
     final canEditBuying = Gates.editBuyingPrice.allows(ref);
-    final manufacturerRequired = _unit.toLowerCase() == 'bottle' && _isCrateBusiness && _trackEmpties;
+    final manufacturerRequired = _unit?.toLowerCase() == 'bottle' && _isCrateBusiness && _trackEmpties;
 
     return Scaffold(
       // Keep the body + save button above the keyboard. This screen is pushed
@@ -1416,23 +1419,31 @@ class _AddProductScreenState extends ConsumerState<AddProductScreen> {
                 ),
                 const SizedBox(height: 16),
 
-                // ── PRODUCT UNIT SELECTOR ──────────────────────────────
-                _sectionLabel('PRODUCT UNIT *', subtext),
+                // ── PRODUCT UNIT SELECTOR (optional, #108) ─────────────
+                _sectionLabel('PRODUCT UNIT', subtext),
                 const SizedBox(height: 8),
-                AppDropdown<String>(
+                AppDropdown<String?>(
                   value: _unit,
-                  items: _dynamicUnits
-                      .map((u) => DropdownMenuItem(value: u, child: Text(u)))
-                      .toList(),
+                  hintText: 'No unit',
+                  // "No unit" (#108) clears the unit — the product saves with
+                  // just its name and is hidden wherever the unit would render.
+                  items: [
+                    const DropdownMenuItem<String?>(
+                      value: null,
+                      child: Text('No unit'),
+                    ),
+                    ..._dynamicUnits.map(
+                      (u) =>
+                          DropdownMenuItem<String?>(value: u, child: Text(u)),
+                    ),
+                  ],
                   onChanged: (v) {
-                    if (v != null) {
-                      setState(() {
-                        _unit = v;
-                        // Auto-enable tracking for bottle products,
-                        // clear it for everything else.
-                        _trackEmpties = v.toLowerCase() == 'bottle';
-                      });
-                    }
+                    setState(() {
+                      _unit = v;
+                      // Auto-enable tracking for bottle products, off otherwise
+                      // (a null unit is not a bottle).
+                      _trackEmpties = v?.toLowerCase() == 'bottle';
+                    });
                   },
                 ),
                 const SizedBox(height: 8),
@@ -1522,7 +1533,7 @@ class _AddProductScreenState extends ConsumerState<AddProductScreen> {
                 // ── TRACK EMPTIES + CRATE VALUE (directly below Manufacturer) ─
                 // Crate-only (rule #13): hidden for non-Bar/Beer-distributor
                 // businesses; _effectiveTrackEmpties also forces it off on save.
-                if (_unit.toLowerCase() == 'bottle' && _isCrateBusiness) ...[
+                if (_unit?.toLowerCase() == 'bottle' && _isCrateBusiness) ...[
                   CheckboxListTile(
                     value: _trackEmpties,
                     onChanged: (v) =>
@@ -1858,19 +1869,27 @@ class _AddProductScreenState extends ConsumerState<AddProductScreen> {
       // ── PRODUCT UNIT ────────────────────────────────────────────────────
       _sectionLabel('PRODUCT UNIT', subtext),
       const SizedBox(height: 8),
-      AppDropdown<String>(
+      AppDropdown<String?>(
         value: _unit,
-        items: _dynamicUnits
-            .map((u) => DropdownMenuItem(value: u, child: Text(u)))
-            .toList(),
+        hintText: 'No unit',
+        // "No unit" (#108) clears the unit — the product saves with just its
+        // name and is hidden wherever the unit would render.
+        items: [
+          const DropdownMenuItem<String?>(
+            value: null,
+            child: Text('No unit'),
+          ),
+          ..._dynamicUnits.map(
+            (u) => DropdownMenuItem<String?>(value: u, child: Text(u)),
+          ),
+        ],
         onChanged: (v) {
-          if (v != null) {
-            setState(() {
-              _unit = v;
-              // Auto-enable tracking for bottle products, clear it otherwise.
-              _trackEmpties = v.toLowerCase() == 'bottle';
-            });
-          }
+          setState(() {
+            _unit = v;
+            // Auto-enable tracking for bottle products, off otherwise (a null
+            // unit is not a bottle).
+            _trackEmpties = v?.toLowerCase() == 'bottle';
+          });
         },
       ),
       const SizedBox(height: 8),
@@ -1890,7 +1909,7 @@ class _AddProductScreenState extends ConsumerState<AddProductScreen> {
       const SizedBox(height: 16),
 
       // ── TRACK EMPTIES + CRATE VALUE (crate business + bottle only) ──────
-      if (_unit.toLowerCase() == 'bottle' && _isCrateBusiness) ...[
+      if (_unit?.toLowerCase() == 'bottle' && _isCrateBusiness) ...[
         CheckboxListTile(
           value: _trackEmpties,
           onChanged: (v) => setState(() => _trackEmpties = v ?? false),

--- a/lib/features/inventory/screens/inventory_screen.dart
+++ b/lib/features/inventory/screens/inventory_screen.dart
@@ -1335,13 +1335,15 @@ class _InventoryScreenState extends ConsumerState<InventoryScreen>
                       ),
                     ),
                   ),
-                  Text(
-                    product.unit,
-                    style: TextStyle(
-                      fontSize: context.getRFontSize(11),
-                      color: _subtext,
+                  // A unitless product (#108) shows just the count — no label.
+                  if ((product.unit ?? '').isNotEmpty)
+                    Text(
+                      product.unit!,
+                      style: TextStyle(
+                        fontSize: context.getRFontSize(11),
+                        color: _subtext,
+                      ),
                     ),
-                  ),
                 ],
               ),
             ],

--- a/lib/features/inventory/screens/product_detail_screen.dart
+++ b/lib/features/inventory/screens/product_detail_screen.dart
@@ -321,8 +321,9 @@ class _ProductDetailScreenState extends ConsumerState<ProductDetailScreen> {
     // when a synced row carries a null/foreign imagePath.
     if (product.imagePath != null) _imagePath = product.imagePath;
     // Keep the unit dropdown inclusive of a (possibly new) synced unit value.
-    if (!_allUnits.contains(product.unit)) {
-      _allUnits = ({..._allUnits, product.unit}.toList())..sort();
+    // A unitless product (#108) has nothing to add.
+    if (product.unit != null && !_allUnits.contains(product.unit)) {
+      _allUnits = ({..._allUnits, product.unit!}.toList())..sort();
     }
   }
 
@@ -958,9 +959,19 @@ class _ProductDetailScreenState extends ConsumerState<ProductDetailScreen> {
                 width: context.getRSize(150),
                 child: AppDropdown<String?>(
                   value: _selectedUnit,
-                  items: _allUnits
-                      .map((u) => DropdownMenuItem(value: u, child: Text(u)))
-                      .toList(),
+                  hintText: 'No unit',
+                  // "No unit" (#108) clears the unit — a product with just a
+                  // name, hidden everywhere the unit would render.
+                  items: [
+                    const DropdownMenuItem<String?>(
+                      value: null,
+                      child: Text('No unit'),
+                    ),
+                    ..._allUnits.map(
+                      (u) =>
+                          DropdownMenuItem<String?>(value: u, child: Text(u)),
+                    ),
+                  ],
                   onChanged: _editMode
                       ? (val) => setState(() => _selectedUnit = val)
                       : (_) {},
@@ -1751,7 +1762,7 @@ class _ProductDetailScreenState extends ConsumerState<ProductDetailScreen> {
                   : (notes.isEmpty ? 'Stock added by $actorName' : notes);
               final summary =
                   '$actorName ${isRemove ? 'removed' : 'added'} $qty '
-                  '${product.unit}(s) of ${product.name} '
+                  '${product.unit != null ? '${product.unit}(s) ' : ''}of ${product.name} '
                   '(${store.name})'
                   '${isRemove ? ' — ${reason!}' : ''}';
               final isStockKeeper =

--- a/lib/features/inventory/screens/stock_count_screen.dart
+++ b/lib/features/inventory/screens/stock_count_screen.dart
@@ -656,7 +656,7 @@ class _StockCountScreenState extends ConsumerState<StockCountScreen> {
               // and only when the business opted into crate tracking.
               final isTrackedBottle =
                   tracksCrates &&
-                  p.product.unit.toLowerCase() == 'bottle' &&
+                  p.product.unit?.toLowerCase() == 'bottle' &&
                   p.product.trackEmpties;
               final fate = isTrackedBottle ? crateFate : 'none';
 
@@ -880,7 +880,7 @@ class _StockCountScreenState extends ConsumerState<StockCountScreen> {
                         final tb =
                             tracksCrates &&
                             v != null &&
-                            v.product.unit.toLowerCase() == 'bottle' &&
+                            v.product.unit?.toLowerCase() == 'bottle' &&
                             v.product.trackEmpties;
                         if (!tb) crateFate = 'none';
                       }),
@@ -912,7 +912,7 @@ class _StockCountScreenState extends ConsumerState<StockCountScreen> {
                     // deposit too. Ask whether the empty crate went with it.
                     if (tracksCrates &&
                         product != null &&
-                        product!.product.unit.toLowerCase() == 'bottle' &&
+                        product!.product.unit?.toLowerCase() == 'bottle' &&
                         product!.product.trackEmpties) ...[
                       SizedBox(height: context.getRSize(14)),
                       AppDropdown<String>(

--- a/lib/features/inventory/widgets/update_product_sheet.dart
+++ b/lib/features/inventory/widgets/update_product_sheet.dart
@@ -59,7 +59,9 @@ class _UpdateProductSheetState extends ConsumerState<UpdateProductSheet> {
   /// null ⇒ a soft collision the sheet warns about; it never blocks the save.
   String? _barcodeCollisionName;
 
-  late String _unit;
+  // Nullable (#108): null = no unit. Seeded from the product (which may already
+  // have no unit) and cleared via the dropdown's "No unit" option.
+  String? _unit;
   late bool _trackEmpties;
   late bool _allowFractionalSales;
   late String _colorHex;
@@ -120,7 +122,7 @@ class _UpdateProductSheetState extends ConsumerState<UpdateProductSheet> {
 
   /// Empty-crate value in kobo, or null when not tracking empties / left blank.
   int? get _emptyCrateValueKobo {
-    if (!(_effectiveTrackEmpties && _unit.toLowerCase() == 'bottle')) {
+    if (!(_effectiveTrackEmpties && _unit?.toLowerCase() == 'bottle')) {
       return null;
     }
     final raw = _emptyCrateValueCtrl.text.trim();
@@ -174,8 +176,11 @@ class _UpdateProductSheetState extends ConsumerState<UpdateProductSheet> {
 
     _unit = p.unit;
     // The industry's starter units, plus this product's own unit so the
-    // dropdown always includes the selected value (#80).
-    _dynamicUnits = <String>{..._lexicon.starterUnits, p.unit}.toList()..sort();
+    // dropdown always includes the selected value (#80). A unitless product
+    // (#108) contributes nothing.
+    _dynamicUnits =
+        <String>{..._lexicon.starterUnits, if (p.unit != null) p.unit!}.toList()
+          ..sort();
     _trackEmpties = p.trackEmpties;
     _allowFractionalSales = p.allowFractionalSales;
     _size = p.size;
@@ -208,9 +213,13 @@ class _UpdateProductSheetState extends ConsumerState<UpdateProductSheet> {
       _allSuppliers = suppliers;
       _allManufacturers = manufacturers;
       _allCategories = cats;
-      _dynamicUnits = <String>{..._lexicon.starterUnits, _unit, ...uniqueUnits}
-          .toList()
-        ..sort();
+      _dynamicUnits =
+          <String>{
+              ..._lexicon.starterUnits,
+              if (_unit != null) _unit!,
+              ...uniqueUnits,
+            }.toList()
+            ..sort();
       if (cachedPhoto != null) _imagePath = cachedPhoto;
 
       // Pre-select store: prefer currentStoreId, else first
@@ -729,7 +738,7 @@ class _UpdateProductSheetState extends ConsumerState<UpdateProductSheet> {
         Theme.of(context).textTheme.bodySmall?.color ??
         Theme.of(context).iconTheme.color!;
     final border = Theme.of(context).dividerColor;
-    final manufacturerRequired = _unit.toLowerCase() == 'bottle' && _isCrateBusiness && _trackEmpties;
+    final manufacturerRequired = _unit?.toLowerCase() == 'bottle' && _isCrateBusiness && _trackEmpties;
 
     return Padding(
       padding: EdgeInsets.only(bottom: context.deviceBottomPadding),
@@ -1063,27 +1072,32 @@ class _UpdateProductSheetState extends ConsumerState<UpdateProductSheet> {
                     ),
                     const SizedBox(height: 16),
 
-                    // ── PRODUCT UNIT ─────────────────────────────────────────
-                    _sectionLabel('PRODUCT UNIT *', subtext),
+                    // ── PRODUCT UNIT (optional, #108) ────────────────────────
+                    _sectionLabel('PRODUCT UNIT', subtext),
                     const SizedBox(height: 8),
-                    AppDropdown<String>(
+                    AppDropdown<String?>(
                       value: _unit,
-                      items: _dynamicUnits
-                          .map(
-                            (u) => DropdownMenuItem(value: u, child: Text(u)),
-                          )
-                          .toList(),
+                      hintText: 'No unit',
+                      // "No unit" (#108) clears the unit — the product keeps
+                      // just its name and is hidden wherever the unit renders.
+                      items: [
+                        const DropdownMenuItem<String?>(
+                          value: null,
+                          child: Text('No unit'),
+                        ),
+                        ..._dynamicUnits.map(
+                          (u) => DropdownMenuItem<String?>(
+                            value: u,
+                            child: Text(u),
+                          ),
+                        ),
+                      ],
                       onChanged: (v) {
-                        if (v != null) {
-                          setState(() {
-                            _unit = v;
-                            if (v.toLowerCase() == 'bottle') {
-                              _trackEmpties = true;
-                            } else {
-                              _trackEmpties = false;
-                            }
-                          });
-                        }
+                        setState(() {
+                          _unit = v;
+                          // A null unit is not a bottle → no crate tracking.
+                          _trackEmpties = v?.toLowerCase() == 'bottle';
+                        });
                       },
                     ),
                     const SizedBox(height: 8),
@@ -1198,7 +1212,7 @@ class _UpdateProductSheetState extends ConsumerState<UpdateProductSheet> {
                     // ── TRACK EMPTIES + CRATE VALUE (directly below Manufacturer) ─
                     // Crate-only (rule #13): hidden for non-Bar/Beer-distributor
                     // businesses; _effectiveTrackEmpties forces it off on save.
-                    if (_unit.toLowerCase() == 'bottle' &&
+                    if (_unit?.toLowerCase() == 'bottle' &&
                         _isCrateBusiness) ...[
                       Material(
                         type: MaterialType.transparency,

--- a/lib/features/orders/widgets/crate_return_modal.dart
+++ b/lib/features/orders/widgets/crate_return_modal.dart
@@ -57,7 +57,7 @@ class CrateReturnModal extends ConsumerStatefulWidget {
     // Guard 1: skip if no bottle items with trackEmpties enabled
     final hasBottles = orderWithItems.items.any((i) {
       final p = i.product; // null for a Quick Sale line — never a crate product
-      return p != null && p.unit.toLowerCase() == 'bottle' && p.trackEmpties;
+      return p != null && p.unit?.toLowerCase() == 'bottle' && p.trackEmpties;
     });
     if (!hasBottles) return CrateReturnResult.empty; // no crates to track
 
@@ -149,7 +149,7 @@ class _CrateReturnModalState extends ConsumerState<CrateReturnModal> {
         if (product == null) {
           continue; // Quick Sale line — never a crate product
         }
-        if (product.unit.toLowerCase() != 'bottle') continue;
+        if (product.unit?.toLowerCase() != 'bottle') continue;
         if (!product.trackEmpties) continue;
         final mfId = product.manufacturerId ?? '';
         if (mfId.isEmpty) continue; // can't track crates without a manufacturer

--- a/lib/features/receiving/screens/receive_cart_screen.dart
+++ b/lib/features/receiving/screens/receive_cart_screen.dart
@@ -209,14 +209,20 @@ class ReceiveCartScreen extends ConsumerWidget {
                                     SizedBox(height: context.getRSize(4)),
                                     Row(
                                       children: [
-                                        Text(
-                                          line.unit ?? 'Unit',
-                                          style: TextStyle(
-                                            fontSize: context.getRFontSize(13),
-                                            color: text.withValues(alpha: 0.6),
+                                        // A unitless product (#108) shows no
+                                        // unit label — just its cost.
+                                        if ((line.unit ?? '').isNotEmpty) ...[
+                                          Text(
+                                            line.unit!,
+                                            style: TextStyle(
+                                              fontSize:
+                                                  context.getRFontSize(13),
+                                              color:
+                                                  text.withValues(alpha: 0.6),
+                                            ),
                                           ),
-                                        ),
-                                        SizedBox(width: context.getRSize(8)),
+                                          SizedBox(width: context.getRSize(8)),
+                                        ],
                                         Flexible(
                                           child: Container(
                                             padding: EdgeInsets.symmetric(

--- a/lib/features/receiving/widgets/receive_product_grid.dart
+++ b/lib/features/receiving/widgets/receive_product_grid.dart
@@ -283,7 +283,7 @@ class _ReceiveProductCard extends ConsumerWidget {
               ),
               SizedBox(height: context.getRSize(2)),
               Text(
-                '${product.size != null && product.size!.isNotEmpty ? '${product.size} ' : ''}${product.unit}'.trim(),
+                '${product.size != null && product.size!.isNotEmpty ? '${product.size} ' : ''}${product.unit ?? ''}'.trim(),
                 style: TextStyle(
                   fontSize: context.getRFontSize(11),
                   color: subtextCol,

--- a/lib/features/stores/screens/store_details_screen.dart
+++ b/lib/features/stores/screens/store_details_screen.dart
@@ -483,10 +483,10 @@ class _StoreDetailsScreenState extends ConsumerState<StoreDetailsScreen> {
                                     color: _text,
                                   ),
                                 ),
-                                if (item.product.unit.isNotEmpty) ...[
+                                if ((item.product.unit ?? '').isNotEmpty) ...[
                                   SizedBox(height: rSize(context, 2)),
                                   Text(
-                                    item.product.unit,
+                                    item.product.unit!,
                                     style: TextStyle(
                                       fontSize: rFontSize(context, 11),
                                       color: _subtext,

--- a/lib/features/stores/widgets/store_transfer_hub.dart
+++ b/lib/features/stores/widgets/store_transfer_hub.dart
@@ -111,7 +111,7 @@ class StoreTransferHub extends ConsumerWidget {
           builder: (t) {
             final p = productMap[t.productId];
             final manufacturerId = p?.manufacturerId;
-            final isCrateEligible = p != null && p.unit.toLowerCase() == 'bottle' && p.trackEmpties;
+            final isCrateEligible = p != null && p.unit?.toLowerCase() == 'bottle' && p.trackEmpties;
             final availableEmpties = manufacturerId != null ? (emptiesMap[manufacturerId] ?? 0) : 0;
             return _TransferActionCard(
               transfer: t,

--- a/supabase/migrations/0151_products_unit_nullable.sql
+++ b/supabase/migrations/0151_products_unit_nullable.sql
@@ -1,0 +1,54 @@
+-- 0151_products_unit_nullable.sql
+--
+-- Reebaplus (#108) — optional product units. A product may have NO unit; when
+-- absent it renders nothing anywhere and crate-eligibility treats it as "not a
+-- bottle". This makes products.unit nullable cloud-side, matching the local
+-- Drift change (schema v62, products table rebuild in app_database.dart
+-- onUpgrade from < 62).
+--
+-- Background:
+--   0001 declared the column
+--     unit text NOT NULL DEFAULT 'Bottle'
+--       CHECK (unit IN (...))                                   (0001:277-278)
+--   and 0065 widened the CHECK to the current 13 units (products_unit_check).
+--
+-- Fix (all additive / backward-compatible — every existing value still
+-- validates, only NULL becomes newly legal; no data change, no backfill):
+--   1. DROP NOT NULL so a product may carry no unit.
+--   2. DROP DEFAULT so an omitted unit stays NULL ("no unit") rather than
+--      silently becoming 'Bottle'. Every product-insert path (mobile outbox
+--      upserts, pos_upsert_product, web pos_create_product) supplies unit
+--      explicitly, so the column default is not load-bearing — the app sends an
+--      explicit null for a unitless product.
+--   3. Relax the CHECK to admit NULL.
+-- Idempotent.
+
+BEGIN;
+
+ALTER TABLE public.products ALTER COLUMN unit DROP NOT NULL;
+ALTER TABLE public.products ALTER COLUMN unit DROP DEFAULT;
+
+-- Drop whatever CHECK constraint currently governs unit, regardless of its
+-- auto-generated name (match by definition, not name — a wrong name would
+-- silently leave the old NOT-NULL-implying constraint in place and still reject
+-- NULL). Excludes the unit_price checks on line-item tables via the table
+-- filter (conrelid) and the '%unit_price%' guard.
+DO $$
+DECLARE c text;
+BEGIN
+  FOR c IN
+    SELECT conname FROM pg_constraint
+    WHERE conrelid = 'public.products'::regclass
+      AND contype = 'c'
+      AND pg_get_constraintdef(oid) ILIKE '%unit%'
+      AND pg_get_constraintdef(oid) NOT ILIKE '%unit_price%'
+  LOOP
+    EXECUTE format('ALTER TABLE public.products DROP CONSTRAINT %I', c);
+  END LOOP;
+END $$;
+
+ALTER TABLE public.products
+  ADD CONSTRAINT products_unit_check
+  CHECK (unit IS NULL OR unit IN ('Bottle','Can','PET','Sachet','Keg','Crate','Pack','Carton','Piece','Bag','Box','Tin','Other'));
+
+COMMIT;

--- a/test/inventory/fast_add_product_model_test.dart
+++ b/test/inventory/fast_add_product_model_test.dart
@@ -44,32 +44,43 @@ void main() {
     selectedStoreId: selectedStoreId,
   );
 
-  group('business-type-aware unit default', () {
-    test('defaults to Bottle for a crate-tracking business', () {
-      expect(fastAddDefaultUnit(tracksCrates: true), 'Bottle');
-    });
-
-    test('defaults to Pack otherwise', () {
-      expect(fastAddDefaultUnit(tracksCrates: false), 'Pack');
-    });
-
-    test('an unset unit resolves to the business-type default (crate)', () {
+  group('optional unit (#108)', () {
+    // The form pre-fills the trade's Lexicon unit as a clearable suggestion, so
+    // the model no longer invents a trade default: a blank/cleared unit means
+    // the user deliberately chose "no unit" and resolves to null.
+    test('an unset unit resolves to null — no unit, no trade default', () {
       final result = resolveFastAdd(
         input(unit: null, hasManufacturer: true),
         ctx(tracksCrates: true),
       );
       expect(result, isA<FastAddIntent>());
-      expect((result as FastAddIntent).unit, 'Bottle');
+      expect((result as FastAddIntent).unit, isNull);
     });
 
-    test('an unset unit resolves to the business-type default (non-crate)', () {
-      final result = resolveFastAdd(input(unit: null), ctx());
-      expect((result as FastAddIntent).unit, 'Pack');
+    test('a cleared (blank) unit resolves to null', () {
+      final result = resolveFastAdd(input(unit: ''), ctx());
+      expect((result as FastAddIntent).unit, isNull);
     });
 
-    test('an explicit unit is preserved', () {
-      final result = resolveFastAdd(input(unit: 'Can'), ctx());
+    test('a whitespace-only unit resolves to null', () {
+      final result = resolveFastAdd(input(unit: '   '), ctx());
+      expect((result as FastAddIntent).unit, isNull);
+    });
+
+    test('an explicit unit is preserved (and trimmed)', () {
+      final result = resolveFastAdd(input(unit: '  Can '), ctx());
       expect((result as FastAddIntent).unit, 'Can');
+    });
+
+    test('a null unit is not a bottle → no crate deposit value', () {
+      // A crate business tracking empties: with no unit the deposit value is
+      // dropped because a null unit is never a bottle.
+      final result = resolveFastAdd(
+        input(unit: null, hasManufacturer: true, emptyCrateValue: '500'),
+        ctx(tracksCrates: true),
+      );
+      expect((result as FastAddIntent).unit, isNull);
+      expect(result.emptyCrateValueKobo, isNull);
     });
   });
 
@@ -88,7 +99,8 @@ void main() {
       expect(intent.name, 'Eva Water 75cl');
       expect(intent.retailerPriceKobo, 25000);
       expect(intent.initialStock, 6);
-      expect(intent.unit, 'Pack');
+      // No unit supplied and none invented (#108): a blank field is "no unit".
+      expect(intent.unit, isNull);
       expect(intent.storeId, 'store-1');
     });
   });

--- a/test/inventory/optional_unit_test.dart
+++ b/test/inventory/optional_unit_test.dart
@@ -1,0 +1,220 @@
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reebaplus_pos/core/database/app_database.dart';
+import 'package:reebaplus_pos/core/utils/product_name.dart';
+import 'package:drift/drift.dart' hide isNull;
+
+/// Optional product units (#108). A product may have NO unit; when absent it
+/// renders nothing anywhere and crate-eligibility treats it as "not a bottle".
+/// These tests pin the three behaviours the acceptance criteria call out:
+///   • a null unit PERSISTS (insert + clear-on-edit) — no silent 'Bottle',
+///   • a null unit RENDERS as absent (the shared display helper), and
+///   • the crate gate treats a null unit as NON-bottle.
+void main() {
+  group('productDisplayName renders an absent unit as nothing (#108)', () {
+    test('a null unit shows just the name', () {
+      expect(productDisplayName('Goldberg', null, unit: null), 'Goldberg');
+    });
+
+    test('a null unit still keeps the size abbreviation', () {
+      expect(productDisplayName('Goldberg', 'big', unit: null), 'Goldberg (B)');
+    });
+
+    test('an empty-string unit is treated as absent', () {
+      expect(productDisplayName('Goldberg', null, unit: ''), 'Goldberg');
+    });
+
+    test('a present unit is still prepended', () {
+      expect(
+        productDisplayName('Goldberg', null, unit: 'Bottle'),
+        'Bottle Goldberg',
+      );
+    });
+  });
+
+  group('CatalogDao — a null unit persists (#108)', () {
+    late AppDatabase db;
+    const businessId = 'biz-1';
+
+    setUp(() async {
+      db = AppDatabase.forTesting(NativeDatabase.memory());
+      db.businessIdResolver = () => businessId;
+      await db.into(db.businesses).insert(
+            BusinessesCompanion.insert(
+              id: const Value(businessId),
+              name: 'Test Biz',
+            ),
+          );
+    });
+
+    tearDown(() async => db.close());
+
+    test('a product saved with no unit reads back null', () async {
+      final id = await db.catalogDao.insertProduct(
+        const ProductsCompanion(
+          businessId: Value(businessId),
+          name: Value('Just A Name'),
+          unit: Value(null),
+        ),
+      );
+
+      final row = await (db.select(db.products)
+            ..where((t) => t.id.equals(id)))
+          .getSingle();
+      expect(row.unit, isNull);
+    });
+
+    test('clearing a unit on edit persists null (not "leave untouched")',
+        () async {
+      final id = await db.catalogDao.insertProduct(
+        const ProductsCompanion(
+          businessId: Value(businessId),
+          name: Value('Was Bottled'),
+          unit: Value('Bottle'),
+        ),
+      );
+
+      // The edit form passes the field's current value; a cleared field is an
+      // explicit null, which must CLEAR the column rather than skip it.
+      await db.catalogDao.updateProductDetails(
+        id,
+        name: 'Was Bottled',
+        buyingPriceKobo: 0,
+        retailerPriceKobo: 1000,
+        wholesalerPriceKobo: 1000,
+        unit: null,
+      );
+
+      final row = await (db.select(db.products)
+            ..where((t) => t.id.equals(id)))
+          .getSingle();
+      expect(row.unit, isNull);
+    });
+
+    test('omitting unit on edit leaves the existing unit untouched', () async {
+      final id = await db.catalogDao.insertProduct(
+        const ProductsCompanion(
+          businessId: Value(businessId),
+          name: Value('Keeps Its Unit'),
+          unit: Value('Can'),
+        ),
+      );
+
+      // No `unit:` argument → the sentinel default → the column is not written.
+      await db.catalogDao.updateProductDetails(
+        id,
+        name: 'Keeps Its Unit',
+        buyingPriceKobo: 0,
+        retailerPriceKobo: 1000,
+        wholesalerPriceKobo: 1000,
+      );
+
+      final row = await (db.select(db.products)
+            ..where((t) => t.id.equals(id)))
+          .getSingle();
+      expect(row.unit, 'Can');
+    });
+
+    test('getUniqueProductUnits skips the null unit', () async {
+      await db.catalogDao.insertProduct(
+        const ProductsCompanion(
+          businessId: Value(businessId),
+          name: Value('Bottled'),
+          unit: Value('Bottle'),
+        ),
+      );
+      await db.catalogDao.insertProduct(
+        const ProductsCompanion(
+          businessId: Value(businessId),
+          name: Value('Unitless'),
+          unit: Value(null),
+        ),
+      );
+
+      final units = await db.catalogDao.getUniqueProductUnits();
+      expect(units, contains('Bottle'));
+      expect(units, isNot(contains(null)));
+    });
+  });
+
+  group('crate-eligibility treats a null unit as not-a-bottle (#108)', () {
+    late AppDatabase db;
+    const businessId = 'biz-1';
+    const storeId = 'store-1';
+    const manufacturerId = 'mfr-1';
+
+    setUp(() async {
+      db = AppDatabase.forTesting(NativeDatabase.memory());
+      db.businessIdResolver = () => businessId;
+      await db.into(db.businesses).insert(
+            BusinessesCompanion.insert(
+              id: const Value(businessId),
+              name: 'Test Biz',
+            ),
+          );
+      await db.into(db.stores).insert(
+            StoresCompanion.insert(
+              id: const Value(storeId),
+              businessId: businessId,
+              name: 'Main',
+            ),
+          );
+      await db.into(db.manufacturers).insert(
+            ManufacturersCompanion.insert(
+              id: const Value(manufacturerId),
+              businessId: businessId,
+              name: 'Test Mfr',
+            ),
+          );
+    });
+
+    tearDown(() async => db.close());
+
+    test('a unitless tracked product is excluded from the full-crate count',
+        () async {
+      // Both products are tracked and share a manufacturer; only the Bottle is
+      // a bottle. The unitless product must NOT count toward full crates.
+      final bottleId = await db.catalogDao.insertProduct(
+        const ProductsCompanion(
+          businessId: Value(businessId),
+          name: Value('Bottled Water'),
+          unit: Value('Bottle'),
+          manufacturerId: Value(manufacturerId),
+          trackEmpties: Value(true),
+        ),
+      );
+      final unitlessId = await db.catalogDao.insertProduct(
+        const ProductsCompanion(
+          businessId: Value(businessId),
+          name: Value('Unitless Item'),
+          unit: Value(null),
+          manufacturerId: Value(manufacturerId),
+          trackEmpties: Value(true),
+        ),
+      );
+
+      await db.into(db.inventory).insert(
+            InventoryCompanion.insert(
+              businessId: businessId,
+              productId: bottleId,
+              storeId: storeId,
+              quantity: const Value(12),
+            ),
+          );
+      await db.into(db.inventory).insert(
+            InventoryCompanion.insert(
+              businessId: businessId,
+              productId: unitlessId,
+              storeId: storeId,
+              quantity: const Value(7),
+            ),
+          );
+
+      final crates =
+          await db.inventoryDao.watchFullCratesByManufacturer().first;
+      // 12 (the Bottle) only — the unitless product's 7 is excluded, proving a
+      // null unit is treated as not-a-bottle.
+      expect(crates[manufacturerId], 12);
+    });
+  });
+}


### PR DESCRIPTION
Closes #108.

## What
A product may now have **no unit**. When absent, the unit isn't shown anywhere — inventory, POS grid, receipts, product/category detail — just the name. The Add/Edit form pre-fills the trade's Lexicon unit as a **clearable** suggestion; clearing it saves no unit. Existing products are untouched.

## Acceptance criteria
- [x] `products.unit` becomes nullable with a relaxed check (null allowed) on client + cloud.
  - Drift schema **v62**: `unit` column `nullable()`, no default, CHECK relaxed to `unit IS NULL OR unit IN (...)`, with a `from < 62` `TableMigration(products)` rebuild (mirrors the v24 pattern).
  - Cloud **`0151_products_unit_nullable.sql`**: `DROP NOT NULL` + `DROP DEFAULT` + relaxed CHECK (drop-by-definition-lookup like 0065). Additive/safe, no backfill.
- [x] Add/edit form unit is a clearable field defaulting to the trade's Lexicon unit; clearing it saves no unit.
  - Both add-screen dropdowns + the edit sheet + product detail are now `AppDropdown<String?>` with a **"No unit"** option; the fast-add model maps a blank field to `null` (no invented trade default). `updateProductDetails.unit` uses the `_unset` sentinel so a cleared field persists as `null` while an omitted arg leaves the column untouched.
- [x] Absent unit renders nothing across inventory, POS grid, receipts, product/category detail; crate-eligibility treats a null unit as "not a bottle".
  - Every `unit == 'bottle' && trackEmpties` gate is now null-safe (`unit?.toLowerCase()`), so a null unit is never a bottle. Display sites hide an absent unit instead of printing an empty/`null` label.
- [x] No data backfill; existing units unchanged.

## Sync
A cleared unit pushes `"unit": null` (verified: the `ProductsCompanion.toColumns` companion path serializes a present `Value(null)`), so the clear converges cross-device against the now-nullable cloud column.

## Tests
- New `test/inventory/optional_unit_test.dart`: null-unit persists on insert, clear-on-edit persists null (vs. omit = untouched), `getUniqueProductUnits` skips null, `productDisplayName` hides an absent unit, and `watchFullCratesByManufacturer` excludes a unitless tracked product (null = not-a-bottle).
- `test/inventory/fast_add_product_model_test.dart` updated to the new "blank = no unit" contract.
- `dart analyze` clean; touched-area suites pass (inventory, crates, costing, golden, orders, database, sync, pos, receiving, receipts; migration-upgrade now exercises → v62).

## Notes
- The cloud migration ships in this PR but is **not deployed** here.
