### PR TITLE
fix(providers): stop ChangeNotifierProvider disposing service-owned notifiers (#153)

### DIFF
--- a/BUILD_LOG.md
+++ b/BUILD_LOG.md
@@ -2,6 +2,35 @@
 
 ---
 
+## 2026-07-20 — Fix: #153 ChangeNotifierProvider disposing service-owned notifiers (re-login crash)
+
+**Context.** Re-login after an admin-removed device wipe threw `A ValueNotifier<String?> was used after
+being disposed` (found during #117 QA). `ChangeNotifierProvider<T>` disposes whatever notifier its body
+returns — on teardown AND every rebuild — but four providers returned a **service-owned** notifier, so
+Riverpod disposed a notifier the owning service still writes to. `deviceUserIdProvider` fired readily
+because `AuthService` is itself a `ChangeNotifier` (notifies on every login/logout → rebuilds the provider
+→ re-disposes the same foreign notifier).
+
+**Fix.** New non-owning factory `mirrorNotifier<T>` ([mirror_notifier.dart](lib/core/providers/mirror_notifier.dart)):
+Riverpod owns a local proxy; the service notifier is only ever listened to (two-way mirrored, listener
+removed on dispose, original never disposed). Converted the 4 unsafe sites (`deviceUserIdProvider`,
+`activeCustomerProvider`, `pullStatusProvider`, `isOnlineNotifierProvider`) AND folded the 3 pre-existing
+safe proxy sites (`currentIndexProvider`, `lockedStoreProvider`, `storeExplicitlyChosenProvider`) onto the
+same helper — deleting ~80 lines of duplicated boilerplate. Behaviour unchanged for consumers (value-
+identical two-way mirror; consumers only read/listen).
+
+**Guard.** [mirror_notifier_ban_test.dart](test/providers/mirror_notifier_ban_test.dart) — a source scan
+that fails if any `ChangeNotifierProvider` body returns a borrowed `ref.watch`/`ref.read` notifier (any
+`ChangeNotifier` subtype, not just `ValueNotifier`); a provider that constructs+owns its notifier is left
+alone. Plus [mirror_notifier_test.dart](test/providers/mirror_notifier_test.dart) proving the original
+survives provider dispose AND rebuild (the crash repro).
+
+**Verified.** `flutter analyze` clean; 6 new tests green; full suite otherwise unchanged (the one
+pre-existing unrelated failure in `who_is_working_screen_test.dart` fails identically on base main).
+Branch `fix/provider-disposes-service-owned-notifier`, commit `bd1f755`.
+
+---
+
 ## 2026-07-20 — QA: #117 self-resign + admin-removed device offboarding PASSED (+ bug #153 found)
 
 **Context.** #117 = the person's own exit: a non-owner staffer's "Leave / delete my account" (Profile),

--- a/CONTEXT/progress-tracker.md
+++ b/CONTEXT/progress-tracker.md
@@ -10,6 +10,19 @@ The human updates it when resolving open questions or making architectural decis
 
 152 sessions logged. Codebase is live and being verified on-device.
 
+### #153 provider-lifecycle crash (re-login) — FIXED (2026-07-20)
+QA of the closed batch (during #117 offboarding) surfaced a re-login crash: four
+`ChangeNotifierProvider`s returned a **service-owned** `ValueNotifier`, so Riverpod
+disposed it out from under its owner (`A ValueNotifier<String?> was used after being
+disposed`). Fixed with a non-owning `mirrorNotifier` factory
+([mirror_notifier.dart](../lib/core/providers/mirror_notifier.dart)) — all 4 unsafe
+sites (`deviceUserId`/`activeCustomer`/`pullStatus`/`isOnline`) plus the 3 pre-existing
+safe proxy sites (`currentIndex`/`lockedStore`/`storeExplicitlyChosen`) routed through
+it — and a static ban-test guard against any `ChangeNotifierProvider` returning a
+borrowed notifier. `flutter analyze` clean, 6 new tests green. Branch
+`fix/provider-disposes-service-owned-notifier`, commit `bd1f755` (PR pending). Details
+in BUILD_LOG.
+
 ### 11-item feature/bug batch — PRD #106 + 13 issues filed; Phase 2 implementation STARTED (2026-07-11)
 Ran the full idea→issues flow (`/ask-matt` → `/grill-with-docs` → `/to-prd` →
 `/to-issues`) over a raw 11-item backlog (staff offboarding, optional units,

--- a/lib/core/providers/app_providers.dart
+++ b/lib/core/providers/app_providers.dart
@@ -8,7 +8,6 @@ library;
 import 'dart:async';
 
 import 'package:drift/drift.dart' show innerJoin;
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
@@ -16,6 +15,7 @@ import 'package:reebaplus_pos/core/industry/industry.dart';
 import 'package:reebaplus_pos/core/industry/lexicon.dart';
 import 'package:reebaplus_pos/core/database/app_database.dart';
 import 'package:reebaplus_pos/core/providers/business_scoped_stream.dart';
+import 'package:reebaplus_pos/core/providers/mirror_notifier.dart';
 import 'package:reebaplus_pos/core/services/biometric_service.dart';
 import 'package:reebaplus_pos/core/services/business_logo_service.dart';
 import 'package:reebaplus_pos/core/services/product_image_service.dart';
@@ -62,66 +62,20 @@ final supabaseClientProvider = Provider<SupabaseClient>(
 final navigationProvider = Provider<NavigationService>((ref) {
   return NavigationService();
 });
-final currentIndexProvider = ChangeNotifierProvider<ValueNotifier<int>>((ref) {
-  final original = ref.watch(navigationProvider).currentIndex;
-  final proxy = ValueNotifier<int>(original.value);
-  void originalListener() {
-    if (proxy.value != original.value) proxy.value = original.value;
-  }
-
-  void proxyListener() {
-    if (original.value != proxy.value) original.value = proxy.value;
-  }
-
-  original.addListener(originalListener);
-  proxy.addListener(proxyListener);
-  ref.onDispose(() {
-    original.removeListener(originalListener);
-  });
-  return proxy;
-});
-final lockedStoreProvider = ChangeNotifierProvider<ValueNotifier<String?>>((
-  ref,
-) {
-  final original = ref.watch(navigationProvider).lockedStoreId;
-  final proxy = ValueNotifier<String?>(original.value);
-  void originalListener() {
-    if (proxy.value != original.value) proxy.value = original.value;
-  }
-
-  void proxyListener() {
-    if (original.value != proxy.value) original.value = proxy.value;
-  }
-
-  original.addListener(originalListener);
-  proxy.addListener(proxyListener);
-  ref.onDispose(() {
-    original.removeListener(originalListener);
-  });
-  return proxy;
-});
+// Non-owning bridges to NavigationService-owned notifiers (issue #153): Riverpod
+// owns only the proxy, so navigation's notifiers survive every rebuild.
+final currentIndexProvider = mirrorNotifier<int>(
+  (ref) => ref.watch(navigationProvider).currentIndex,
+);
+final lockedStoreProvider = mirrorNotifier<String?>(
+  (ref) => ref.watch(navigationProvider).lockedStoreId,
+);
 // §12.1: true once the user explicitly picked a concrete active store this
 // session (vs MainLayout's silent confined-user default). Drives the POS
 // "pick a store" gate for every user with more than one store.
-final storeExplicitlyChosenProvider =
-    ChangeNotifierProvider<ValueNotifier<bool>>((ref) {
-      final original = ref.watch(navigationProvider).storeExplicitlyChosen;
-      final proxy = ValueNotifier<bool>(original.value);
-      void originalListener() {
-        if (proxy.value != original.value) proxy.value = original.value;
-      }
-
-      void proxyListener() {
-        if (original.value != proxy.value) original.value = proxy.value;
-      }
-
-      original.addListener(originalListener);
-      proxy.addListener(proxyListener);
-      ref.onDispose(() {
-        original.removeListener(originalListener);
-      });
-      return proxy;
-    });
+final storeExplicitlyChosenProvider = mirrorNotifier<bool>(
+  (ref) => ref.watch(navigationProvider).storeExplicitlyChosen,
+);
 
 // ── Secure Storage ─────────────────────────────────────────────────────────
 final secureStorageProvider = Provider<SecureStorageService>(
@@ -139,11 +93,13 @@ final authProvider = ChangeNotifierProvider<AuthService>((ref) {
     googleWebClientId: googleWebClientId,
   );
 });
-final deviceUserIdProvider = ChangeNotifierProvider<ValueNotifier<String?>>((
-  ref,
-) {
-  return ref.watch(authProvider).deviceUserIdNotifier;
-});
+// Non-owning bridge to the AuthService-owned notifier (issue #153). AuthService
+// is itself a ChangeNotifier and notifies on every login/logout, so returning
+// `deviceUserIdNotifier` directly had Riverpod dispose it out from under the
+// service — the "used after being disposed" crash on re-login.
+final deviceUserIdProvider = mirrorNotifier<String?>(
+  (ref) => ref.watch(authProvider).deviceUserIdNotifier,
+);
 
 // ── Theme (global — initialised before runApp) ─────────────────────────────
 final themeProvider = ChangeNotifierProvider<ThemeController>(
@@ -154,10 +110,8 @@ final themeProvider = ChangeNotifierProvider<ThemeController>(
 final cartProvider = ChangeNotifierProvider<CartService>((ref) {
   return CartService(ref.read(authProvider), ref.read(navigationProvider));
 });
-final activeCustomerProvider = ChangeNotifierProvider<ValueNotifier<Customer?>>(
-  (ref) {
-    return ref.watch(cartProvider).activeCustomer;
-  },
+final activeCustomerProvider = mirrorNotifier<Customer?>(
+  (ref) => ref.watch(cartProvider).activeCustomer,
 );
 
 // ── Notification ────────────────────────────────────────────────────────────
@@ -551,13 +505,10 @@ final productImageServiceProvider = Provider<ProductImageService>((ref) {
 
 /// Lifts the `SupabaseSyncService.pullStatus` ValueNotifier into Riverpod
 /// so the MainLayout catch-up banner (and SyncIssues) can `ref.watch` it.
-/// Mirrors the pattern used for the `isOnline` ValueNotifier (read directly
-/// from the service in `app_drawer.dart`).
-final pullStatusProvider = ChangeNotifierProvider<ValueNotifier<PullStatus>>((
-  ref,
-) {
-  return ref.watch(supabaseSyncServiceProvider).pullStatus;
-});
+/// Non-owning (issue #153) — the service keeps ownership of `pullStatus`.
+final pullStatusProvider = mirrorNotifier<PullStatus>(
+  (ref) => ref.watch(supabaseSyncServiceProvider).pullStatus,
+);
 
 /// True while a user-initiated pull-to-refresh is in flight. The
 /// `AppRefreshWrapper` orb is the sole animation for a manual pull, so

--- a/lib/core/providers/mirror_notifier.dart
+++ b/lib/core/providers/mirror_notifier.dart
@@ -1,0 +1,69 @@
+/// Non-owning bridge from a service-owned `ValueNotifier` into Riverpod
+/// (issue #153).
+///
+/// **The bug this retires.** `ChangeNotifierProvider<T>` *takes ownership of,
+/// and disposes,* whatever `T` its body returns — on the provider being torn
+/// down AND on every rebuild. Returning a notifier owned by a long-lived
+/// service is therefore unsafe: Riverpod disposes a notifier the service still
+/// writes to, and the next `notifier.value = …` throws
+/// `A ValueNotifier<…> was used after being disposed`. It bites readily when the
+/// selected service is itself a `ChangeNotifier` (e.g. `AuthService`), because
+/// every notify rebuilds the provider and re-disposes the same foreign notifier.
+///
+/// ```dart
+/// // UNSAFE — Riverpod disposes a notifier AuthService owns and keeps writing to.
+/// final deviceUserIdProvider = ChangeNotifierProvider<ValueNotifier<String?>>(
+///   (ref) => ref.watch(authProvider).deviceUserIdNotifier,
+/// );
+/// ```
+///
+/// **The fix.** [mirrorNotifier] makes the bug unrepresentable: it constructs a
+/// local *proxy* `ValueNotifier` (the only thing Riverpod owns and disposes) and
+/// two-way-mirrors it to the [select]ed service notifier with listeners that are
+/// removed on dispose. The original is only ever listened to — never disposed —
+/// so it survives every rebuild and teardown. Consumers see identical values in
+/// both directions, so behaviour is unchanged.
+///
+/// The static ban test (`test/providers/mirror_notifier_ban_test.dart`) keeps
+/// every `ChangeNotifierProvider<ValueNotifier<…>>` on this factory so the
+/// anti-pattern cannot re-enter.
+library;
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Selects the service-owned [ValueNotifier] to mirror. Receives the provider
+/// [ref] so the selection can `ref.watch`/`ref.read` the owning service (the
+/// mirror stays correct even when that watch rebuilds the provider).
+typedef NotifierSelector<T> = ValueNotifier<T> Function(Ref ref);
+
+/// Re-exposes the service-owned [ValueNotifier] returned by [select] through a
+/// `ChangeNotifierProvider` **without taking ownership of it**. Riverpod owns and
+/// disposes only the local proxy; the selected notifier is never disposed here.
+///
+/// Use this for any provider that lifts a notifier owned by another object into
+/// Riverpod. A provider that *constructs and owns* its notifier does not need it.
+ChangeNotifierProvider<ValueNotifier<T>> mirrorNotifier<T>(
+  NotifierSelector<T> select,
+) {
+  return ChangeNotifierProvider<ValueNotifier<T>>((ref) {
+    final original = select(ref);
+    final proxy = ValueNotifier<T>(original.value);
+
+    void originalListener() {
+      if (proxy.value != original.value) proxy.value = original.value;
+    }
+
+    void proxyListener() {
+      if (original.value != proxy.value) original.value = proxy.value;
+    }
+
+    original.addListener(originalListener);
+    proxy.addListener(proxyListener);
+    // Only detach from the original — Riverpod disposes the proxy itself, which
+    // clears the proxy's own listeners. The original is left untouched.
+    ref.onDispose(() => original.removeListener(originalListener));
+
+    return proxy;
+  });
+}

--- a/lib/features/sync/controllers/first_load_overlay_controller.dart
+++ b/lib/features/sync/controllers/first_load_overlay_controller.dart
@@ -1,9 +1,9 @@
 import 'dart:async';
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:reebaplus_pos/core/providers/app_providers.dart';
 import 'package:reebaplus_pos/core/providers/business_scoped_stream.dart';
+import 'package:reebaplus_pos/core/providers/mirror_notifier.dart';
 import 'package:reebaplus_pos/core/services/first_load_marker_service.dart';
 import 'package:reebaplus_pos/core/services/supabase_sync_service.dart';
 
@@ -282,12 +282,10 @@ class FirstLoadOverlayController extends StateNotifier<FirstLoadOverlayState> {
 // ─────────────────────────────────────────────────────────────────────────────
 
 /// Lifts the sync service's `isOnline` ValueNotifier into Riverpod (mirrors
-/// [pullStatusProvider]).
-final isOnlineNotifierProvider = ChangeNotifierProvider<ValueNotifier<bool>>((
-  ref,
-) {
-  return ref.watch(supabaseSyncServiceProvider).isOnline;
-});
+/// [pullStatusProvider]). Non-owning (issue #153) — the service keeps ownership.
+final isOnlineNotifierProvider = mirrorNotifier<bool>(
+  (ref) => ref.watch(supabaseSyncServiceProvider).isOnline,
+);
 
 /// Online / offline, as a plain bool the controller consumes.
 final firstLoadOnlineProvider = Provider<bool>((ref) {

--- a/test/providers/mirror_notifier_ban_test.dart
+++ b/test/providers/mirror_notifier_ban_test.dart
@@ -1,0 +1,118 @@
+// Static enforcement seam (issue #153). A source scan that bans handing a
+// FOREIGN, service-owned notifier to a `ChangeNotifierProvider` anywhere in
+// `lib/`. Riverpod disposes whatever notifier a `ChangeNotifierProvider` body
+// returns — on teardown AND every rebuild — so a provider that returns a
+// notifier owned by a long-lived service disposes it out from under its owner,
+// and the next write throws "used after being disposed". Such providers must go
+// through the non-owning factory `mirrorNotifier`
+// (`lib/core/providers/mirror_notifier.dart`). Prior art:
+// test/providers/business_scoped_stream_ban_test.dart and
+// test/permissions/gate_static_ban_test.dart.
+//
+// The ban targets the *behaviour* (a body that RETURNS `ref.watch(…)` /
+// `ref.read(…)` — a borrowed notifier), not a type, so it catches a foreign
+// notifier of ANY `ChangeNotifier` subtype, not only `ValueNotifier`. A provider
+// that CONSTRUCTS and owns its notifier (`=> SomeService(…)`, `=> ValueNotifier(0)`)
+// is a correct use of `ChangeNotifierProvider` and is left alone.
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// The factory itself contains `ChangeNotifierProvider<ValueNotifier<T>>` — the
+/// one place the raw primitive is correct. Never scanned.
+const _factoryFile = 'lib/core/providers/mirror_notifier.dart';
+
+/// Matches a top-level `final xProvider = ChangeNotifierProvider<…>(…)` whose
+/// body immediately RETURNS a borrowed notifier — `(ref) => ref.watch(…` /
+/// `ref.read(…`, or `(ref) { return ref.watch(…`. A body that returns a
+/// constructor (`=> SomeService(…)`, `=> ValueNotifier(0)`) does not match, and
+/// neither does the sanctioned `= mirrorNotifier<…>(…)`. Dart's `\s` and the
+/// negated class span newlines, so a split-across-lines declaration and the
+/// `.autoDispose` variant are still caught.
+final _foreignNotifierReturn = RegExp(
+  r'final\s+(\w+)\s*=\s*ChangeNotifierProvider(?:\.autoDispose)?\s*<[^(]*>\s*\(\s*\(\s*ref\s*\)\s*(?:=>\s*|\{\s*return\s+)ref\.(?:watch|read)\s*\(',
+);
+
+void main() {
+  test(
+      'no ChangeNotifierProvider returns a foreign, service-owned notifier '
+      '(they must go through mirrorNotifier)', () {
+    final offenders = <String>[]; // "name  (path)"
+    for (final entity in Directory('lib').listSync(recursive: true)) {
+      if (entity is! File) continue;
+      final path = entity.path;
+      if (!path.endsWith('.dart') || path.endsWith('.g.dart')) continue;
+      if (path == _factoryFile) continue;
+      for (final m
+          in _foreignNotifierReturn.allMatches(entity.readAsStringSync())) {
+        offenders.add('${m.group(1)}  ($path)');
+      }
+    }
+
+    expect(
+      offenders,
+      isEmpty,
+      reason:
+          'A ChangeNotifierProvider returns a borrowed notifier (ref.watch/read). '
+          'Riverpod disposes whatever the body returns — on teardown AND every '
+          'rebuild — so a service-owned notifier gets disposed out from under its '
+          'owner (use-after-dispose). Declare it through the factory instead: '
+          'mirrorNotifier<T>((ref) => ref.watch(service).theNotifier) '
+          '(lib/core/providers/mirror_notifier.dart, issue #153).\n'
+          '${offenders.join('\n')}',
+    );
+  });
+
+  test('the scan is strict — a planted foreign return is caught for ANY notifier '
+      'type; owned + migrated forms are not', () {
+    // A foreign-owned ValueNotifier return is caught…
+    const plantedValueNotifier =
+        'final xProvider = ChangeNotifierProvider<ValueNotifier<int>>('
+        '(ref) => ref.watch(svcProvider).someNotifier);';
+    expect(_foreignNotifierReturn.hasMatch(plantedValueNotifier), isTrue,
+        reason: 'a re-introduced foreign ValueNotifier return must be caught');
+
+    // …a foreign-owned NON-ValueNotifier ChangeNotifier return is ALSO caught —
+    // the same use-after-dispose class the AC names, which a `<ValueNotifier`
+    // type-only ban would have missed…
+    const plantedOtherNotifier =
+        'final xProvider = ChangeNotifierProvider<FooController>('
+        '(ref) => ref.watch(svcProvider).fooController);';
+    expect(_foreignNotifierReturn.hasMatch(plantedOtherNotifier), isTrue,
+        reason: 'a foreign notifier of any ChangeNotifier subtype must be caught');
+
+    // …a block body, `ref.read`, and a split-across-lines / autoDispose form…
+    const plantedBlockMultiline =
+        'final xProvider =\n    ChangeNotifierProvider<FooController>((ref) {\n'
+        '  return ref.read(svcProvider).fooController;\n});';
+    expect(_foreignNotifierReturn.hasMatch(plantedBlockMultiline), isTrue,
+        reason: 'a block/ref.read/multiline declaration must still be caught');
+    const plantedAutoDispose =
+        'final xProvider = ChangeNotifierProvider.autoDispose<ValueNotifier<int>>('
+        '(ref) => ref.watch(s).n);';
+    expect(_foreignNotifierReturn.hasMatch(plantedAutoDispose), isTrue,
+        reason: 'the autoDispose variant must still be caught');
+
+    // …a provider that CONSTRUCTS and OWNS its notifier is NOT flagged (a
+    // correct use of ChangeNotifierProvider — the bug is only borrowed notifiers)…
+    const ownedService =
+        'final xProvider = ChangeNotifierProvider<CartService>('
+        '(ref) => CartService(ref.read(a), ref.read(b)));';
+    expect(_foreignNotifierReturn.hasMatch(ownedService), isFalse,
+        reason: 'a provider that constructs+owns its notifier must not be flagged');
+    const ownedValueNotifier =
+        'final xProvider = ChangeNotifierProvider<ValueNotifier<int>>('
+        '(ref) => ValueNotifier(0));';
+    expect(_foreignNotifierReturn.hasMatch(ownedValueNotifier), isFalse,
+        reason: 'a self-constructed ValueNotifier must not be forced onto '
+            'mirrorNotifier (that would leak it — the helper never disposes the '
+            'original)');
+
+    // …and the sanctioned factory form never trips the ban.
+    const migrated =
+        'final xProvider = mirrorNotifier<int>((ref) => ref.watch(svc).n);';
+    expect(_foreignNotifierReturn.hasMatch(migrated), isFalse,
+        reason: 'a factory-built provider must not trip the ban');
+  });
+}

--- a/test/providers/mirror_notifier_test.dart
+++ b/test/providers/mirror_notifier_test.dart
@@ -1,0 +1,86 @@
+// Behaviour spec for the `mirrorNotifier` non-owning proxy (issue #153).
+//
+// `ChangeNotifierProvider<T>` disposes whatever `T` its body returns — on
+// teardown AND on every rebuild. When `T` is a notifier a long-lived service
+// owns (e.g. `AuthService.deviceUserIdNotifier`), Riverpod disposes a notifier
+// the service still writes to, and the next write throws
+// "used after being disposed". `mirrorNotifier` re-exposes a service-owned
+// `ValueNotifier` through Riverpod WITHOUT taking ownership: Riverpod disposes a
+// local proxy, the service's notifier is only ever listened to.
+//
+// These tests observe that contract through the public boundary (a
+// `ProviderContainer`), never internals.
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reebaplus_pos/core/providers/mirror_notifier.dart';
+
+void main() {
+  group('mirrorNotifier', () {
+    test('seeds the proxy with the original notifier\'s current value', () {
+      final original = ValueNotifier<int>(7);
+      addTearDown(original.dispose);
+      final provider = mirrorNotifier<int>((ref) => original);
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      expect(container.read(provider).value, 7);
+    });
+
+    test('mirrors changes in both directions', () {
+      final original = ValueNotifier<int>(0);
+      addTearDown(original.dispose);
+      final provider = mirrorNotifier<int>((ref) => original);
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      final proxy = container.read(provider);
+
+      original.value = 5;
+      expect(proxy.value, 5, reason: 'original → proxy');
+
+      proxy.value = 9;
+      expect(original.value, 9, reason: 'proxy → original');
+    });
+
+    test('disposing the provider does NOT dispose the service-owned original',
+        () {
+      final original = ValueNotifier<String?>('a');
+      addTearDown(original.dispose);
+      final provider = mirrorNotifier<String?>((ref) => original);
+      final container = ProviderContainer();
+      container.read(provider); // materialise the proxy
+      container.dispose(); // Riverpod disposes the proxy it owns
+
+      // The bug: the original would now throw "used after being disposed".
+      expect(() => original.value = 'b', returnsNormally);
+    });
+
+    test('rebuilding the provider disposes only the proxy, never the original',
+        () {
+      // Models AuthService notifying (every login/logout) while
+      // deviceUserIdProvider is alive: the selector watches a dependency that
+      // changes, so ChangeNotifierProvider recomputes and disposes its proxy.
+      final original = ValueNotifier<String?>('a');
+      addTearDown(original.dispose);
+      final tick = StateProvider<int>((ref) => 0);
+      final provider = mirrorNotifier<String?>((ref) {
+        ref.watch(tick); // recompute when the "auth" signal ticks
+        return original;
+      });
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      // Keep the provider alive so the tick forces an eager recompute (and the
+      // old proxy is disposed) rather than a lazy one.
+      final sub = container.listen(provider, (_, __) {});
+      addTearDown(sub.close);
+
+      container.read(tick.notifier).state++; // recompute → old proxy disposed
+
+      // The original survived the rebuild — this is the re-login crash repro.
+      expect(() => original.value = 'b', returnsNormally);
+      expect(container.read(provider).value, 'b',
+          reason: 'the fresh proxy mirrors the still-alive original');
+    });
+  });
+}


### PR DESCRIPTION
## Summary

`ChangeNotifierProvider<T>` disposes whatever notifier its body returns — on teardown **and on every rebuild**. Four providers returned a notifier owned by a long-lived service, so Riverpod disposed a notifier the service still writes to → `A ValueNotifier<…> was used after being disposed`, fired on **re-login after an admin-removed device wipe** (see #153 repro). `deviceUserIdProvider` bit readily because `AuthService` is itself a `ChangeNotifier` (notifies on every login/logout → rebuilds the provider → re-disposes the same foreign notifier).

## Fix

New non-owning `mirrorNotifier<T>` factory (`lib/core/providers/mirror_notifier.dart`): Riverpod owns a local **proxy**, the service notifier is only ever listened to (two-way mirrored, listener removed on dispose, original never disposed).

- **4 unsafe sites converted:** `deviceUserIdProvider` (the observed crash), `activeCustomerProvider`, `pullStatusProvider`, `isOnlineNotifierProvider`.
- **3 pre-existing safe proxy sites folded onto the same helper:** `currentIndexProvider`, `lockedStoreProvider`, `storeExplicitlyChosenProvider` — removing ~80 lines of duplicated proxy boilerplate so the safe pattern is the only pattern.
- Behaviour unchanged for consumers (value-identical two-way mirror; consumers only read/listen).

## Guard

`test/providers/mirror_notifier_ban_test.dart` fails if any `ChangeNotifierProvider` returns a **borrowed** `ref.watch`/`ref.read` notifier — of **any** `ChangeNotifier` subtype, not just `ValueNotifier` — while leaving a provider that constructs+owns its notifier alone. `test/providers/mirror_notifier_test.dart` proves the original survives provider **dispose** and **rebuild** (the crash repro).

## Verification

- `flutter analyze` clean.
- 6 new tests green.
- Full suite otherwise unchanged — the one failure (`who_is_working_screen_test.dart`) is **pre-existing and unrelated**, confirmed failing identically on base `main`.

## Acceptance criteria

- [x] The 4 named providers no longer hand a service-owned notifier to `ChangeNotifierProvider`.
- [x] Re-login after an admin-removed device wipe no longer throws "used after being disposed" (the rebuild test models the repro).
- [x] Behaviour of all four (and the three reference providers) unchanged for consumers.
- [x] A guard test fails if a new `ChangeNotifierProvider` returns a foreign-owned notifier.
- [x] `flutter analyze` clean.

Closes #153


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a crash that could occur after re-login or provider rebuilds.
  * Improved notifier lifecycle handling so service-owned state remains available when providers are disposed or recreated.

* **Tests**
  * Added safeguards and coverage to prevent incorrect notifier ownership patterns.
  * Verified state synchronization and safe provider disposal behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->