### PR TITLE
feat(reports): attention dot on Home Reports button (#119)

### DIFF
--- a/lib/core/providers/stream_providers.dart
+++ b/lib/core/providers/stream_providers.dart
@@ -1382,6 +1382,16 @@ final activeInviteCodesProvider = businessScopedStream<List<InviteCodeData>>(
 
 // ── Current-user role & permission checks (PIVOT_PLAN step 8A) ───────────────
 
+/// The current session user's id, or null when logged out / not yet resolved
+/// locally. A lightweight watchable seam over [authProvider] — the identity
+/// counterpart of the businessId seam `currentBusinessIdProvider` — so per-user
+/// device-local state (e.g. the Daily Reconciliation review marker, issue #119)
+/// can key on it and tests can flip it via `overrideWith` without constructing
+/// an [AuthService].
+final currentUserIdProvider = Provider<String?>((ref) {
+  return ref.watch(authProvider.select((a) => a.currentUser?.id));
+});
+
 /// The [RoleData] for the currently logged-in user. Resolves the session
 /// user's id via [authProvider] and reuses [userRoleProvider]. Returns null
 /// while no one is logged in or before the membership + role rows have

--- a/lib/features/dashboard/reports_attention.dart
+++ b/lib/features/dashboard/reports_attention.dart
@@ -1,0 +1,123 @@
+/// Home Reports button attention dot (issue #119).
+///
+/// The Home tab's Reports button (CEO + Manager only) shows a single dot — no
+/// number — when there is something in Reports for this viewer to look at:
+///   • pending approvals await them (the #115-fixed viewer-scoped count), OR
+///   • a daily stock count has been recorded since they last opened the Daily
+///     Reconciliation report.
+/// The dot clears when both are false: opening Daily Reconciliation stamps a
+/// per-user, device-local "last reviewed" marker, retiring the stock-count
+/// reason. The in-hub Approvals card keeps its own numeric badge — only the
+/// Home button collapses to a dot.
+///
+/// Mirrors [get_started_checklist.dart]'s shape: a pure, widget-free, Riverpod-
+/// free derivation ([computeReportsAttentionDot]) wired to live signals by the
+/// providers below, with the marker persisted the way [UiHintService] persists
+/// its hints (SharedPreferences, un-synced, no migration — a UI-review pointer,
+/// not business data) but keyed per device user, so a shared till tracks each
+/// staff member's review independently.
+library;
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:reebaplus_pos/core/database/app_database.dart';
+import 'package:reebaplus_pos/core/providers/stream_providers.dart';
+
+/// Pure derivation of whether the Home Reports button shows its attention dot.
+///
+/// The dot is on when [pendingApprovals] > 0, or when a daily stock count exists
+/// ([latestStockCountAt] non-null) recorded after the viewer last opened Daily
+/// Reconciliation ([lastReviewedAt]). A null [lastReviewedAt] (never opened on
+/// this device by this user) means every existing count is un-reviewed. With no
+/// approvals and no counts the dot is off.
+bool computeReportsAttentionDot({
+  required int pendingApprovals,
+  required DateTime? latestStockCountAt,
+  required DateTime? lastReviewedAt,
+}) {
+  if (pendingApprovals > 0) return true;
+  if (latestStockCountAt == null) return false;
+  return lastReviewedAt == null || latestStockCountAt.isAfter(lastReviewedAt);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Providers — the live wiring. Each input is a watchable provider, so the
+// derivation is unit-testable in a ProviderContainer with no widget tree.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Per-user, device-local marker of when the current viewer last opened the
+/// Daily Reconciliation report, mirroring [UiHintService]'s SharedPreferences
+/// pattern. Un-synced and migration-free — it is a per-device UI-review pointer,
+/// not business data — but keyed by the session user id so a shared till tracks
+/// each staff member separately. Starts null (never opened) and hydrates
+/// asynchronously from prefs; [markOpenedNow] stamps it to the current instant
+/// and persists. Re-hydrates on a user switch (build watches the id seam).
+class ReconReviewMarkerNotifier extends Notifier<DateTime?> {
+  /// Pref-key prefix; the current user id is appended so the marker is per-user.
+  static const prefKeyPrefix = 'recon_last_reviewed_at_v1_';
+
+  static String prefKeyFor(String userId) => '$prefKeyPrefix$userId';
+
+  @override
+  DateTime? build() {
+    final userId = ref.watch(currentUserIdProvider);
+    if (userId == null) return null;
+    _hydrate(userId);
+    return null;
+  }
+
+  Future<void> _hydrate(String userId) async {
+    final prefs = await SharedPreferences.getInstance();
+    final millis = prefs.getInt(prefKeyFor(userId));
+    if (millis != null) {
+      state = DateTime.fromMillisecondsSinceEpoch(millis);
+    }
+  }
+
+  /// Stamps the marker to now and persists it for the current user — called when
+  /// the Daily Reconciliation report is opened; clears the dot's stock-count
+  /// reason. No-op when logged out.
+  Future<void> markOpenedNow() async {
+    final userId = ref.read(currentUserIdProvider);
+    if (userId == null) return;
+    final now = DateTime.now();
+    state = now;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setInt(prefKeyFor(userId), now.millisecondsSinceEpoch);
+  }
+}
+
+final reconReviewMarkerProvider =
+    NotifierProvider<ReconReviewMarkerNotifier, DateTime?>(
+      ReconReviewMarkerNotifier.new,
+    );
+
+/// Whether the Home Reports button shows its attention dot for the current
+/// viewer. Composes the #115-fixed viewer-scoped pending-approval counts, the
+/// latest daily-stock-count timestamp, and the per-user review marker through
+/// [computeReportsAttentionDot]. Consumed only by the Home Reports button, which
+/// is itself CEO/Manager-gated.
+final reportsAttentionDotProvider = Provider<bool>((ref) {
+  final pendingApprovals =
+      ref.watch(viewerScopedPendingStockRequestsProvider).length +
+      ref.watch(viewerScopedPendingQuickSaleRequestsProvider).length;
+
+  final counts =
+      ref.watch(allStockCountsProvider).valueOrNull ??
+      const <StockCountData>[];
+  // Compare wall-clock createdAt (when the count was saved), not the ordered
+  // list head — watchAllForBusiness orders by businessDate first, so a
+  // back-dated count saved today would not be counts.first.
+  final latestStockCountAt = counts.isEmpty
+      ? null
+      : counts.map((c) => c.createdAt).reduce((a, b) => a.isAfter(b) ? a : b);
+
+  final lastReviewedAt = ref.watch(reconReviewMarkerProvider);
+
+  return computeReportsAttentionDot(
+    pendingApprovals: pendingApprovals,
+    latestStockCountAt: latestStockCountAt,
+    lastReviewedAt: lastReviewedAt,
+  );
+});

--- a/lib/features/dashboard/screens/daily_reconciliation_list_screen.dart
+++ b/lib/features/dashboard/screens/daily_reconciliation_list_screen.dart
@@ -9,6 +9,7 @@ import 'package:reebaplus_pos/core/utils/csv_export.dart';
 import 'package:reebaplus_pos/core/utils/number_format.dart';
 import 'package:reebaplus_pos/core/utils/responsive.dart';
 import 'package:reebaplus_pos/features/dashboard/reconciliation/recon_data.dart';
+import 'package:reebaplus_pos/features/dashboard/reports_attention.dart';
 import 'package:reebaplus_pos/features/dashboard/screens/daily_reconciliation_detail_screen.dart';
 import 'package:reebaplus_pos/shared/widgets/app_dropdown.dart';
 import 'package:reebaplus_pos/shared/widgets/shared_scaffold.dart';
@@ -33,6 +34,18 @@ class _DailyReconciliationListScreenState
   ReconGrouping _grouping = ReconGrouping.day;
   DateTimeRange? _customRange;
   bool _isScrolled = false;
+
+  @override
+  void initState() {
+    super.initState();
+    // Opening the Daily Reconciliation report marks its daily stock counts
+    // reviewed for this viewer, clearing the Home Reports attention dot's
+    // stock-count reason (issue #119). Per-user, device-local; deferred past
+    // first build so it never mutates a provider mid-build.
+    Future.microtask(
+      () => ref.read(reconReviewMarkerProvider.notifier).markOpenedNow(),
+    );
+  }
 
   Future<void> _exportCsv(List<ReconBucket> buckets, String scope) async {
     final rows = <List<String>>[

--- a/lib/features/dashboard/screens/home_screen.dart
+++ b/lib/features/dashboard/screens/home_screen.dart
@@ -23,6 +23,7 @@ import 'package:reebaplus_pos/shared/widgets/app_dropdown.dart';
 import 'package:reebaplus_pos/features/dashboard/widgets/get_started_card.dart';
 import 'package:reebaplus_pos/features/dashboard/screens/sales_detail_screen.dart';
 import 'package:reebaplus_pos/features/dashboard/screens/reports_hub_screen.dart';
+import 'package:reebaplus_pos/features/dashboard/reports_attention.dart';
 import 'package:reebaplus_pos/features/customers/screens/customers_screen.dart';
 import 'package:reebaplus_pos/features/expenses/screens/expenses_screen.dart';
 import 'package:reebaplus_pos/features/orders/screens/orders_screen.dart';
@@ -479,6 +480,12 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
   }
 
   Widget _buildReportButton() {
+    // Attention dot (issue #119): a single dot — no number — lights when this
+    // viewer has pending approvals OR an un-reviewed daily stock count. The
+    // button itself is already CEO/Manager-gated (showReports); the dot clears
+    // when they open Daily Reconciliation. The in-hub Approvals card keeps its
+    // own numeric badge.
+    final showDot = ref.watch(reportsAttentionDotProvider);
     return Material(
       color: context.primaryColor.withValues(alpha: 0.1),
       borderRadius: BorderRadius.circular(context.radiusM),
@@ -512,22 +519,17 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
                   fontSize: context.getRFontSize(14),
                 ),
               ),
-              SizedBox(width: context.getRSize(6)),
-              Container(
-                padding: EdgeInsets.all(context.getRSize(5)),
-                decoration: BoxDecoration(
-                  color: Theme.of(context).colorScheme.error,
-                  shape: BoxShape.circle,
-                ),
-                child: Text(
-                  '3',
-                  style: TextStyle(
-                    color: Colors.white,
-                    fontSize: context.getRFontSize(10),
-                    fontWeight: FontWeight.bold,
+              if (showDot) ...[
+                SizedBox(width: context.getRSize(6)),
+                Container(
+                  width: context.getRSize(8),
+                  height: context.getRSize(8),
+                  decoration: BoxDecoration(
+                    color: Theme.of(context).colorScheme.error,
+                    shape: BoxShape.circle,
                   ),
                 ),
-              ),
+              ],
             ],
           ),
         ),

--- a/test/dashboard/reports_attention_test.dart
+++ b/test/dashboard/reports_attention_test.dart
@@ -1,0 +1,309 @@
+// Home Reports button attention dot (issue #119).
+//
+// Three layers, all asserting external behaviour (mirrors the Seam 3
+// get-started checklist tests):
+//   1. `computeReportsAttentionDot` — the pure derivation, exhaustive over
+//      approvals / latest-count / last-reviewed.
+//   2. `reportsAttentionDotProvider` — the live wiring, driven purely through
+//      input overrides in a ProviderContainer (no widget tree), proving each
+//      signal maps to the dot.
+//   3. `ReconReviewMarkerNotifier` — the per-user, device-local marker: opening
+//      Daily Reconciliation (markOpenedNow) clears the dot, persists across a
+//      simulated restart, and is independent per device user.
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:reebaplus_pos/core/database/app_database.dart';
+import 'package:reebaplus_pos/core/providers/stream_providers.dart';
+import 'package:reebaplus_pos/features/dashboard/reports_attention.dart';
+
+// ── Test factories ───────────────────────────────────────────────────────────
+
+StockCountData _count(DateTime createdAt) => StockCountData(
+      id: 'sc-${createdAt.microsecondsSinceEpoch}',
+      businessId: 'biz1',
+      storeId: null,
+      businessDate: '2026-01-01',
+      productsCounted: 5,
+      shortageCount: 0,
+      surplusCount: 0,
+      shortageUnits: 0,
+      surplusUnits: 0,
+      linesJson: '[]',
+      countedBy: null,
+      createdAt: createdAt,
+      lastUpdatedAt: createdAt,
+    );
+
+StockAdjustmentRequestData _stockReq(String id) => StockAdjustmentRequestData(
+      id: id,
+      businessId: 'biz1',
+      productId: 'p1',
+      storeId: 's1',
+      quantityDiff: 5,
+      reason: 'restock',
+      summary: 'Add 5',
+      requestedBy: 'u1',
+      status: 'pending',
+      approvedBy: null,
+      approvedAt: null,
+      createdAt: DateTime(2026, 1, 1),
+      lastUpdatedAt: DateTime(2026, 1, 1),
+    );
+
+QuickSaleRequestData _quickSaleReq(String id) => QuickSaleRequestData(
+      id: id,
+      businessId: 'biz1',
+      storeId: 's1',
+      itemName: 'Bottled Water',
+      quantity: 3,
+      unitPriceKobo: 50000,
+      summary: '3 x Bottled Water',
+      requestedBy: 'u1',
+      status: 'pending',
+      approvedBy: null,
+      approvedAt: null,
+      createdAt: DateTime(2026, 1, 1),
+      lastUpdatedAt: DateTime(2026, 1, 1),
+    );
+
+/// A marker notifier that skips SharedPreferences and reports a fixed value —
+/// lets the wiring tests inject a "last reviewed" instant deterministically.
+class _StubMarker extends ReconReviewMarkerNotifier {
+  _StubMarker(this._value);
+  final DateTime? _value;
+  @override
+  DateTime? build() => _value;
+}
+
+/// Drives [reportsAttentionDotProvider] through its input providers only.
+Future<bool> _evaluateDot({
+  List<StockAdjustmentRequestData> stockRequests = const [],
+  List<QuickSaleRequestData> quickSaleRequests = const [],
+  List<StockCountData> counts = const [],
+  DateTime? lastReviewedAt,
+}) async {
+  final container = ProviderContainer(
+    overrides: [
+      viewerScopedPendingStockRequestsProvider
+          .overrideWith((ref) => stockRequests),
+      viewerScopedPendingQuickSaleRequestsProvider
+          .overrideWith((ref) => quickSaleRequests),
+      allStockCountsProvider.overrideWith((ref) => Stream.value(counts)),
+      reconReviewMarkerProvider.overrideWith(() => _StubMarker(lastReviewedAt)),
+    ],
+  );
+  addTearDown(container.dispose);
+  // Let the overridden stream emit before reading the derived provider.
+  await container.read(allStockCountsProvider.future);
+  return container.read(reportsAttentionDotProvider);
+}
+
+void main() {
+  group('computeReportsAttentionDot (pure)', () {
+    final t0 = DateTime(2026, 1, 1, 8);
+    final t1 = DateTime(2026, 1, 1, 9);
+
+    test('pending approvals light the dot even with no counts', () {
+      expect(
+        computeReportsAttentionDot(
+          pendingApprovals: 1,
+          latestStockCountAt: null,
+          lastReviewedAt: null,
+        ),
+        isTrue,
+      );
+    });
+
+    test('pending approvals dominate an already-reviewed count', () {
+      expect(
+        computeReportsAttentionDot(
+          pendingApprovals: 2,
+          latestStockCountAt: t0,
+          lastReviewedAt: t1,
+        ),
+        isTrue,
+      );
+    });
+
+    test('a count recorded after the last review is un-reviewed → on', () {
+      expect(
+        computeReportsAttentionDot(
+          pendingApprovals: 0,
+          latestStockCountAt: t1,
+          lastReviewedAt: t0,
+        ),
+        isTrue,
+      );
+    });
+
+    test('a count never reviewed on this device (null marker) → on', () {
+      expect(
+        computeReportsAttentionDot(
+          pendingApprovals: 0,
+          latestStockCountAt: t0,
+          lastReviewedAt: null,
+        ),
+        isTrue,
+      );
+    });
+
+    test('a count reviewed at/after the latest count → off', () {
+      expect(
+        computeReportsAttentionDot(
+          pendingApprovals: 0,
+          latestStockCountAt: t0,
+          lastReviewedAt: t1,
+        ),
+        isFalse,
+      );
+      // The review instant equalling the count instant counts as reviewed
+      // (isAfter is strict) — a count is un-reviewed only if strictly newer.
+      expect(
+        computeReportsAttentionDot(
+          pendingApprovals: 0,
+          latestStockCountAt: t0,
+          lastReviewedAt: t0,
+        ),
+        isFalse,
+      );
+    });
+
+    test('no approvals and no counts → off', () {
+      expect(
+        computeReportsAttentionDot(
+          pendingApprovals: 0,
+          latestStockCountAt: null,
+          lastReviewedAt: null,
+        ),
+        isFalse,
+      );
+      expect(
+        computeReportsAttentionDot(
+          pendingApprovals: 0,
+          latestStockCountAt: null,
+          lastReviewedAt: t0,
+        ),
+        isFalse,
+      );
+    });
+  });
+
+  group('reportsAttentionDotProvider (input overrides)', () {
+    test('a pending stock-adjustment approval lights the dot', () async {
+      expect(await _evaluateDot(stockRequests: [_stockReq('r1')]), isTrue);
+    });
+
+    test('a pending quick-sale approval lights the dot', () async {
+      expect(
+        await _evaluateDot(quickSaleRequests: [_quickSaleReq('q1')]),
+        isTrue,
+      );
+    });
+
+    test('an un-reviewed stock count lights the dot', () async {
+      expect(
+        await _evaluateDot(
+          counts: [_count(DateTime(2026, 1, 1))],
+          lastReviewedAt: null,
+        ),
+        isTrue,
+      );
+    });
+
+    test('a stock count reviewed later clears the dot', () async {
+      expect(
+        await _evaluateDot(
+          counts: [_count(DateTime(2026, 1, 1, 8))],
+          lastReviewedAt: DateTime(2026, 1, 1, 9),
+        ),
+        isFalse,
+      );
+    });
+
+    test('no approvals and no counts → dot off', () async {
+      expect(await _evaluateDot(), isFalse);
+    });
+
+    test('the newest of several counts drives the comparison', () async {
+      // Reviewed at 10:00 but a 12:00 count exists → still un-reviewed → on.
+      // (watchAllForBusiness orders by businessDate first, so the provider must
+      // take the max createdAt, not the list head.)
+      expect(
+        await _evaluateDot(
+          counts: [
+            _count(DateTime(2026, 1, 1, 8)),
+            _count(DateTime(2026, 1, 1, 12)),
+          ],
+          lastReviewedAt: DateTime(2026, 1, 1, 10),
+        ),
+        isTrue,
+      );
+    });
+  });
+
+  group('ReconReviewMarkerNotifier (per-user device-local marker)', () {
+    setUp(TestWidgetsFlutterBinding.ensureInitialized);
+
+    test('opening Daily Reconciliation stamps the marker and clears the dot',
+        () async {
+      SharedPreferences.setMockInitialValues({});
+      final container = ProviderContainer(
+        overrides: [
+          currentUserIdProvider.overrideWith((ref) => 'user-1'),
+          viewerScopedPendingStockRequestsProvider.overrideWith((ref) => const []),
+          viewerScopedPendingQuickSaleRequestsProvider
+              .overrideWith((ref) => const []),
+          allStockCountsProvider
+              .overrideWith((ref) => Stream.value([_count(DateTime(2026, 1, 1))])),
+        ],
+      );
+      addTearDown(container.dispose);
+      await container.read(allStockCountsProvider.future);
+
+      // A count exists and was never reviewed → dot on.
+      expect(container.read(reportsAttentionDotProvider), isTrue);
+
+      // Opening the report stamps "now" (which is after the 2026-01-01 count)
+      // → the stock-count reason clears and the dot turns off.
+      await container.read(reconReviewMarkerProvider.notifier).markOpenedNow();
+      expect(container.read(reportsAttentionDotProvider), isFalse);
+    });
+
+    test('the marker persists across a restart and is independent per user',
+        () async {
+      SharedPreferences.setMockInitialValues({});
+
+      final c1 = ProviderContainer(
+        overrides: [currentUserIdProvider.overrideWith((ref) => 'user-1')],
+      );
+      addTearDown(c1.dispose);
+      expect(c1.read(reconReviewMarkerProvider), isNull);
+      await c1.read(reconReviewMarkerProvider.notifier).markOpenedNow();
+      expect(c1.read(reconReviewMarkerProvider), isNotNull);
+
+      // Simulate a restart: a fresh container re-hydrates user-1 from prefs.
+      final c2 = ProviderContainer(
+        overrides: [currentUserIdProvider.overrideWith((ref) => 'user-1')],
+      );
+      addTearDown(c2.dispose);
+      expect(c2.read(reconReviewMarkerProvider), isNull); // before hydrate
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      expect(c2.read(reconReviewMarkerProvider), isNotNull); // hydrated
+
+      // A different user on the same device has an independent (empty) marker.
+      final c3 = ProviderContainer(
+        overrides: [currentUserIdProvider.overrideWith((ref) => 'user-2')],
+      );
+      addTearDown(c3.dispose);
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      expect(
+        c3.read(reconReviewMarkerProvider),
+        isNull,
+        reason: 'per-user: user-2 has not opened Daily Reconciliation',
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Issue
Closes #119 — Reports attention dot (approvals or un-reviewed stock count).

## What changed
The Home **Reports** button showed a hardcoded number badge (`3`). It now shows a single **attention dot** — no number — that lights when there is something in Reports for this viewer to look at, and clears when they open the Daily Reconciliation report. CEO + Managers only (the button is already role-gated). The in-hub **Approvals** card keeps its own numeric count (unchanged).

**Dot condition:** `pending approvals > 0` **OR** `a daily stock count was recorded since this viewer last opened Daily Reconciliation`.

- **`lib/features/dashboard/reports_attention.dart`** (new): mirrors the `get_started_checklist.dart` shape — a pure, widget-free `computeReportsAttentionDot(...)`, a per-user device-local `ReconReviewMarkerNotifier` (SharedPreferences, un-synced, no migration, keyed by session user id — a shared till tracks each staff member independently), and `reportsAttentionDotProvider` that composes the #115-fixed viewer-scoped approval counts + the latest daily-stock-count timestamp + the marker.
- **`home_screen.dart`**: number badge → conditional single dot (`colorScheme.error`, matching the notification-bell dot). No change to `showReports` (already `isCeo || isManager`).
- **`daily_reconciliation_list_screen.dart`**: stamps the per-user marker on open (clears the stock-count reason).
- **`stream_providers.dart`**: adds a lightweight `currentUserIdProvider` seam (mirrors the existing `currentBusinessIdProvider`) so the marker keys per-user and is testable via `overrideWith`.

No migration (device-local marker). Reused the #115 pending-approvals providers rather than rebuilding them.

## Acceptance criteria
- [x] Home Reports button shows a single dot (no number).
- [x] Dot on when: pending approvals > 0 OR a daily stock count recorded since this viewer last opened Daily Reconciliation.
- [x] Opening Daily Reconciliation clears the stock-count reason (tracked per user, locally).
- [x] Visible to CEO + Managers; the in-hub Approvals card still shows a count.

## Tests
`test/dashboard/reports_attention_test.dart` (14 cases): the pure derivation exhaustively; the provider wiring (each signal → dot) via input overrides; and the marker (opening Daily Reconciliation clears the dot, persists across a simulated restart, independent per device user). `dart analyze` clean; dashboard / providers-ban / permissions suites green. Branch synced with latest `main`.