### PR TITLE
feat(industry): offer only 3 selectable trades + trade-aware product form copy (#112)

### DIFF
--- a/lib/core/data/business_types.dart
+++ b/lib/core/data/business_types.dart
@@ -6,10 +6,19 @@ import 'package:reebaplus_pos/core/industry/industry.dart';
 /// existing callers keep working without a second copy of the list.
 export 'package:reebaplus_pos/core/industry/industry.dart' show isCrateBusiness;
 
-/// The business-type display labels shown in settings/dropdowns, in plan order.
-/// Derived from [Industry.catalogue] — no longer a hand-maintained list, so it
-/// cannot drift from the registry. DB stores the canonical 'Beer distributor'
-/// string for Beverage distributor tenants; the Business Info screen maps the
-/// display ↔ DB label at load/save time.
+/// All known business-type display labels, in plan order — the full registry
+/// via [Industry.catalogue]. Used to VALIDATE / round-trip a stored type on
+/// load (so a tenant already on a now-hidden trade keeps its selection), not to
+/// populate a picker: pickers OFFER only [kSelectableBusinessTypes] (#112).
+/// Derived from the registry so it cannot drift. DB stores the canonical
+/// 'Beer distributor' string for Beverage distributor tenants; the Business
+/// Info screen maps the display ↔ DB label at load/save time.
 final List<String> kBusinessTypes =
     Industry.catalogue.map((i) => i.label).toList(growable: false);
+
+/// The business-type labels OFFERED in the onboarding + Settings pickers — the
+/// [Industry.selectable] subset only (Beverage distributor, Pharmacy, Frozen
+/// Foods & Grocery), issue #112. Derived from [Industry.selectableCatalogue] so
+/// it can never drift from the registry.
+final List<String> kSelectableBusinessTypes =
+    Industry.selectableCatalogue.map((i) => i.label).toList(growable: false);

--- a/lib/core/industry/industry.dart
+++ b/lib/core/industry/industry.dart
@@ -4,8 +4,9 @@ import 'package:flutter/material.dart';
 /// words, presets, and optional feature surfaces (CONTEXT.md → *Industry*).
 ///
 /// This enum **is** the one Industry registry (ADR 0015): the single source of
-/// truth for each industry's display label, icon, coming-soon flag, and
-/// crate-eligibility. It supersedes the two lists these facts used to be split
+/// truth for each industry's display label, icon, coming-soon flag,
+/// crate-eligibility, and picker selectability. It supersedes the two lists
+/// these facts used to be split
 /// across — the `kBusinessTypes` display list and the private `_businessTypes`
 /// record list in CEO Sign Up — so the two can no longer drift.
 ///
@@ -31,9 +32,14 @@ enum Industry {
     label: 'Beverage distributor',
     icon: Icons.sports_bar_rounded,
     crateEligible: true,
+    selectable: true,
     aliases: {'beer distributor'},
   ),
-  pharmacy(label: 'Pharmacy', icon: Icons.local_pharmacy_rounded),
+  pharmacy(
+    label: 'Pharmacy',
+    icon: Icons.local_pharmacy_rounded,
+    selectable: true,
+  ),
   buildingMaterials(label: 'Building Materials', icon: Icons.foundation_rounded),
   boutique(label: 'Boutique', icon: Icons.checkroom_rounded),
 
@@ -47,6 +53,7 @@ enum Industry {
   frozenFoodsAndGrocery(
     label: 'Frozen Foods & Grocery',
     icon: Icons.ac_unit_rounded,
+    selectable: true,
   ),
 
   /// Safe fallback for an unknown, legacy, or null `businesses.type`. Never
@@ -63,6 +70,7 @@ enum Industry {
     // ignore: unused_element_parameter
     this.comingSoon = false,
     this.crateEligible = false,
+    this.selectable = false,
     this.aliases = const <String>{},
   });
 
@@ -83,15 +91,33 @@ enum Industry {
   /// the `tracks_empty_crates` opt-in for the full surface gate.
   final bool crateEligible;
 
+  /// Whether this industry is offered in the onboarding + Settings pickers.
+  /// Only Beverage distributor, Pharmacy, and Frozen Foods & Grocery ship
+  /// selectable today (issue #112); the other trades stay in the registry so
+  /// existing tenants keep normalizing + their features, but appear in no
+  /// picker. New industries default to hidden — flip this deliberately once
+  /// their flow is ready. [generic] is never selectable.
+  final bool selectable;
+
   /// Extra lowercase strings (besides the lowercased [label]) that resolve to
   /// this industry — legacy DB canonicals and casings. See [industryOf].
   final Set<String> aliases;
 
-  /// The industries offered in pickers, in plan order — every entry except
-  /// [generic]. Onboarding and Settings render from this so the two lists can
-  /// never diverge from the registry. Computed once (used inside `build`).
+  /// The full registry of real industries, in plan order — every entry except
+  /// [generic]. This is what [industryOf] normalizes against and what the
+  /// business-type round-trip validates against, so it keeps ALL nine even
+  /// though the pickers now offer only [selectableCatalogue]: a tenant on a
+  /// now-hidden trade must still resolve to its own profile and keep its
+  /// features (no data migration, issue #112). Computed once.
   static final List<Industry> catalogue =
       values.where((i) => i != generic).toList(growable: false);
+
+  /// The industries actually offered in the onboarding + Settings pickers — the
+  /// [selectable] subset of [catalogue], in plan order (issue #112). Onboarding
+  /// and Settings render from this so the two pickers can never diverge from the
+  /// registry or offer a hidden trade. Computed once (used inside `build`).
+  static final List<Industry> selectableCatalogue =
+      values.where((i) => i.selectable).toList(growable: false);
 }
 
 /// Resolves a stored `businesses.type` string to its [Industry]. Total: known

--- a/lib/core/settings/business_info_screen.dart
+++ b/lib/core/settings/business_info_screen.dart
@@ -245,6 +245,14 @@ class _BusinessInfoScreenState extends ConsumerState<BusinessInfoScreen> {
     // Screen-level gate (hard rule #6) + keeps the permission chain warm for
     // the save-site guard.
     final canManage = Gates.manageSettings.allows(ref);
+    // Offer only the selectable trades (#112). If this tenant is already on a
+    // now-hidden trade, keep its current type visible + selected (grandfathered)
+    // so opening this screen can never blank or silently change their industry —
+    // switching still offers only the three.
+    final typeOptions = <String>[
+      ...kSelectableBusinessTypes,
+      if (_type != null && !kSelectableBusinessTypes.contains(_type)) _type!,
+    ];
     return GlassyScaffold(
       title: 'Business Info',
       body: !canManage
@@ -315,7 +323,7 @@ class _BusinessInfoScreenState extends ConsumerState<BusinessInfoScreen> {
                           prefixIcon:
                               const Icon(Icons.category_rounded, size: 20),
                           items: [
-                            for (final type in kBusinessTypes)
+                            for (final type in typeOptions)
                               DropdownMenuItem(
                                 value: type,
                                 child: Text(type),

--- a/lib/features/auth/screens/ceo_sign_up_screen.dart
+++ b/lib/features/auth/screens/ceo_sign_up_screen.dart
@@ -50,9 +50,10 @@ class CeoSignUpScreen extends ConsumerStatefulWidget {
 class _CeoSignUpScreenState extends ConsumerState<CeoSignUpScreen> {
   static const int _totalSteps = 9;
 
-  // The business-type picker is rendered from [Industry.catalogue] — the one
-  // Industry registry (ADR 0015). Each entry carries its own label, icon and
-  // coming-soon flag, so this screen no longer keeps a private duplicate list.
+  // The business-type picker is rendered from [Industry.selectableCatalogue] —
+  // the selectable subset of the one Industry registry (ADR 0015, #112). Only
+  // the three offered trades appear here; each entry carries its own label,
+  // icon and coming-soon flag, so this screen keeps no private duplicate list.
 
   // Obvious PINs to block (master plan §5.1). Mirrors create_pin_screen.dart.
   static const Set<String> _blockedPins = {
@@ -850,7 +851,7 @@ class _CeoSignUpScreenState extends ConsumerState<CeoSignUpScreen> {
       title: 'What type of business?',
       subtitle: 'Pick the one that fits best.',
       children: [
-        ...Industry.catalogue.map((t) {
+        ...Industry.selectableCatalogue.map((t) {
           final selected = _businessType == t.label;
           return Padding(
             padding: const EdgeInsets.only(bottom: 12),

--- a/lib/features/inventory/screens/add_product_screen.dart
+++ b/lib/features/inventory/screens/add_product_screen.dart
@@ -110,9 +110,11 @@ class _AddProductScreenState extends ConsumerState<AddProductScreen> {
 
   /// The required fields that live in the always-visible fast section. A
   /// validation error naming anything else (only Store today) expands "More
-  /// details" first, so an error never points at a collapsed field.
-  static const _fastSectionFields = {
-    'Product Name',
+  /// details" first, so an error never points at a collapsed field. The item
+  /// label morphs per trade (#112), so the name entry is built from the active
+  /// Lexicon — a hardcoded 'Product Name' would never match 'Medicine Name'.
+  Set<String> get _fastSectionFields => {
+    '${_lexicon.item} Name',
     'Selling Price',
     'Quantity',
     'Buying Price',
@@ -718,7 +720,10 @@ class _AddProductScreenState extends ConsumerState<AddProductScreen> {
         CrashReporter.record(e, st, context: 'inventory.add_product');
         debugPrint('AddProductScreen._save (existing) error: $e');
         if (mounted) {
-          AppNotification.showError(context, 'Could not update product: $e');
+          AppNotification.showError(
+            context,
+            'Could not update ${_lexicon.itemLower}: $e',
+          );
         }
       } finally {
         if (mounted) setState(() => _isSaving = false);
@@ -796,7 +801,7 @@ class _AddProductScreenState extends ConsumerState<AddProductScreen> {
       if (mounted) {
         AppNotification.showError(
           context,
-          'A product named "$name" already exists.',
+          'A ${_lexicon.itemLower} named "$name" already exists.',
         );
       }
       return;
@@ -909,7 +914,10 @@ class _AddProductScreenState extends ConsumerState<AddProductScreen> {
       CrashReporter.record(e, st, context: 'inventory.add_product');
       debugPrint('AddProductScreen._save error: $e');
       if (mounted) {
-        AppNotification.showError(context, 'Could not save product: $e');
+        AppNotification.showError(
+          context,
+          'Could not save ${_lexicon.itemLower}: $e',
+        );
       }
     } finally {
       if (mounted) setState(() => _isSaving = false);
@@ -977,7 +985,7 @@ class _AddProductScreenState extends ConsumerState<AddProductScreen> {
       if (mounted) {
         AppNotification.showError(
           context,
-          'A product named "${intent.name}" already exists.',
+          'A ${_lexicon.itemLower} named "${intent.name}" already exists.',
         );
       }
       return;
@@ -1081,7 +1089,10 @@ class _AddProductScreenState extends ConsumerState<AddProductScreen> {
       CrashReporter.record(e, st, context: 'inventory.add_product');
       debugPrint('AddProductScreen._persistNewProduct error: $e');
       if (mounted) {
-        AppNotification.showError(context, 'Could not save product: $e');
+        AppNotification.showError(
+          context,
+          'Could not save ${_lexicon.itemLower}: $e',
+        );
       }
     } finally {
       if (mounted) setState(() => _isSaving = false);
@@ -1140,7 +1151,7 @@ class _AddProductScreenState extends ConsumerState<AddProductScreen> {
       resizeToAvoidBottomInset: true,
       appBar: AppBar(
         leading: const BackButton(),
-        title: Text(isExisting ? 'Add Stock' : 'Add Product'),
+        title: Text(isExisting ? 'Add Stock' : 'Add ${_lexicon.item}'),
         titleTextStyle: TextStyle(
           fontSize: 18,
           fontWeight: FontWeight.w800,
@@ -1236,7 +1247,7 @@ class _AddProductScreenState extends ConsumerState<AddProductScreen> {
                           crossAxisAlignment: CrossAxisAlignment.start,
                           children: [
                             Text(
-                              'Adding stock to existing product',
+                              'Adding stock to existing ${_lexicon.itemLower}',
                               style: TextStyle(
                                 fontSize: 12,
                                 fontWeight: FontWeight.w600,
@@ -1464,8 +1475,8 @@ class _AddProductScreenState extends ConsumerState<AddProductScreen> {
                   onChanged: (v) =>
                       setState(() => _allowFractionalSales = v ?? false),
                   title: const Text('Allow fractional sales'),
-                  subtitle: const Text(
-                    'Enables ±0.5 quantity steps when selling this product',
+                  subtitle: Text(
+                    'Enables ±0.5 quantity steps when selling this ${_lexicon.itemLower}',
                   ),
                   controlAffinity: ListTileControlAffinity.leading,
                   contentPadding: EdgeInsets.zero,
@@ -1549,8 +1560,8 @@ class _AddProductScreenState extends ConsumerState<AddProductScreen> {
                     onChanged: (v) =>
                         setState(() => _trackEmpties = v ?? false),
                     title: const Text('Track empty crate returns'),
-                    subtitle: const Text(
-                      'Enables deposit collection and crate return flow for this product',
+                    subtitle: Text(
+                      'Enables deposit collection and crate return flow for this ${_lexicon.itemLower}',
                     ),
                     controlAffinity: ListTileControlAffinity.leading,
                     contentPadding: EdgeInsets.zero,
@@ -1690,7 +1701,7 @@ class _AddProductScreenState extends ConsumerState<AddProductScreen> {
           12 + context.deviceBottomPadding,
         ),
         child: AppButton(
-          text: isExisting ? 'Add Stock' : 'Add Product',
+          text: isExisting ? 'Add Stock' : 'Add ${_lexicon.item}',
           variant: AppButtonVariant.primary,
           isLoading: _isSaving,
           onPressed: _save,
@@ -1909,8 +1920,8 @@ class _AddProductScreenState extends ConsumerState<AddProductScreen> {
         value: _allowFractionalSales,
         onChanged: (v) => setState(() => _allowFractionalSales = v ?? false),
         title: const Text('Allow fractional sales'),
-        subtitle: const Text(
-          'Enables ±0.5 quantity steps when selling this product',
+        subtitle: Text(
+          'Enables ±0.5 quantity steps when selling this ${_lexicon.itemLower}',
         ),
         controlAffinity: ListTileControlAffinity.leading,
         contentPadding: EdgeInsets.zero,
@@ -1924,8 +1935,8 @@ class _AddProductScreenState extends ConsumerState<AddProductScreen> {
           value: _trackEmpties,
           onChanged: (v) => setState(() => _trackEmpties = v ?? false),
           title: const Text('Track empty crate returns'),
-          subtitle: const Text(
-            'Enables deposit collection and crate return flow for this product',
+          subtitle: Text(
+            'Enables deposit collection and crate return flow for this ${_lexicon.itemLower}',
           ),
           controlAffinity: ListTileControlAffinity.leading,
           contentPadding: EdgeInsets.zero,
@@ -2033,7 +2044,7 @@ class _AddProductScreenState extends ConsumerState<AddProductScreen> {
         AppInput(
           controller: _barcodeCtrl,
           labelText: 'Barcode (optional)',
-          hintText: 'Type or scan the product barcode',
+          hintText: 'Type or scan the ${_lexicon.itemLower} barcode',
           onChanged: _onBarcodeChanged,
         ),
         if (_barcodeCollisionName != null)

--- a/lib/features/inventory/widgets/update_product_sheet.dart
+++ b/lib/features/inventory/widgets/update_product_sheet.dart
@@ -469,7 +469,8 @@ class _UpdateProductSheetState extends ConsumerState<UpdateProductSheet> {
     // bail if `products.edit_price` was revoked while the sheet was open.
     if (!_canEditPrice) {
       setState(
-        () => _errorMessage = 'You no longer have permission to edit products.',
+        () => _errorMessage =
+            'You no longer have permission to edit ${_lexicon.itemPluralLower}.',
       );
       return;
     }
@@ -675,7 +676,9 @@ class _UpdateProductSheetState extends ConsumerState<UpdateProductSheet> {
     } catch (e, st) {
       CrashReporter.record(e, st, context: 'inventory.update_product');
       debugPrint('UpdateProductSheet._save error: $e');
-      setState(() => _errorMessage = 'Could not update product: $e');
+      setState(
+        () => _errorMessage = 'Could not update ${_lexicon.itemLower}: $e',
+      );
     } finally {
       if (mounted) setState(() => _isSaving = false);
     }
@@ -855,7 +858,7 @@ class _UpdateProductSheetState extends ConsumerState<UpdateProductSheet> {
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
                         Text(
-                          'Update Product',
+                          'Update ${_lexicon.item}',
                           maxLines: 1,
                           overflow: TextOverflow.ellipsis,
                           style: TextStyle(
@@ -1110,8 +1113,8 @@ class _UpdateProductSheetState extends ConsumerState<UpdateProductSheet> {
                         onChanged: (v) =>
                             setState(() => _allowFractionalSales = v ?? false),
                         title: const Text('Allow fractional sales'),
-                        subtitle: const Text(
-                          'Enables ±0.5 quantity steps when selling this product',
+                        subtitle: Text(
+                          'Enables ±0.5 quantity steps when selling this ${_lexicon.itemLower}',
                         ),
                         controlAffinity: ListTileControlAffinity.leading,
                         contentPadding: EdgeInsets.zero,
@@ -1221,8 +1224,8 @@ class _UpdateProductSheetState extends ConsumerState<UpdateProductSheet> {
                           onChanged: (v) =>
                               setState(() => _trackEmpties = v ?? false),
                           title: const Text('Track empty crate returns'),
-                          subtitle: const Text(
-                            'Enables deposit collection and crate return flow for this product',
+                          subtitle: Text(
+                            'Enables deposit collection and crate return flow for this ${_lexicon.itemLower}',
                           ),
                           controlAffinity: ListTileControlAffinity.leading,
                           contentPadding: EdgeInsets.zero,
@@ -1349,7 +1352,7 @@ class _UpdateProductSheetState extends ConsumerState<UpdateProductSheet> {
                       ),
                       const SizedBox(height: 4),
                       Text(
-                        'This will set the quantity of this product in the receive cart.',
+                        'This will set the quantity of this ${_lexicon.itemLower} in the receive cart.',
                         style: TextStyle(fontSize: 11, color: subtext),
                       ),
                       const SizedBox(height: 14),
@@ -1402,7 +1405,7 @@ class _UpdateProductSheetState extends ConsumerState<UpdateProductSheet> {
             Padding(
               padding: const EdgeInsets.fromLTRB(20, 0, 20, 20),
               child: AppButton(
-                text: 'Update Product',
+                text: 'Update ${_lexicon.item}',
                 variant: AppButtonVariant.primary,
                 isLoading: _isSaving,
                 onPressed: _save,
@@ -1484,7 +1487,7 @@ class _UpdateProductSheetState extends ConsumerState<UpdateProductSheet> {
         AppInput(
           controller: _barcodeCtrl,
           labelText: 'Barcode (optional)',
-          hintText: 'Type or scan the product barcode',
+          hintText: 'Type or scan the ${_lexicon.itemLower} barcode',
           onChanged: _onBarcodeChanged,
         ),
         if (_barcodeCollisionName != null)

--- a/test/industry/industry_registry_test.dart
+++ b/test/industry/industry_registry_test.dart
@@ -6,12 +6,15 @@
 // These tests exercise the module's public behaviour, never its internals:
 //   (a) resolution   — canonical labels, legacy casings, unknown/null → generic;
 //   (b) membership   — the catalogue holds exactly the nine master-plan
-//                      industries, in plan order, with no duplicates and every
-//                      one selectable (the #79 unlock flipped coming-soon off);
+//                      industries, in plan order, with no duplicates and none
+//                      coming-soon (the #79 unlock flipped that off);
 //   (c) crate-gate   — crate-eligibility stays Bar/Beverage-only and reproduces
 //                      the old hardcoded `isCrateBusiness` truth table exactly;
 //   (d) golden pin   — a frozen snapshot of every catalogue entry, so any drift
-//                      in a label/icon/flag surfaces here for deliberate review.
+//                      in a label/icon/flag surfaces here for deliberate review;
+//   (e) selectable   — the pickers offer only the three selectable trades
+//                      (#112) while the registry keeps all nine, so hidden
+//                      trades still normalize + keep features (no migration).
 //
 // Prior art: test/permissions/gate_registry_membership_test.dart (membership)
 // and test/sync/sync_registry_golden_test.dart (frozen golden).
@@ -90,9 +93,10 @@ void main() {
           reason: 'duplicate label in the catalogue: $labels');
     });
 
-    test('every catalogue industry is selectable — none coming soon (#79)', () {
-      // The multi-industry unlock makes all nine selectable at onboarding, so
-      // the picker greys out nothing.
+    test('no catalogue industry is coming-soon (#79 unlock)', () {
+      // The multi-industry unlock flipped every coming-soon flag off, so the
+      // picker greys out nothing. (Whether a trade is *offered* is the separate
+      // `selectable` flag exercised in group (e).)
       expect(
         Industry.catalogue.where((i) => i.comingSoon).map((i) => i.label),
         isEmpty,
@@ -160,30 +164,94 @@ void main() {
   // === (d) GOLDEN PIN — frozen snapshot of the catalogue =================
 
   group('catalogue golden', () {
-    // FROZEN GOLDEN DATA — the exact facts each catalogue entry holds after the
-    // #79 unlock (nine industries, all selectable). A diff here means an
-    // industry's label, icon, coming-soon or crate flag changed: update this
-    // golden in the SAME commit, deliberately.
-    // (label | icon codepoint | comingSoon | crateEligible)
+    // FROZEN GOLDEN DATA — the exact facts each catalogue entry holds. The nine
+    // industries stay in the registry; #112 makes only three selectable. A diff
+    // here means an industry's label, icon, coming-soon, crate, or selectable
+    // flag changed: update this golden in the SAME commit, deliberately.
+    // (label | icon codepoint | comingSoon | crateEligible | selectable)
     const golden = <String>[
-      'Restaurant|0xf0108|false|false',
-      'Supermarket|0xf86e|false|false',
-      'Bar|0xf865|false|true',
-      'Beverage distributor|0xf01b8|false|true',
-      'Pharmacy|0xf877|false|false',
-      'Building Materials|0xf7a3|false|false',
-      'Boutique|0xf639|false|false',
-      'Phone & Gadgets|0xf019b|false|false',
-      'Frozen Foods & Grocery|0xf516|false|false',
+      'Restaurant|0xf0108|false|false|false',
+      'Supermarket|0xf86e|false|false|false',
+      'Bar|0xf865|false|true|false',
+      'Beverage distributor|0xf01b8|false|true|true',
+      'Pharmacy|0xf877|false|false|true',
+      'Building Materials|0xf7a3|false|false|false',
+      'Boutique|0xf639|false|false|false',
+      'Phone & Gadgets|0xf019b|false|false|false',
+      'Frozen Foods & Grocery|0xf516|false|false|true',
     ];
 
     test('catalogue matches the frozen golden', () {
       final actual = Industry.catalogue
           .map((i) =>
               '${i.label}|0x${i.icon.codePoint.toRadixString(16)}|'
-              '${i.comingSoon}|${i.crateEligible}')
+              '${i.comingSoon}|${i.crateEligible}|${i.selectable}')
           .toList();
       expect(actual, golden);
+    });
+  });
+
+  // === (e) SELECTABLE — pickers offer only the three (#112) ==============
+
+  group('selectable industries', () {
+    test('selectableCatalogue is exactly the three, in plan order', () {
+      expect(
+        Industry.selectableCatalogue.map((i) => i.label).toList(),
+        const [
+          'Beverage distributor',
+          'Pharmacy',
+          'Frozen Foods & Grocery',
+        ],
+      );
+    });
+
+    test('the other six trades + generic are not selectable', () {
+      final hidden =
+          Industry.values.where((i) => !i.selectable).map((i) => i.label);
+      expect(
+        hidden,
+        unorderedEquals(const [
+          'Restaurant',
+          'Supermarket',
+          'Bar',
+          'Building Materials',
+          'Boutique',
+          'Phone & Gadgets',
+          'Business', // generic
+        ]),
+      );
+      expect(Industry.generic.selectable, isFalse);
+    });
+
+    test('selectableCatalogue is a strict subset of the full catalogue', () {
+      for (final ind in Industry.selectableCatalogue) {
+        expect(Industry.catalogue, contains(ind));
+      }
+      expect(
+        Industry.selectableCatalogue.length,
+        lessThan(Industry.catalogue.length),
+        reason: 'the registry must keep more than the offered three',
+      );
+    });
+
+    test('a hidden-trade tenant still normalizes and keeps its features', () {
+      // The registry keeps all nine (#112): a tenant onboarded on a now-hidden
+      // trade must still resolve to its own profile (words + feature flags),
+      // never generic, with no data migration.
+      expect(industryOf('Boutique'), Industry.boutique);
+      expect(industryOf('Bar'), Industry.bar);
+      expect(Industry.boutique.selectable, isFalse);
+      // Bar keeps its crate features even though it is no longer offered.
+      expect(isCrateBusiness('Bar'), isTrue);
+    });
+
+    test('the legacy "beer distributor" alias resolves to selectable Beverage',
+        () {
+      final ind = industryOf('beer distributor');
+      expect(ind, Industry.beverage);
+      expect(ind.selectable, isTrue);
+      // No DB rewrite: the legacy canonical string still normalizes in code.
+      expect(industryOf('Beer distributor'), Industry.beverage);
     });
   });
 }


### PR DESCRIPTION
Closes #112.

## What changed
Onboarding and Settings now offer **only three** trades — Beverage distributor, Pharmacy, Frozen Foods & Grocery. The other six stay in the registry so existing tenants keep working; no migration.

### Registry (`lib/core/industry/industry.dart`)
- New `selectable` bool on each `Industry` (defaults **false**; true only for Beverage distributor, Pharmacy, Frozen Foods & Grocery). `generic` stays false.
- New `Industry.selectableCatalogue` (the offered subset). `Industry.catalogue` is unchanged — still all nine — so `industryOf()` normalization and the business-type round-trip keep every hidden trade resolving to its own profile + features.

### Pickers
- **Onboarding** (`ceo_sign_up_screen.dart`): renders `Industry.selectableCatalogue` — the six render nowhere.
- **Settings → Business Info** (`business_info_screen.dart`): dropdown offers `kSelectableBusinessTypes`, and **grandfathers** a hidden-trade tenant's current type (so opening the screen can never blank or silently change their industry; switching still offers only the three). Load-validation still uses the full `kBusinessTypes`.

### Product-form copy audit (`add_product_screen.dart`, `update_product_sheet.dart`)
Routed the remaining hardcoded item nouns through the `Lexicon`: screen titles, primary buttons, the "adding stock to existing …" banner, fractional/crate helper subtitles, save/update + duplicate-name errors, and barcode hints. Also fixed a latent bug — `_fastSectionFields` hardcoded `'Product Name'` never matched the morphed `'${_lexicon.item} Name'`, so a non-beverage trade wrongly expanded "More details" on a name error. Beverage stays verbatim (its `item` is "Product", so every morph is a no-op there). Internal action-log codes, crash contexts, and `$productName` data interpolations left untouched.

### "Beverage distributor" label + "beer distributor" alias
Confirmed: label unchanged; `industryOf('beer distributor')`/`'Beer distributor'` still normalize to the (now selectable) beverage profile. No DB rewrite of legacy `businesses.type` strings.

## Tests (`test/industry/industry_registry_test.dart`)
Extended the frozen golden with the `selectable` fact and added a **selectable industries** group: `selectableCatalogue` is exactly the three in plan order; the other six + generic are not selectable; a hidden-trade tenant (Bar/Boutique) still normalizes and keeps features (e.g. `isCrateBusiness('Bar')` stays true); and the "beer distributor" alias resolves to the selectable Beverage profile.

## Verification
- `dart analyze` on all changed files: **No issues found.**
- `flutter test test/industry/ test/inventory/`: **89 passing.**

No migration (registry-only, per the ACs). ADR 0015 left unchanged to avoid a docs-PR conflict.