### PR TITLE
feat(sync): Sync Issues "Cancel this sale" entry point for oversell recovery (#150)

### DIFF
--- a/BUILD_LOG.md
+++ b/BUILD_LOG.md
@@ -2,6 +2,52 @@
 
 ---
 
+## 2026-07-19 — #150: a Sync Issues entry point for oversell recovery (fallback for a dismissed alert)
+
+Branch `feat/sync-issues-cancel-rejected-sale` (off `origin/main` = #149's merge). Pairs with #149
+(PR #151, which stops the *cloud* phantom) — #150 is the *client* fallback route.
+
+**Problem.** The one-tap recovery `OrderService.cancelRejectedSale` (full local undo of a
+server-rejected v2 sale — order + inventory + wallet + crate) was reachable from **exactly one**
+place: the tappable `sale_rejected` notification (`notifications_modal.dart`). If the cashier
+swipe-dismisses / clears that alert, the phantom `completed` order is stranded on the device with no
+recovery affordance. The Sync Issues screen *surfaces* the orphaned `domain:pos_record_sale_v2`
+envelope but only offered **Retry** (re-orphans an oversell) / **Discard** (deletes the very
+`p_items` payload the reversal needs).
+
+**Fix (issue's preferred route).** Added a **second entry point** — a "Cancel this sale" action on
+the Sync Issues orphan tile for a `domain:pos_record_sale_v2` row:
+- `OrderCommands.cancelRejectedSaleFromOrphan({orderId, orphanId, staffId})` (exposed via
+  `OrderService`) runs the **same** reversal as the notification (`cancelRejectedSale`, which sources
+  the sold lines from the orphan's `p_items` via `SyncDao.rejectedSalePayload`) and **then**
+  `discardOrphan(orphanId)`.
+- **Critical ordering — reverse BEFORE clear.** The reversal reads the orphan payload, so
+  discard-then-recover would delete the `p_items` and refund nothing. The command awaits the reversal
+  first, then clears the orphan. Idempotent (a second tap finds the orphan gone → empty lines →
+  no-op; `reverseRejectedSaleLocal` early-returns on an already-`cancelled` order).
+- **UI.** `sync_issues_screen.dart`'s orphan tile computes `_rejectedSaleOrderId(item)` (gated on
+  `actionType == 'domain:pos_record_sale_v2'`, parses `p_order_id`) and, when present, renders a
+  "Cancel this sale" `TextButton` → a plain-language confirm dialog mirroring the notification's copy
+  → the command → a success/error snackbar. The action row became a `Wrap` (WrapAlignment.end) so a
+  third button can't overflow (the now-invalid `Spacer` was dropped — Spacer only works in a Flex).
+  Retry/Discard left intact. All `ref` reads happen before any `await` (element-unmount race, per the
+  screen's existing initState-capture note).
+
+**Scope kept minimal.** The *"and/or"* phantom-order-detail entry point was not added (explicit
+alternative to the *preferred* Sync Issues route). No schema/migration; the reversal is local-only
+(the rejected sale never reached the cloud). No invariant touched — #12 (the orphan stays visible
+until the cashier's deliberate confirmed Cancel), #3 (wallet legs reversed by compensating rows, not
+edits), #1/#4 (no direct cloud read/write; reversal is pure Drift).
+
+**TDD.** `test/orders/cancel_rejected_sale_from_orphan_test.dart` (mirrors
+`cancel_rejected_sale_test.dart`): reverse-AND-clear; reverse-BEFORE-clear (inventory 5 not 3 proves
+the payload was still present); idempotent second Cancel; orphan-already-gone still cancels the
+phantom header. `flutter analyze` clean on all touched files; `test/orders/` + `test/sync/` 254 green;
+full suite green except the **pre-existing** `who_is_working_screen_test.dart` failure (confirmed
+failing on clean `origin/main`, unrelated).
+
+---
+
 ## 2026-07-19 — #149: a rejected v2 oversell no longer leaks a phantom `completed` cloud order
 
 Branch `fix/rejected-v2-phantom-cloud-order`. Fixes the leak found during QA of #100/#121: on the

--- a/CONTEXT/progress-tracker.md
+++ b/CONTEXT/progress-tracker.md
@@ -2852,6 +2852,33 @@ Spec: `context/specs/brief-sync-data-safety-and-efficiency.md`. Branch
 
 ## Session Notes
 
+**2026-07-19 — #150: a Sync Issues entry point for oversell recovery (client
+fallback).** Pairs with #149 (which stops the *cloud* phantom); this is the
+*client* fallback route. `OrderService.cancelRejectedSale` (full local undo of a
+server-rejected v2 sale) was reachable from **one** place — the tappable
+`sale_rejected` notification — so a swipe-dismiss stranded the phantom with no
+recovery affordance. Added a **second entry point**: a "Cancel this sale" action
+on the Sync Issues orphan tile for a `domain:pos_record_sale_v2` row →
+`OrderCommands.cancelRejectedSaleFromOrphan({orderId, orphanId, staffId})`, which
+runs the **same** reversal (`cancelRejectedSale`, sourcing `p_items` from the
+orphan via `SyncDao.rejectedSalePayload`) and **then** `discardOrphan`. **Critical
+ordering — reverse BEFORE clear** (the reversal reads the orphan payload, so
+discard-first would refund nothing); idempotent. UI: the tile computes
+`_rejectedSaleOrderId(item)` (gated on the action type + `p_order_id`) and renders
+a `TextButton` → a plain-language confirm dialog mirroring the notification copy →
+snackbar; the orphan action row became a `Wrap` so a third button can't overflow;
+all `ref` reads precede any `await`. Retry/Discard kept. No schema/migration
+(reversal is local-only). Invariants untouched (#12 orphan stays visible until the
+deliberate confirmed Cancel; #3 wallet reversed by compensating rows; #1/#4 no
+direct cloud read/write). The *"and/or"* order-detail entry point was left out
+(explicit alternative to the *preferred* route). TDD:
+`test/orders/cancel_rejected_sale_from_orphan_test.dart` (reverse-AND-clear;
+reverse-BEFORE-clear proven by inventory 5≠3; idempotent; orphan-gone still cancels
+the header). `flutter analyze` clean; `test/orders/`+`test/sync/` 254 green; full
+suite green except the pre-existing `who_is_working_screen_test` failure (verified
+failing on clean `origin/main`). Branch `feat/sync-issues-cancel-rejected-sale`;
+full detail in `BUILD_LOG.md` (2026-07-19).
+
 **2026-07-19 — #149: rejected v2 oversell no longer leaks a phantom `completed`
 cloud order.** Hardens Invariant #12 on the order *header*. On the guarded path
 (`feature.domain_rpcs_v2.record_sale`), the Confirm-time header push

--- a/lib/features/sync/screens/sync_issues_screen.dart
+++ b/lib/features/sync/screens/sync_issues_screen.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:convert';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -678,6 +679,10 @@ class _SyncIssuesScreenState extends ConsumerState<SyncIssuesScreen> {
 
   Widget _orphanItemTile(ThemeData t, SyncQueueOrphanData item) {
     final reasonText = item.reason;
+    // A rejected `pos_record_sale_v2` sale (an oversell the cloud rolled back)
+    // gets a one-tap recovery: run the same full local reversal as the
+    // `sale_rejected` notification, then clear this orphan (#150).
+    final rejectedOrderId = _rejectedSaleOrderId(item);
     final payloadPreview = item.payload.length > 200
         ? '${item.payload.substring(0, 200)}…'
         : item.payload;
@@ -744,9 +749,16 @@ class _SyncIssuesScreenState extends ConsumerState<SyncIssuesScreen> {
             ),
           ),
           const SizedBox(height: 10),
-          Row(
+          Wrap(
+            alignment: WrapAlignment.end,
+            spacing: 4,
             children: [
-              const Spacer(),
+              if (rejectedOrderId != null)
+                TextButton(
+                  onPressed: () =>
+                      _confirmCancelRejectedSale(item, rejectedOrderId),
+                  child: const Text('Cancel this sale'),
+                ),
               TextButton(
                 onPressed: () async {
                   try {
@@ -795,6 +807,99 @@ class _SyncIssuesScreenState extends ConsumerState<SyncIssuesScreen> {
         ],
       ),
     );
+  }
+
+  /// The plain `p_order_id` of a rejected-sale orphan
+  /// (`domain:pos_record_sale_v2`), or null for any other orphan or an
+  /// unparseable payload. Drives the one-tap "Cancel this sale" recovery (#150).
+  String? _rejectedSaleOrderId(SyncQueueOrphanData item) {
+    if (item.actionType != 'domain:pos_record_sale_v2') return null;
+    try {
+      final decoded = jsonDecode(item.payload);
+      if (decoded is Map) {
+        final oid = decoded['p_order_id'];
+        if (oid is String && oid.isNotEmpty) return oid;
+      }
+    } catch (_) {
+      // Unparseable payload — no recovery affordance.
+    }
+    return null;
+  }
+
+  /// Confirms and runs the second recovery entry point for a server-rejected
+  /// sale (#150): the SAME full local reversal the `sale_rejected` notification
+  /// runs — order + inventory + wallet + crate — sourced from this orphan's
+  /// `p_items`, then the orphan is cleared. The reversal runs BEFORE the orphan
+  /// is discarded (it reads the payload), so it is never discard-then-recover.
+  Future<void> _confirmCancelRejectedSale(
+    SyncQueueOrphanData item,
+    String orderId,
+  ) async {
+    final t = Theme.of(context);
+    // Resolve everything off `ref` before any await — the element can unmount
+    // while the dialog is open, and touching `ref` afterwards races the
+    // riverpod invalidation (see the initState capture note above).
+    final staffId = ref.read(authProvider).currentUser?.id;
+    final orderService = ref.read(orderServiceProvider);
+    if (staffId == null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Please sign in again to cancel this sale.'),
+        ),
+      );
+      return;
+    }
+
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Cancel this rejected sale?'),
+        content: const Text(
+          'The server turned this sale down — the item was likely sold on '
+          'another till. Cancelling removes the sale from this device: the '
+          'stock and any customer empties balance go back to what they were '
+          'before it, and this entry is cleared.',
+          style: TextStyle(fontSize: 14),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, false),
+            child: const Text('Keep'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            style: TextButton.styleFrom(foregroundColor: t.colorScheme.error),
+            child: const Text('Cancel the sale'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true) return;
+
+    try {
+      await orderService.cancelRejectedSaleFromOrphan(
+        orderId: orderId,
+        orphanId: item.id,
+        staffId: staffId,
+      );
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Sale cancelled. Stock and balances restored.'),
+          duration: Duration(seconds: 3),
+        ),
+      );
+    } catch (_) {
+      // Mirror the notification path: show a friendly generic message rather
+      // than a raw exception string to a cashier.
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: const Text('Could not cancel the sale. Please try again.'),
+          backgroundColor: t.colorScheme.error,
+        ),
+      );
+    }
   }
 
   Widget _pendingItemTile(ThemeData t, SyncQueueData item) {

--- a/lib/shared/services/orders/order_commands.dart
+++ b/lib/shared/services/orders/order_commands.dart
@@ -492,6 +492,25 @@ class OrderCommands {
     );
   }
 
+  /// Cashier-initiated Cancel of a rejected sale from the **Sync Issues** screen
+  /// (#150) — the fallback route when the `sale_rejected` notification was
+  /// swipe-dismissed. Runs the complete local reversal FIRST via
+  /// [cancelRejectedSale] — which sources the sold lines from the orphaned
+  /// envelope's `p_items` — and only THEN clears the orphan ([orphanId]).
+  ///
+  /// The order is load-bearing: discarding the orphan first would delete the
+  /// `p_items` payload the reversal depends on, so inventory would never be
+  /// refunded (never discard-then-recover). Idempotent, and safe if the orphan
+  /// has already been cleaned up.
+  Future<void> cancelRejectedSaleFromOrphan({
+    required String orderId,
+    required String orphanId,
+    required String staffId,
+  }) async {
+    await cancelRejectedSale(orderId, staffId);
+    await _db.syncDao.discardOrphan(orphanId);
+  }
+
   String _resolvePaymentType({
     required String paymentSubType,
     required int amountPaidKobo,

--- a/lib/shared/services/orders/order_service.dart
+++ b/lib/shared/services/orders/order_service.dart
@@ -103,6 +103,24 @@ class OrderService {
     return _commands.cancelRejectedSale(orderId, staffId);
   }
 
+  /// **Cancel a server-REJECTED sale from Sync Issues** (#150) — the fallback
+  /// route when the `sale_rejected` alert was swipe-dismissed. Runs the same
+  /// complete local reversal as [cancelRejectedSale] and then clears the
+  /// orphaned envelope ([orphanId]). Reverses BEFORE clearing — the reversal
+  /// reads the sold lines out of that orphan — so it is never discard-then-
+  /// recover. Idempotent.
+  Future<void> cancelRejectedSaleFromOrphan({
+    required String orderId,
+    required String orphanId,
+    required String staffId,
+  }) {
+    return _commands.cancelRejectedSaleFromOrphan(
+      orderId: orderId,
+      orphanId: orphanId,
+      staffId: staffId,
+    );
+  }
+
   Future<void> assignRider(String orderId, String riderName) {
     return _commands.assignRider(orderId, riderName);
   }

--- a/test/orders/cancel_rejected_sale_from_orphan_test.dart
+++ b/test/orders/cancel_rejected_sale_from_orphan_test.dart
@@ -1,0 +1,224 @@
+// cancel_rejected_sale_from_orphan_test.dart
+//
+// Oversell recovery — the Sync Issues fallback route (#150). If the cashier
+// swipe-dismissed the `sale_rejected` notification, the rejected v2 sale is
+// still recoverable from the Sync Issues screen: its orphaned
+// `domain:pos_record_sale_v2` envelope carries `p_order_id` + `p_items`, so a
+// "Cancel this sale" action can run the SAME complete local reversal as the
+// notification and THEN clear the orphan.
+//
+// Critical gotcha this pins: the reversal MUST run BEFORE the orphan is cleared.
+// `cancelRejectedSale` sources the sold lines from the orphan's `p_items`, so a
+// discard-then-recover ordering would delete the payload and refund nothing.
+//
+// Pins: (1) the sale is reversed (order cancelled + inventory refunded) AND the
+// orphan is cleared; (2) the refund proves the reversal ran while the payload
+// was still present (reverse-before-clear); (3) idempotent — a second Cancel is
+// a no-op; (4) with the orphan already gone, the phantom header is still
+// cancelled.
+
+import 'dart:convert';
+
+import 'package:drift/drift.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:reebaplus_pos/core/database/app_database.dart';
+import 'package:reebaplus_pos/core/database/uuid_v7.dart';
+import 'package:reebaplus_pos/shared/services/orders/order_service.dart';
+
+import '../helpers/dispatch_test_utils.dart';
+
+void main() {
+  late AppDatabase db;
+  late String businessId;
+
+  setUp(() async {
+    final boot = await bootstrapTestDb();
+    db = boot.db;
+    businessId = boot.businessId;
+    // v2 path — the sale writes an order + inventory deduction locally, but NO
+    // order_items (they'd come from the RPC), exactly the state a rejected v2
+    // sale leaves behind.
+    await setFlag(db, 'feature.domain_rpcs_v2.record_sale', on: true);
+  });
+
+  tearDown(() => db.close());
+
+  Future<({String storeId, String staffId, String productId})> seed() async {
+    final storeId = UuidV7.generate();
+    await db.into(db.stores).insert(StoresCompanion.insert(
+        id: Value(storeId), businessId: businessId, name: 'Main'));
+    final staffId = UuidV7.generate();
+    await db.into(db.users).insert(UsersCompanion.insert(
+        id: Value(staffId),
+        businessId: businessId,
+        name: 'Cashier',
+        pin: '0000'));
+    final productId = UuidV7.generate();
+    await db.into(db.products).insert(ProductsCompanion.insert(
+        id: Value(productId),
+        businessId: businessId,
+        name: 'Beer',
+        retailerPriceKobo: const Value(100000)));
+    await db.into(db.inventory).insert(InventoryCompanion.insert(
+        businessId: businessId,
+        productId: productId,
+        storeId: storeId,
+        quantity: const Value(5)));
+    return (storeId: storeId, staffId: staffId, productId: productId);
+  }
+
+  // A v2 walk-in sale: order header + inventory deduction, no local order_items.
+  Future<String> sellV2(
+    ({String storeId, String staffId, String productId}) f, {
+    required int qty,
+  }) {
+    final total = qty * 100000;
+    return db.ordersDao.createOrder(
+      order: OrdersCompanion.insert(
+        businessId: businessId,
+        orderNumber: 'ORD-${UuidV7.generate()}',
+        totalAmountKobo: total,
+        netAmountKobo: total,
+        amountPaidKobo: Value(total),
+        paymentType: 'cash',
+        status: 'completed',
+        staffId: Value(f.staffId),
+        storeId: Value(f.storeId),
+      ),
+      items: [
+        OrderItemsCompanion.insert(
+          businessId: businessId,
+          orderId: 'placeholder',
+          productId: Value(f.productId),
+          storeId: f.storeId,
+          quantity: qty,
+          unitPriceKobo: 100000,
+          totalKobo: total,
+        ),
+      ],
+      customerId: null,
+      amountPaidKobo: total,
+      totalAmountKobo: total,
+      staffId: f.staffId,
+      storeId: f.storeId,
+      paymentMethod: 'cash',
+    );
+  }
+
+  // The rejection lifted the envelope into sync_queue_orphans. Returns the
+  // orphan's id (what the Sync Issues tile passes as `orphanId`).
+  Future<String> orphanEnvelope(
+    String orderId,
+    String storeId,
+    String productId,
+    int qty,
+  ) async {
+    final orphanId = UuidV7.generate();
+    await db.into(db.syncQueueOrphans).insert(
+          SyncQueueOrphansCompanion.insert(
+            id: Value(orphanId),
+            originalId: UuidV7.generate(),
+            actionType: 'domain:pos_record_sale_v2',
+            payload: jsonEncode({
+              'p_order_id': orderId,
+              'p_store_id': storeId,
+              'p_business_id': businessId,
+              'p_items': [
+                {'product_id': productId, 'quantity': qty},
+              ],
+            }),
+            reason: 'insufficient_stock',
+          ),
+        );
+    return orphanId;
+  }
+
+  Future<int> orphanCount() async =>
+      (await db.select(db.syncQueueOrphans).get()).length;
+
+  test('reverses the sale AND clears the orphan', () async {
+    final f = await seed();
+    final orderId = await sellV2(f, qty: 2);
+    expect((await db.select(db.inventory).getSingle()).quantity, 3,
+        reason: 'the optimistic pre-check deducted 2');
+    final orphanId = await orphanEnvelope(orderId, f.storeId, f.productId, 2);
+    expect(await orphanCount(), 1);
+
+    await OrderService(db).cancelRejectedSaleFromOrphan(
+      orderId: orderId,
+      orphanId: orphanId,
+      staffId: f.staffId,
+    );
+
+    final order = await db.select(db.orders).getSingle();
+    expect(order.status, 'cancelled');
+    expect(order.cancellationReason, 'rejected_by_server');
+    expect((await db.select(db.inventory).getSingle()).quantity, 5,
+        reason: 'inventory refunded from the envelope p_items');
+    expect(await orphanCount(), 0,
+        reason: 'the orphan envelope is cleared after recovery');
+  });
+
+  test('runs the reversal BEFORE clearing the orphan (refund proves ordering)',
+      () async {
+    final f = await seed();
+    final orderId = await sellV2(f, qty: 2);
+    final orphanId = await orphanEnvelope(orderId, f.storeId, f.productId, 2);
+
+    await OrderService(db).cancelRejectedSaleFromOrphan(
+      orderId: orderId,
+      orphanId: orphanId,
+      staffId: f.staffId,
+    );
+
+    // A discard-then-recover ordering would delete the payload first, leaving
+    // `cancelRejectedSale` with no lines to refund — inventory would stay at 3.
+    expect((await db.select(db.inventory).getSingle()).quantity, 5,
+        reason: 'reversal ran while the orphan payload was still present');
+    expect(await orphanCount(), 0);
+  });
+
+  test('is idempotent — a second Cancel is a no-op', () async {
+    final f = await seed();
+    final orderId = await sellV2(f, qty: 2);
+    final orphanId = await orphanEnvelope(orderId, f.storeId, f.productId, 2);
+
+    final svc = OrderService(db);
+    await svc.cancelRejectedSaleFromOrphan(
+      orderId: orderId,
+      orphanId: orphanId,
+      staffId: f.staffId,
+    );
+    expect((await db.select(db.inventory).getSingle()).quantity, 5);
+    expect(await orphanCount(), 0);
+
+    // A second tap must not double-refund and must not throw on the now-gone
+    // orphan.
+    await svc.cancelRejectedSaleFromOrphan(
+      orderId: orderId,
+      orphanId: orphanId,
+      staffId: f.staffId,
+    );
+    expect((await db.select(db.inventory).getSingle()).quantity, 5,
+        reason: 'no double refund on a second Cancel');
+    expect((await db.select(db.orders).getSingle()).status, 'cancelled');
+    expect(await orphanCount(), 0);
+  });
+
+  test('with the orphan already gone, still cancels the phantom order header',
+      () async {
+    final f = await seed();
+    final orderId = await sellV2(f, qty: 2);
+    // No orphan seeded → nothing to source items from, nothing to discard.
+
+    await OrderService(db).cancelRejectedSaleFromOrphan(
+      orderId: orderId,
+      orphanId: UuidV7.generate(),
+      staffId: f.staffId,
+    );
+
+    expect((await db.select(db.orders).getSingle()).status, 'cancelled',
+        reason: 'the phantom header is cancelled even with no recoverable lines');
+  });
+}


### PR DESCRIPTION
Closes #150. Pairs with #149 (PR #151, which stops the *cloud* phantom) — this is the *client* fallback route.

## Problem
`OrderService.cancelRejectedSale` (full local undo of a server-rejected v2 sale — order + inventory + wallet + crate) was reachable from **exactly one** place: the tappable `sale_rejected` notification. A swipe-dismiss / clear-all stranded the phantom `completed` order on the device with no recovery affordance. The Sync Issues screen surfaced the orphaned `domain:pos_record_sale_v2` envelope but only offered **Retry** (re-orphans an oversell) / **Discard** (deletes the very `p_items` payload the reversal needs).

## Change
A **second entry point** — a "Cancel this sale" action on the Sync Issues orphan tile for a `domain:pos_record_sale_v2` row:

- **`OrderCommands.cancelRejectedSaleFromOrphan({orderId, orphanId, staffId})`** (exposed via `OrderService`) runs the **same** reversal as the notification (`cancelRejectedSale`, sourcing `p_items` from the orphan via `SyncDao.rejectedSalePayload`) and **then** `discardOrphan`.
- **Critical ordering — reverse BEFORE clear.** The reversal reads the orphan payload, so a discard-then-recover ordering would delete `p_items` and refund nothing. The command awaits the reversal first, then clears the orphan. Idempotent.
- **UI** — the orphan tile computes `_rejectedSaleOrderId(item)` (gated on the action type + `p_order_id`) and renders a "Cancel this sale" `TextButton` → a plain-language confirm dialog mirroring the notification copy → success/error snackbar. The action row became a `Wrap` (WrapAlignment.end) so a third button can't overflow (the now-invalid `Spacer` was dropped). Retry/Discard kept. All `ref` reads precede any `await`.

Local-only reversal (the rejected sale never reached the cloud); no schema/migration. Invariants untouched (#12 orphan stays visible until the deliberate confirmed Cancel; #3 wallet reversed by compensating rows; #1/#4 no direct cloud read/write). The *"and/or"* order-detail entry point was left out (explicit alternative to the *preferred* Sync Issues route).

## Tests
- **TDD** — `test/orders/cancel_rejected_sale_from_orphan_test.dart` (mirrors `cancel_rejected_sale_test.dart`): reverse-AND-clear; reverse-BEFORE-clear (inventory 5≠3 proves the payload was still present); idempotent second Cancel; orphan-already-gone still cancels the phantom header.
- `flutter analyze` clean on all touched files.
- `test/orders/` + `test/sync/` 254 green; full suite green except the pre-existing `who_is_working_screen_test.dart` failure (verified failing identically on clean `origin/main`, unrelated).
- Two-axis `/code-review` clean (no hard blockers).