### PR TITLE
fix(sync): hold the v2 order header until its sale envelope resolves (#149)

### DIFF
--- a/BUILD_LOG.md
+++ b/BUILD_LOG.md
@@ -2,6 +2,62 @@
 
 ---
 
+## 2026-07-19 — #149: a rejected v2 oversell no longer leaks a phantom `completed` cloud order
+
+Branch `fix/rejected-v2-phantom-cloud-order`. Fixes the leak found during QA of #100/#121: on the
+guarded path (`feature.domain_rpcs_v2.record_sale` ON), when `pos_record_sale_v2` **rejects** a sale
+for oversell, the cloud was still left with a phantom order `status='completed'` — a real
+`net_amount_kobo` but **zero** items/stock/payments — because the order **header** reached the cloud
+independently of the envelope.
+
+**Root cause.** The header is pushed at Confirm by `OrdersDao.markCompleted → _enqueueFullOrder`, a
+plain LWW `orders` upsert with **no stock guard** and **not** covered by #121's `held_by_order_id`.
+So it drained regardless of whether the envelope later confirmed or rejected. `pos_record_sale_v2`
+itself rolls back correctly on the oversell (its own txn), and `reverseRejectedSaleLocal` is
+local-only — so the phone showed `cancelled` while the cloud kept `completed` forever. Proof it was
+the client upsert: cloud `created_at` = client ring-time, not the RPC's exec-time `now()`.
+
+**Fix (issue's preferred Option 1 — hold the header).** Every order-header push now routes through
+one envelope-aware primitive, `OrdersDao._enqueueFullOrder`, which classifies the sale's
+`pos_record_sale_v2` envelope via new `SyncDao.saleEnvelopeState(orderId)` → `{pending, confirmed,
+rejected}`:
+- **REJECTED** (envelope in `sync_queue_orphans`) → **skip** the header push (never resurrect a
+  rolled-back sale);
+- **PENDING** (un-synced envelope still in `sync_queue`) → enqueue the header **HELD** by the order
+  (new optional `heldByOrderId` on `SyncDao.enqueueUpsert`), so #121's existing
+  release-on-confirm / discard-on-reject / `reconcileHeldRows` machinery covers it verbatim;
+- **CONFIRMED** (envelope synced-and-lingering, purged, or a **v1** sale with no envelope) → enqueue
+  normally; it drains immediately, exactly as before — no completion-sync delay on the online path.
+
+`assignRider` and `markCancelled`'s v1 path already went through `_enqueueFullOrder` and inherit the
+guard; `renumberForCollisionHeal` was re-routed through it too, so `_enqueueFullOrder` is now the
+**sole** order-header push site (the only remaining direct `enqueueUpsert('orders')` is v1
+`createOrder`, the sale record itself). `reconcileHeldRows` and `saleEnvelopeState` now share two
+private envelope-lookup helpers (`_saleEnvelopeQueued` with an explicit `onlyUnsynced` flag +
+`_saleEnvelopeOrphaned`) — the `is_synced` divergence is a visible parameter, not duplicated SQL.
+
+**Why Option 1, not Option 2.** The RPC inserts the header `ON CONFLICT (id) DO NOTHING` and **never
+updates** it, and the envelope's `p_status` is frozen at ring-time `'pending'`. So dropping the
+Confirm header push (Option 2) would strand the cloud order at `pending` forever — only the released
+header LWW upsert carries `completed`/`completed_at`. Confirmed by reading `0091` + `daos_orders`.
+
+**No schema change** (the `held_by_order_id` column already exists; no migration, no `build_runner`).
+
+**Tests.** New `test/sync/rejected_sale_header_hold_test.dart` (12 cases): classifier for all four
+envelope states, header HELD while pending, **DISCARDED on reject (no phantom)**, released on
+confirm, `reconcileHeldRows` backstop, and the no-regression cases (confirmed/v1 push unheld;
+already-rejected-at-Confirm never enqueues a header). `flutter analyze` clean; full suite green
+(963 pass) except one **pre-existing, unrelated** failure (`who_is_working_screen_test`, verified
+failing on the pristine baseline).
+
+**Follow-up (not this fix).** This is preventive — it does not reconcile phantoms that already
+reached the cloud before it ships. The QA repro's own `ORD-000002-GF0C4C` was manually set to
+`cancelled` during QA; any other device that leaked a phantom while the flag was live needs a one-off
+cloud cleanup (`UPDATE orders SET status='cancelled' … WHERE status='completed' AND no children`).
+Pairs with **#150** (a second, Sync-Issues entry point to the one-tap recovery).
+
+---
+
 ## 2026-07-11 — Oversell orphan recovery: one-tap Cancel + local crate reversal (Slice 2c)
 
 Completes the reversal on branch `feat/oversell-orphan-recovery`. The go-live flip stays

--- a/CONTEXT/progress-tracker.md
+++ b/CONTEXT/progress-tracker.md
@@ -2852,6 +2852,26 @@ Spec: `context/specs/brief-sync-data-safety-and-efficiency.md`. Branch
 
 ## Session Notes
 
+**2026-07-19 — #149: rejected v2 oversell no longer leaks a phantom `completed`
+cloud order.** Hardens Invariant #12 on the order *header*. On the guarded path
+(`feature.domain_rpcs_v2.record_sale`), the Confirm-time header push
+(`OrdersDao.markCompleted → _enqueueFullOrder`) was a plain LWW `orders` upsert
+uncovered by #121's `held_by_order_id`, so a rejected (oversold) sale still left a
+cloud order `status='completed'` with zero children (`reverseRejectedSaleLocal` is
+local-only, so the cashier's Cancel never reconciled it). Fix: every order-header
+push routes through the now envelope-aware `_enqueueFullOrder`, which classifies
+the sale via new `SyncDao.saleEnvelopeState` → `{pending, confirmed, rejected}` and
+**skips** (rejected) / **holds by order** (pending — reuses #121's release/discard/
+`reconcileHeldRows`) / **pushes immediately** (confirmed, incl. v1 with no
+envelope). `assignRider` + `renumberForCollisionHeal` inherit the guard, so
+`_enqueueFullOrder` is the sole header-push site. Chose Option 1 (hold the header),
+not Option 2 — the RPC inserts `ON CONFLICT (id) DO NOTHING` and never updates, so
+dropping the push would strand the cloud at `pending`. No schema change. Tests:
+`test/sync/rejected_sale_header_hold_test.dart` (12). Branch
+`fix/rejected-v2-phantom-cloud-order`; full detail in `BUILD_LOG.md` (2026-07-19).
+Follow-up: preventive only — phantoms already in the cloud need a one-off cleanup;
+pairs with **#150** (Sync-Issues entry point to the recovery).
+
 **2026-07-03 — Settings & sidebar migrated to named gates (issue #21, epic #16).**
 The Settings/nav batch: all 11 `lib/core/settings/` screens, `app_drawer.dart`,
 `main_layout.dart`, and the Sync Issues screen guard now cite named registry

--- a/lib/core/database/daos_orders.dart
+++ b/lib/core/database/daos_orders.dart
@@ -462,15 +462,32 @@ class OrdersDao extends DatabaseAccessor<AppDatabase>
 
   // ── Writes ─────────────────────────────────────────────────────────────────
 
-  /// Enqueues the FULL order row for sync. Per-column order updates build a
-  /// partial companion; a partial `orders` upsert omits NOT NULL columns
-  /// (order_number, total_amount_kobo, …) and the cloud rejects it (23502).
+  /// Enqueues the FULL order row for sync (a partial companion would omit NOT
+  /// NULL columns — order_number, total_amount_kobo, … — and the cloud rejects
+  /// it, 23502). Every order-header push routes through here, so the v2
+  /// sale-envelope guard (#149) lives in one place: on the guarded path the
+  /// cloud order exists ONLY once `pos_record_sale_v2` confirms, so the header
+  /// must never reach the cloud ahead of — or instead of — its sale.
+  ///   • REJECTED (envelope orphaned) → skip: pushing the header would
+  ///     resurrect the phantom `completed` order the cloud already rolled back;
+  ///   • PENDING (envelope still in flight) → enqueue HELD by the order,
+  ///     released when it confirms / discarded when it rejects, with
+  ///     `reconcileHeldRows` as the crash-safe backstop;
+  ///   • CONFIRMED (envelope done/purged, or a v1 sale that never had one) →
+  ///     enqueue normally; it drains immediately, exactly as before.
   Future<void> _enqueueFullOrder(String id) async {
     final row = await (select(
       orders,
     )..where((o) => o.id.equals(id) & whereBusiness(o))).getSingleOrNull();
-    if (row != null) {
-      await db.syncDao.enqueueUpsert('orders', row.toCompanion(true));
+    if (row == null) return;
+    final companion = row.toCompanion(true);
+    switch (await db.syncDao.saleEnvelopeState(id)) {
+      case SaleEnvelopeState.rejected:
+        return; // never resurrect a rolled-back sale's header
+      case SaleEnvelopeState.pending:
+        await db.syncDao.enqueueUpsert('orders', companion, heldByOrderId: id);
+      case SaleEnvelopeState.confirmed:
+        await db.syncDao.enqueueUpsert('orders', companion);
     }
   }
 
@@ -1447,11 +1464,9 @@ class OrdersDao extends DatabaseAccessor<AppDatabase>
         lastUpdatedAt: Value(DateTime.now()),
       ),
     );
-    // Re-enqueue a FULL row so the cloud upsert carries every NOT NULL column.
-    final updated = await (select(
-      orders,
-    )..where((t) => t.id.equals(orderId) & whereBusiness(t))).getSingle();
-    await db.syncDao.enqueueUpsert('orders', updated.toCompanion(true));
+    // Re-enqueue via the shared header path so the FULL row carries every NOT
+    // NULL column AND respects the v2 sale-envelope guard (#149).
+    await _enqueueFullOrder(orderId);
     return newNumber;
   }
 

--- a/lib/core/database/daos_sync_diagnostics.dart
+++ b/lib/core/database/daos_sync_diagnostics.dart
@@ -1,5 +1,26 @@
 part of 'daos.dart';
 
+/// The sync state of a v2 sale's `pos_record_sale_v2` envelope, derived from
+/// durable outbox state. Drives whether the order header ([OrdersDao] via
+/// `_enqueueFullOrder`) may push: on the guarded path the cloud order exists
+/// ONLY once the envelope confirms, so a header must never reach the cloud
+/// ahead of — or instead of — its sale (#149).
+enum SaleEnvelopeState {
+  /// The envelope is still un-synced in `sync_queue` (offline, retrying, or
+  /// mid-drain) — the cloud order does not exist yet, so the header must wait.
+  pending,
+
+  /// The envelope confirmed (synced-and-lingering, or already purged) OR the
+  /// order never had one (a v1 sale) — the cloud order exists (or the v1 path
+  /// owns its own header), so the header may push immediately.
+  confirmed,
+
+  /// The envelope was permanently REJECTED and lifted to `sync_queue_orphans`
+  /// (an oversell the cloud rolled back) — the header must never push, or it
+  /// resurrects a phantom order the cloud has already refused.
+  rejected,
+}
+
 @DriftAccessor(tables: [SyncQueue, SyncQueueOrphans])
 class SyncDao extends DatabaseAccessor<AppDatabase>
     with _$SyncDaoMixin, BusinessScopedDao<AppDatabase> {
@@ -111,20 +132,10 @@ class SyncDao extends DatabaseAccessor<AppDatabase>
     var discarded = 0;
     for (final row in heldOrders) {
       final orderId = row.read<String>('oid');
-      final envelopePending = await customSelect(
-        "SELECT 1 FROM sync_queue "
-        "WHERE action_type = 'domain:pos_record_sale_v2' "
-        "AND json_extract(payload, '\$.p_order_id') = ?1 LIMIT 1",
-        variables: [Variable.withString(orderId)],
-      ).get();
-      if (envelopePending.isNotEmpty) continue; // still in flight
-      final envelopeOrphaned = await customSelect(
-        "SELECT 1 FROM sync_queue_orphans "
-        "WHERE action_type = 'domain:pos_record_sale_v2' "
-        "AND json_extract(payload, '\$.p_order_id') = ?1 LIMIT 1",
-        variables: [Variable.withString(orderId)],
-      ).get();
-      if (envelopeOrphaned.isNotEmpty) {
+      // Any queue row (synced-and-lingering or not) means the envelope hasn't
+      // left the queue yet — still in flight; keep waiting.
+      if (await _saleEnvelopeQueued(orderId)) continue;
+      if (await _saleEnvelopeOrphaned(orderId)) {
         discarded += await discardHeldByOrder(orderId);
       } else {
         await releaseHeldByOrder(orderId);
@@ -132,6 +143,58 @@ class SyncDao extends DatabaseAccessor<AppDatabase>
       }
     }
     return (released: released, discarded: discarded);
+  }
+
+  /// Classifies [orderId]'s `pos_record_sale_v2` envelope (see
+  /// [SaleEnvelopeState]) using the same envelope lookups as [reconcileHeldRows],
+  /// but the queue check is restricted to UN-synced rows: a synced-but-lingering
+  /// envelope (markDone keeps the row until the 7-day purge) means the sale
+  /// CONFIRMED. A v1 order (no envelope) also resolves to
+  /// [SaleEnvelopeState.confirmed], so its header pushes exactly as before.
+  /// (No `business_id` filter — the order id is a globally-unique UUIDv7, the
+  /// same basis on which reconcileHeldRows matches an envelope per order.)
+  Future<SaleEnvelopeState> saleEnvelopeState(String orderId) async {
+    // An un-synced envelope still in the main queue → the cloud order isn't
+    // there yet. Checked first so that if a live retry ever coexisted with a
+    // stale orphan we hold (wait) rather than leak a phantom.
+    if (await _saleEnvelopeQueued(orderId, onlyUnsynced: true)) {
+      return SaleEnvelopeState.pending;
+    }
+    // Archived to orphans → permanently rejected (oversell rolled back).
+    if (await _saleEnvelopeOrphaned(orderId)) return SaleEnvelopeState.rejected;
+    // No un-synced envelope and not orphaned: confirmed (synced/purged) or v1.
+    return SaleEnvelopeState.confirmed;
+  }
+
+  /// Whether a `pos_record_sale_v2` envelope for [orderId] sits in `sync_queue`.
+  /// With [onlyUnsynced] the match is limited to not-yet-uploaded rows
+  /// (`is_synced = 0`) — a synced-but-lingering envelope then does NOT count (it
+  /// confirmed). Without it, any queue row counts (the "not gone" signal
+  /// [reconcileHeldRows] keeps waiting on).
+  Future<bool> _saleEnvelopeQueued(
+    String orderId, {
+    bool onlyUnsynced = false,
+  }) async {
+    final rows = await customSelect(
+      "SELECT 1 FROM sync_queue "
+      "WHERE action_type = 'domain:pos_record_sale_v2' "
+      "${onlyUnsynced ? 'AND is_synced = 0 ' : ''}"
+      "AND json_extract(payload, '\$.p_order_id') = ?1 LIMIT 1",
+      variables: [Variable.withString(orderId)],
+    ).get();
+    return rows.isNotEmpty;
+  }
+
+  /// Whether a `pos_record_sale_v2` envelope for [orderId] was archived to
+  /// `sync_queue_orphans` (a permanent rejection — e.g. an oversell).
+  Future<bool> _saleEnvelopeOrphaned(String orderId) async {
+    final rows = await customSelect(
+      "SELECT 1 FROM sync_queue_orphans "
+      "WHERE action_type = 'domain:pos_record_sale_v2' "
+      "AND json_extract(payload, '\$.p_order_id') = ?1 LIMIT 1",
+      variables: [Variable.withString(orderId)],
+    ).get();
+    return rows.isNotEmpty;
   }
 
   Future<void> markInProgress(String id) async {
@@ -737,7 +800,14 @@ class SyncDao extends DatabaseAccessor<AppDatabase>
     await (delete(syncQueueOrphans)..where((t) => t.id.equals(orphanId))).go();
   }
 
-  Future<void> enqueueUpsert(String tableName, Insertable row) async {
+  Future<void> enqueueUpsert(
+    String tableName,
+    Insertable row, {
+    // Oversell recovery (#149/#121): when set, the enqueued row is HELD by this
+    // order — invisible to the drain ([getPendingItems]) until the sale's
+    // `pos_record_sale_v2` envelope confirms (release) or is rejected (discard).
+    String? heldByOrderId,
+  }) async {
     // Sync safeguard (CLAUDE.md §5): fail fast on an unknown/typo'd table.
     // The pusher dispatches `<table>:upsert` to `_supabase.from(table)` with
     // no whitelist, so a bad name would silently stick as a failed queue row.
@@ -799,6 +869,12 @@ class SyncDao extends DatabaseAccessor<AppDatabase>
             nextAttemptAt: const Value(null),
             errorMessage: const Value(null),
             authUserId: Value(db.currentAuthUserId),
+            // Apply the hold only when explicitly requested; leave it untouched
+            // otherwise so coalescing an unrelated re-upsert never releases an
+            // already-held (#121) child row early.
+            heldByOrderId: heldByOrderId == null
+                ? const Value.absent()
+                : Value(heldByOrderId),
           ),
         );
       } else {
@@ -809,6 +885,7 @@ class SyncDao extends DatabaseAccessor<AppDatabase>
             actionType: actionType,
             payload: payloadJson,
             authUserId: Value(db.currentAuthUserId),
+            heldByOrderId: Value(heldByOrderId),
           ),
         );
       }

--- a/test/sync/rejected_sale_header_hold_test.dart
+++ b/test/sync/rejected_sale_header_hold_test.dart
@@ -1,0 +1,285 @@
+// rejected_sale_header_hold_test.dart
+//
+// Issue #149 — a rejected v2 oversell must NOT leave a phantom `completed`
+// order in the cloud. The order *header* is pushed at Confirm time by
+// `OrdersDao.markCompleted` → `_enqueueFullOrder` (a plain LWW `orders` upsert).
+// On the guarded v2 path (`feature.domain_rpcs_v2.record_sale`) the cloud order
+// exists ONLY once the `pos_record_sale_v2` envelope confirms, so that header
+// push must be HELD by the order — exactly like the #121 child rows — until the
+// envelope resolves: released to push on CONFIRM, discarded on REJECT. A v1 sale
+// (no envelope) and an already-CONFIRMED v2 sale push the header immediately,
+// unchanged, so a completed status never lags behind the cloud.
+
+import 'package:drift/drift.dart' hide isNull, isNotNull;
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:reebaplus_pos/core/database/app_database.dart';
+import 'package:reebaplus_pos/core/database/uuid_v7.dart';
+
+import '../helpers/dispatch_test_utils.dart';
+
+void main() {
+  late AppDatabase db;
+  late String businessId;
+
+  setUp(() async {
+    final boot = await bootstrapTestDb();
+    db = boot.db;
+    businessId = boot.businessId;
+  });
+
+  tearDown(() => db.close());
+
+  // Seeds a registered sale rung at status 'pending' (as real checkout does)
+  // and returns its order id + cashier. On the v2 path the pos_record_sale_v2
+  // envelope is left PENDING in the queue and NO header row is enqueued yet —
+  // v2 defers the header to Confirm (markCompleted). With [domainV2] off it is a
+  // plain v1 sale (never any envelope).
+  Future<({String orderId, String staffId})> seedPendingSale({
+    bool domainV2 = true,
+  }) async {
+    final storeId = UuidV7.generate();
+    await db.into(db.stores).insert(
+          StoresCompanion.insert(
+              id: Value(storeId), businessId: businessId, name: 'Main'),
+        );
+    final staffId = UuidV7.generate();
+    await db.into(db.users).insert(
+          UsersCompanion.insert(
+              id: Value(staffId),
+              businessId: businessId,
+              name: 'Cashier',
+              pin: '0000'),
+        );
+    final productId = UuidV7.generate();
+    await db.into(db.products).insert(
+          ProductsCompanion.insert(
+              id: Value(productId),
+              businessId: businessId,
+              name: 'Beer',
+              retailerPriceKobo: const Value(100000)),
+        );
+    await db.into(db.inventory).insert(
+          InventoryCompanion.insert(
+              businessId: businessId,
+              productId: productId,
+              storeId: storeId,
+              quantity: const Value(5)),
+        );
+    final customerId = await db.customersDao.addCustomer(
+      CustomersCompanion.insert(businessId: businessId, name: 'Buyer'),
+    );
+    await setFlag(db, 'feature.domain_rpcs_v2.record_sale', on: domainV2);
+    await db.delete(db.syncQueue).go(); // clear addCustomer enqueues
+
+    final orderId = await db.ordersDao.createOrder(
+      order: OrdersCompanion.insert(
+        businessId: businessId,
+        orderNumber: 'ORD-1',
+        customerId: Value(customerId),
+        totalAmountKobo: 200000,
+        netAmountKobo: 200000,
+        amountPaidKobo: const Value(50000),
+        paymentType: 'credit',
+        status: 'pending',
+        staffId: Value(staffId),
+        storeId: Value(storeId),
+      ),
+      items: [
+        OrderItemsCompanion.insert(
+          businessId: businessId,
+          orderId: 'placeholder',
+          productId: Value(productId),
+          storeId: storeId,
+          quantity: 2,
+          unitPriceKobo: 100000,
+          totalKobo: 200000,
+        ),
+      ],
+      customerId: customerId,
+      amountPaidKobo: 50000,
+      totalAmountKobo: 200000,
+      staffId: staffId,
+      storeId: storeId,
+      paymentMethod: 'cash',
+    );
+    return (orderId: orderId, staffId: staffId);
+  }
+
+  // The `orders:upsert` queue row for [orderId], or null if the header was
+  // never enqueued (payload carries the order id under 'id').
+  Future<SyncQueueData?> headerRow(String orderId) async {
+    final rows = await (db.select(db.syncQueue)
+          ..where((t) => t.actionType.equals('orders:upsert')))
+        .get();
+    for (final r in rows) {
+      if (decodePayload(r)['id'] == orderId) return r;
+    }
+    return null;
+  }
+
+  Future<SyncQueueData> envelope() => (db.select(db.syncQueue)
+        ..where((t) => t.actionType.equals('domain:pos_record_sale_v2')))
+      .getSingle();
+
+  Future<void> orphanTheEnvelope() async {
+    final env = await envelope();
+    await db.into(db.syncQueueOrphans).insert(
+          SyncQueueOrphansCompanion.insert(
+            originalId: env.id,
+            actionType: env.actionType,
+            payload: env.payload,
+            reason: 'pg_P0001: insufficient_stock',
+          ),
+        );
+    await (db.delete(db.syncQueue)..where((t) => t.id.equals(env.id))).go();
+  }
+
+  group('saleEnvelopeState classifies the pos_record_sale_v2 envelope', () {
+    test('an un-synced envelope still in the queue → pending', () async {
+      final sale = await seedPendingSale();
+      expect(await db.syncDao.saleEnvelopeState(sale.orderId),
+          SaleEnvelopeState.pending);
+    });
+
+    test('a synced (markDone) envelope lingering in the queue → confirmed',
+        () async {
+      final sale = await seedPendingSale();
+      await db.syncDao.markDone((await envelope()).id);
+      expect(await db.syncDao.saleEnvelopeState(sale.orderId),
+          SaleEnvelopeState.confirmed);
+    });
+
+    test('an envelope purged from the queue (not orphaned) → confirmed',
+        () async {
+      final sale = await seedPendingSale();
+      await (db.delete(db.syncQueue)
+            ..where((t) => t.actionType.equals('domain:pos_record_sale_v2')))
+          .go();
+      expect(await db.syncDao.saleEnvelopeState(sale.orderId),
+          SaleEnvelopeState.confirmed);
+    });
+
+    test('an envelope archived to orphans → rejected', () async {
+      final sale = await seedPendingSale();
+      await orphanTheEnvelope();
+      expect(await db.syncDao.saleEnvelopeState(sale.orderId),
+          SaleEnvelopeState.rejected);
+    });
+
+    test('an order that never had an envelope (v1 sale) → confirmed', () async {
+      final sale = await seedPendingSale(domainV2: false);
+      expect(await db.syncDao.saleEnvelopeState(sale.orderId),
+          SaleEnvelopeState.confirmed);
+    });
+  });
+
+  group('markCompleted holds the order header behind the v2 envelope (#149)',
+      () {
+    test('while the envelope is PENDING the header is HELD (never drains)',
+        () async {
+      final sale = await seedPendingSale();
+      await db.ordersDao.markCompleted(sale.orderId, sale.staffId);
+
+      final header = await headerRow(sale.orderId);
+      expect(header, isNotNull, reason: 'markCompleted enqueues the header');
+      expect(header!.heldByOrderId, sale.orderId,
+          reason: 'the header must be held by the order until the envelope '
+              'confirms — otherwise a rejected sale leaks a phantom order');
+
+      final drainable =
+          await db.syncDao.getPendingItems(businessId: businessId);
+      expect(drainable.where((r) => r.actionType == 'orders:upsert'), isEmpty,
+          reason: 'the held header is invisible to the drain');
+    });
+
+    test('a REJECTED sale discards the held header — no phantom cloud order',
+        () async {
+      final sale = await seedPendingSale();
+      await db.ordersDao.markCompleted(sale.orderId, sale.staffId);
+
+      // The server rejects the oversell; the drain calls discardHeldByOrder
+      // for the order (SupabaseSyncService._pushDomainItems, reject path).
+      await db.syncDao.discardHeldByOrder(sale.orderId);
+
+      expect(await headerRow(sale.orderId), isNull,
+          reason: 'the phantom header is discarded with the child rows');
+      final drainable =
+          await db.syncDao.getPendingItems(businessId: businessId);
+      expect(drainable.where((r) => r.actionType == 'orders:upsert'), isEmpty,
+          reason: 'a rejected sale never pushes its order header');
+    });
+
+    test('a CONFIRMED sale releases the held header — it may push as completed',
+        () async {
+      final sale = await seedPendingSale();
+      await db.ordersDao.markCompleted(sale.orderId, sale.staffId);
+
+      // The envelope confirms; the drain calls releaseHeldByOrder
+      // (SupabaseSyncService._pushDomainItems, confirm path).
+      await db.syncDao.releaseHeldByOrder(sale.orderId);
+
+      final drainable =
+          await db.syncDao.getPendingItems(businessId: businessId);
+      expect(drainable.where((r) => r.actionType == 'orders:upsert'),
+          isNotEmpty,
+          reason: 'once the cloud order exists the completed header may push');
+    });
+
+    test('reconcileHeldRows DISCARDS a held header for a rejected envelope',
+        () async {
+      final sale = await seedPendingSale();
+      await db.ordersDao.markCompleted(sale.orderId, sale.staffId);
+      await orphanTheEnvelope(); // rejected, but the inline discard was missed
+
+      final result = await db.syncDao.reconcileHeldRows(businessId);
+      expect(result.discarded, greaterThan(0));
+      expect(await headerRow(sale.orderId), isNull,
+          reason: 'the crash-safe backstop also removes the phantom header');
+    });
+  });
+
+  group('markCompleted pushes the header immediately when safe (no regression)',
+      () {
+    test('an already-CONFIRMED v2 sale pushes the header UNHELD', () async {
+      final sale = await seedPendingSale();
+      // Online sale: the envelope confirmed before Confirm was tapped.
+      await db.syncDao.markDone((await envelope()).id);
+
+      await db.ordersDao.markCompleted(sale.orderId, sale.staffId);
+
+      final header = await headerRow(sale.orderId);
+      expect(header, isNotNull);
+      expect(header!.heldByOrderId, isNull,
+          reason: 'a confirmed sale need not hold — no completion-sync delay');
+      final drainable =
+          await db.syncDao.getPendingItems(businessId: businessId);
+      expect(drainable.where((r) => r.actionType == 'orders:upsert'),
+          isNotEmpty);
+    });
+
+    test('a v1 sale (flag off) pushes the header UNHELD', () async {
+      final sale = await seedPendingSale(domainV2: false);
+      await db.ordersDao.markCompleted(sale.orderId, sale.staffId);
+
+      final header = await headerRow(sale.orderId);
+      expect(header, isNotNull);
+      expect(header!.heldByOrderId, isNull);
+      final drainable =
+          await db.syncDao.getPendingItems(businessId: businessId);
+      expect(drainable.where((r) => r.actionType == 'orders:upsert'),
+          isNotEmpty);
+    });
+
+    test('a sale already REJECTED before Confirm never enqueues a header',
+        () async {
+      final sale = await seedPendingSale();
+      await orphanTheEnvelope();
+
+      await db.ordersDao.markCompleted(sale.orderId, sale.staffId);
+
+      expect(await headerRow(sale.orderId), isNull,
+          reason: 'completing a rolled-back sale must not resurrect a header');
+    });
+  });
+}


### PR DESCRIPTION
## What & why

On the guarded sale path (`feature.domain_rpcs_v2.record_sale` ON), a **rejected** `pos_record_sale_v2` oversell left a **phantom `completed` order in the cloud** — a real `net_amount_kobo` but **zero** items/stock/payments. The order *header* reaches the cloud independently of the envelope, via Confirm (`OrdersDao.markCompleted → _enqueueFullOrder`, a plain LWW `orders` upsert **not** covered by #121's `held_by_order_id`), so it drained even though the envelope was rejected. `reverseRejectedSaleLocal` is local-only, so the cashier's Cancel never reconciled the cloud. (Proof it was the client upsert: cloud `created_at` = client ring-time, not the RPC's exec-time `now()`.)

## Fix — the issue's preferred Option 1 (hold the header)

Every order-header push now routes through one envelope-aware primitive, `_enqueueFullOrder`, which classifies the sale's envelope via new `SyncDao.saleEnvelopeState(orderId) → {pending, confirmed, rejected}`:

- **rejected** (envelope in `sync_queue_orphans`) → **skip** the push — never resurrect a rolled-back sale;
- **pending** (un-synced envelope in `sync_queue`) → enqueue **held** by the order (new `enqueueUpsert(..., heldByOrderId:)`) — reuses #121's release-on-confirm / discard-on-reject / `reconcileHeldRows`;
- **confirmed** (synced/purged envelope, or a **v1** sale with no envelope) → push immediately, unchanged — no completion-sync delay on the online path.

`assignRider` + `markCancelled`(v1) inherit the guard; `renumberForCollisionHeal` is re-routed through it, so `_enqueueFullOrder` is the **sole** order-header push site (the only remaining direct `enqueueUpsert('orders')` is v1 `createOrder`, the sale record itself). `saleEnvelopeState` and `reconcileHeldRows` share two private envelope-lookup helpers, with the `is_synced` divergence made an explicit parameter.

**Why not Option 2:** the RPC inserts the header `ON CONFLICT (id) DO NOTHING` and **never updates** it, and `p_status` is frozen at ring-time `pending` — so dropping the Confirm push would strand the cloud order at `pending` forever.

## Tests / verification

- New `test/sync/rejected_sale_header_hold_test.dart` (12 cases): classifier for all four envelope states, held-while-pending, **discarded-on-reject (no phantom)**, released-on-confirm, `reconcileHeldRows` backstop, and no-regression (confirmed/v1 push unheld; already-rejected-at-Confirm never enqueues a header).
- `flutter analyze` clean; full suite green (963 pass). The one failure (`who_is_working_screen_test`) is **pre-existing and unrelated** — verified failing identically on the pristine baseline.
- No schema change (`held_by_order_id` already exists); no migration, no codegen.

## Follow-up (not this PR)

Preventive only — it does not reconcile phantoms that already reached the cloud before it ships (need a one-off `UPDATE orders SET status='cancelled' … WHERE status='completed' AND no children`; the QA repro's `ORD-000002-GF0C4C` was cleaned by hand). Pairs with **#150** (a Sync-Issues entry point to the one-tap recovery).

Closes #149


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented rejected oversell transactions from creating phantom completed orders in the cloud.
  * Order updates now wait for pending sale confirmation and are discarded when sales are rejected.
  * Confirmed sales continue syncing normally, including recovery after interrupted processing.

* **Tests**
  * Added coverage for pending, confirmed, rejected, archived, and legacy sale-sync scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->