### PR TITLE
feat(crates): Crate Pool seam + complete ledger (prefactor, #157)

### DIFF
--- a/BUILD_LOG.md
+++ b/BUILD_LOG.md
@@ -2,6 +2,52 @@
 
 ---
 
+## 2026-07-22 — Feature: #157 Crate Pool seam + complete ledger (prefactor)
+
+First slice of the crate-pool ledger-as-truth refactor (PRD #156, ADR **0020**).
+Branch `feat/crate-pool-seam-prefactor` off `main`. **Behavior-preserving** — the
+balance caches are still written exactly as before; this slice only centralizes
+the writes, completes the ledger, and seeds opening balances so the later derive
+slices (#158–#160) don't zero existing counts.
+
+- **Seam.** `CrateLedgerDao` → **`CratePoolDao`** (`daos_crates.dart`) is now the
+  SOLE writer of the six crate tables (`crate_ledger`, `supplier_crate_ledger`,
+  the four `*_crate_balances`) **and** the `manufacturers.empty_crate_stock`
+  scalar. Absorbed the supplier-crate write path, the physical-pool verbs
+  (`addEmptiesToPool` / `recordDamage` / `recordManualCountCorrection`, moved from
+  `InventoryDao`) and the store-transfer legs (`transferBetweenStores`, moved from
+  `StockTransferDao`). Former writers (Inventory, `SupplierCrateLedgerDao`,
+  `StockTransferDao`, `CrateReturnApprovalService.approve`, checkout / confirm /
+  receive / customer-return callers) are now thin delegators — public method names
+  kept, so callers + the existing crate test suite are unchanged. Accessor
+  `crateLedgerDao` → `cratePoolDao` (~21 mechanical sites; codegen regenerated).
+- **Ledger completeness.** A manual "set to N" records a reconciling **delta** row
+  (N − current); a store-less `addEmptyCrates`/damage now writes a row too.
+- **Migration (Drift v62→v63).** Data-only `_seedCrateOpeningLedger()` appends one
+  reconciling `adjusted` opening row per non-zero cache balance (delta = cache −
+  current SUM under that cache's filter) so `SUM(quantity_delta)` == the displayed
+  count at cutover. **LOCAL-ONLY** (a migration write never enqueues; every device
+  seeds from its own caches — pushing would double-count). No cloud migration.
+- **Guard.** `test/crates/crate_seam_ban_test.dart` fails the build if any
+  crate-table write or `empty_crate_stock` mutation (raw-SQL **or** the
+  `ManufacturersCompanion` builder form) appears outside the seam; the sync engine
+  + `app_database.dart` carry `// crate-seam-exempt-file:` markers.
+- **Docs.** ADR `0020-crate-pool-ledger-as-truth`; CONTEXT.md `### Crates` glossary
+  (Empties Pool, Crate Ledger, Crate Deposit, Held Deposit, Money-Track vs
+  Crate-Track). Lexicon intentionally untouched (crate nouns stay out by design).
+- **Verify.** `flutter analyze` 0/0; new `crate_pool_seam_test` (5, incl. the real
+  v62→v63 seed SUM==cache) + `crate_seam_ban_test` green; full suite 979 pass / 110
+  skip (the 1 failure — `who_is_working_screen_test` — is pre-existing, confirmed at
+  base with changes stashed). Two-axis `/review`: no hard standards violations;
+  spec-faithful (all 8 verbs routed, seed filters correct) — the one finding (ban
+  test missed the builder-form scalar mutation) is fixed here. Commit `f1e4f02`.
+- **Noted, not fixed (out of scope):** `StockTransferDao.cancelTransfer` restores
+  product stock but not crate legs (pre-existing); `recordCrateReceiveFromManufacturer`
+  is dead; `manufacturer_crate_balances` and the scalar remain two disjoint
+  business-side tallies — unifying + deriving the pool is #159.
+
+---
+
 ## 2026-07-21 — QA: #116 receipt paper size manual 58/80mm (default 58mm) PASSED
 
 **Context.** #116 = a device-local paper-size setting (58mm default, 80mm option) near the printer picker, and

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -158,6 +158,66 @@ _Avoid_: server-arrival order as the FIFO key; prompting the user per corrected
 sale; treating an assignment as permanent (it is stable only until an earlier
 sale arrives).
 
+### Crates
+
+Beverage-only vocabulary — every term is gated by `isCrateBusiness` and never
+leaks to another trade (so these nouns stay out of the `Lexicon`, by design).
+See ADR 0020 and PRD #156.
+
+**Empties Pool**:
+The empty returnable crates a business physically holds, per manufacturer. The
+"empties on hand" figure. Its truth is `SUM(quantity_delta)` over the business-
+side [Crate Ledger] rows (per manufacturer, and per store when store-stamped) —
+the same number at every store-rollup level, so the All-Stores total always
+equals the sum of the store totals. Historically also mirrored in the
+`manufacturers.empty_crate_stock` scalar and the `*_crate_balances` caches; those
+are being demoted to derived/local projections (ADR 0020).
+_Avoid_: reading a stored total as authoritative; letting the business total and
+the per-store totals disagree; treating a customer's or supplier's owed crates as
+part of the pool (those are debts, not on-hand stock).
+
+**Crate Ledger**:
+The append-only record of every crate movement — `crate_ledger` (customer- and
+business-side) and `supplier_crate_ledger`. One signed, store-stamped row per
+movement (`issued` / `returned` / `damaged` / `adjusted` / `transferred_in` /
+`transferred_out`; supplier side: `received` / `returned` / `adjusted`). It is
+the single source of truth; every crate balance is derived from it, exactly as
+the wallet balance is derived from `wallet_transactions`. Corrections are new
+compensating rows, never edits. Every movement routes through the one Crate Pool
+seam (`CratePoolDao`).
+_Avoid_: updating or deleting a ledger row; writing a crate table outside the
+seam; shipping a balance as an absolute value (only ledger rows sync).
+
+**Crate Deposit**:
+The refundable money a returnable crate is worth — its per-crate **rate** is
+`manufacturers.deposit_amount_kobo`, snapshotted onto `order_crate_lines.
+deposit_rate_kobo` at sale time so a later rate edit never changes a historic
+settlement. A crate sale is either **Money-Track** or **Crate-Track** (below).
+_Avoid_: recomputing a historic deposit at today's rate; conflating the deposit
+*money* flow (largely unmodelled app-wide — a separate PRD) with the crate
+*count*, which #156 makes trustworthy.
+
+**Held Deposit**:
+Deposit money the shop is currently holding for a customer against crates they
+took but haven't returned — the `crate_deposit`-family legs on the customer
+wallet ledger (net = paid-in − refunded − forfeited). It is a liability: money
+owed back. Net-position honesty (#163) subtracts it from business worth.
+_Avoid_: counting held deposits as income; leaving them inflated after a return
+or a cancel (the deposit legs must be reversed with a deposit-family reference
+type, not a generic `void`).
+
+**Money-Track vs Crate-Track**:
+The two ways a crate sale is settled. **Money-Track** = the customer paid a
+deposit for the crates (`deposit_paid_kobo > 0`); the crates are settled in
+*money* — the deposit is held on the wallet and later refunded / forfeited /
+shortfall-charged, and **no** crate balance is issued. **Crate-Track** = no
+deposit paid (`deposit_paid_kobo == 0`); the crates are tracked as a *count* — an
+`issued` ledger row raises the customer's crate debt, a later `returned` row nets
+it back toward zero. A walk-in (no registered customer) holds neither.
+_Avoid_: issuing a crate balance for a money-track sale (that double-counts the
+deposit as both money held and crates owed); netting a money-track return against
+the crate ledger.
+
 ### Industry
 
 **Industry**:

--- a/CONTEXT/progress-tracker.md
+++ b/CONTEXT/progress-tracker.md
@@ -10,6 +10,55 @@ The human updates it when resolving open questions or making architectural decis
 
 152 sessions logged. Codebase is live and being verified on-device.
 
+### Crate pool #1 (#157) — the Crate Pool seam + a complete ledger (prefactor) — CODE-COMPLETE (2026-07-22)
+First slice of the crate-pool ledger-as-truth refactor (PRD #156, ADR **0020**).
+Branch `feat/crate-pool-seam-prefactor` off `main`. **Behavior-preserving**: the
+balance caches are still written exactly as before, so nothing the user sees
+changes — this slice only introduces the seam, completes the ledger, and seeds
+opening balances so the later derive slices (#158–#160) don't zero existing
+counts.
+- **The seam.** `CrateLedgerDao` → **`CratePoolDao`** (`daos_crates.dart`), now the
+  SOLE writer of the six crate tables (`crate_ledger`, `supplier_crate_ledger`,
+  the four `*_crate_balances`) **and** the `manufacturers.empty_crate_stock`
+  scalar. Absorbed the supplier-crate write path (`_appendSupplierMovement`), the
+  physical-pool verbs (`addEmptiesToPool` / `recordDamage` /
+  `recordManualCountCorrection`, moved from `InventoryDao`), and the store-transfer
+  legs (`transferBetweenStores`, moved from `StockTransferDao`). Every former
+  writer is now a thin delegator (InventoryDao add/damage/manual-set + transfer,
+  `SupplierCrateLedgerDao` receipt/return, `CrateReturnApprovalService.approve`,
+  Checkout/Confirm/Receive/customer-return callers) — public method names kept, so
+  callers and the existing crate test-suite assertions are unchanged. Accessor
+  renamed `crateLedgerDao` → `cratePoolDao` (~21 mechanical sites; codegen
+  regenerated).
+- **Ledger completeness.** The two paths that skipped the ledger now write a row:
+  a manual "set to N" records a reconciling **delta** row (N − current); a
+  store-less `addEmptyCrates`/damage writes a store-less row.
+- **Migration (Drift v62→**v63**).** Data-only `_seedCrateOpeningLedger()` appends
+  one reconciling `adjusted` opening row per non-zero cache balance (delta = cache
+  − current SUM under that cache's filter), so `SUM(quantity_delta)` == the
+  displayed count at cutover. **LOCAL-ONLY** (a migration write never enqueues;
+  pushing would double-count across devices). No cloud migration — client-only
+  data seed.
+- **Guard.** New `test/crates/crate_seam_ban_test.dart` (models
+  `sync_raw_write_leak_test`) fails the build if any crate-table write or
+  `empty_crate_stock` mutation appears outside the seam; the sync engine +
+  `app_database.dart` carry `// crate-seam-exempt-file:` markers (restore /
+  DDL-triggers-seed-wipe, not movements).
+- **Docs.** ADR `0020-crate-pool-ledger-as-truth.md`; CONTEXT.md gained a
+  `### Crates` glossary (Empties Pool, Crate Ledger, Crate Deposit, Held Deposit,
+  Money-Track vs Crate-Track). **Lexicon intentionally untouched** — its docstring
+  keeps crate/empties nouns out by design (gated by `isCrateBusiness`), so the PRD's
+  "keep beverage nouns in the Lexicon" reconciles to "leave them out, as they
+  already are."
+- **Verification.** `flutter analyze` 0/0; new `crate_pool_seam_test` (5, incl. the
+  real v62→v63 migration-seed SUM==cache) + `crate_seam_ban_test` green; the
+  existing crate/wallet/supplier/sync-dispatch suites (77) pass unchanged.
+- **Noted, not fixed here (out of #157 scope):** `StockTransferDao.cancelTransfer`
+  restores product stock but does NOT reverse crate legs (pre-existing gap);
+  `recordCrateReceiveFromManufacturer` is dead (no callers); the
+  `manufacturer_crate_balances` cache and the `empty_crate_stock` scalar remain two
+  disjoint business-side tallies — unifying them and deriving the pool is #159.
+
 ### #153 provider-lifecycle crash (re-login) — FIXED (2026-07-20)
 QA of the closed batch (during #117 offboarding) surfaced a re-login crash: four
 `ChangeNotifierProvider`s returned a **service-owned** `ValueNotifier`, so Riverpod

--- a/docs/adr/0020-crate-pool-ledger-as-truth.md
+++ b/docs/adr/0020-crate-pool-ledger-as-truth.md
@@ -1,0 +1,85 @@
+# The crate pool is ledger-as-truth behind one write seam
+
+**Status:** accepted (2026-07-22)
+
+The empty-crate pool is recorded in **three representations that no single write
+path keeps in step**: the append-only `crate_ledger` / `supplier_crate_ledger`,
+the four balance caches (`customer_crate_balances`, `manufacturer_crate_balances`,
+`store_crate_balances`, `supplier_crate_balances`), and the
+`manufacturers.empty_crate_stock` scalar. Worse, the running balances sync
+between devices as **absolute "the count is now N" rows** (`isCache` LWW), so a
+late-arriving row silently overwrites another device's work. Two offline tills
+that both move the same brand's crates permanently lose one till's activity when
+they reconnect. The counts drift, never self-correct, and disagree across the
+Crates tab, a locked store's view, and the customer/supplier records. The
+append-only ledger that *could* be the single truth exists but is treated as
+secondary. (Full analysis: `CRATE_TRACKING_AUDIT.md`; PRD #156.)
+
+The customer wallet already solved exactly this problem in this codebase:
+`getWalletBalanceKobo` **derives** a balance by summing signed, append-only
+ledger rows and cancels voided rows with compensating entries — never storing or
+shipping a mutable total, so it is conflict-free under sync (architecture
+invariant #3).
+
+## Decision
+
+**The crate ledger is the one source of truth; every balance is derived, never
+stored or shipped as an absolute total.** Every crate balance the app shows —
+business empties on hand (per manufacturer), per-store empties, a customer's
+crate debt, a supplier's crate debt — is `SUM(quantity_delta)` over the relevant
+append-only ledger rows. The balance caches and the `empty_crate_stock` scalar
+stop being independently authoritative: they are replaced by live sum queries or
+demoted to local-only projections rebuilt from the ledger after each pull. The
+hard contract is: **no crate balance is ever pushed to the cloud as an
+absolute-value row — only append-only ledger rows sync.** This is the change
+that removes the last-write-wins data loss by construction (two devices' ledgers
+merge; there is no absolute-value row left to overwrite).
+
+**One write seam — the Crate Pool module (`CratePoolDao`, in
+`lib/core/database/daos_crates.dart`; it absorbs the former `CrateLedgerDao`).**
+Every write that moves a crate routes through it as a domain verb
+(issue-to-customer, return-from-customer, receive/return-supplier, record-damage,
+transfer-between-stores, reverse-order-issuance, record-manual-count-correction,
+add-empties-to-pool). Each appends a correctly-signed, store-stamped, append-only
+ledger row in one transaction and enqueues it to the Outbox. A `crate_seam_ban_test`
+fails the build if any crate-table write (or an `empty_crate_stock` mutation)
+appears outside the seam, so a new surface (a report, a van, a screen) has exactly
+one place to call and cannot reintroduce the drift.
+
+## Rejected alternatives
+
+- **Server-authoritative deltas** — keep the cache tables and route crate
+  movements through a guarded relative-decrement RPC (mirroring
+  `pos_record_sale_v2`). This still ships totals and keeps three representations;
+  it narrows the race window but leaves the drift surface. Rejected: it treats the
+  symptom (the LWW push) without making the ledger the truth.
+- **Minimal fix** — keep the three representations and schedule the existing
+  `verifyCrateReconciliation` nightly. Rejected: reconciliation papers over a
+  model with three sources of truth; it will drift again between runs, and the
+  reconciler has no authority to decide which representation is right.
+
+## Rollout (this is a multi-slice refactor)
+
+- **#157 (this slice) — prefactor, behavior-preserving.** Introduce the seam and
+  make the ledger *complete* (every movement, including a manual "set to N" as a
+  reconciling delta row and a store-less `addEmptyCrates`, appends a row). The
+  caches are still written exactly as before, so nothing the user sees changes. A
+  migration seeds one opening-balance ledger delta per existing cache balance so
+  `SUM(quantity_delta)` equals today's displayed number at cutover — without it
+  the later derive slices would zero out every existing business's counts. Opening
+  rows are **local-only** (every device seeds from its own caches; pushing them
+  would double-count).
+- **#158 / #159 / #160** — derive customer, physical-pool (business + per-store),
+  and supplier balances from the ledger; demote the caches; unify the scalar.
+- **#162** — Cancel appends compensating rows (no phantom debt; deposit reversed
+  with a deposit-family reference type).
+- **#163** — `businessNetPositionKobo` subtracts held customer crate deposits and
+  supplier crate debt (honest in both directions), which is only trustworthy once
+  balances are ledger-derived.
+
+## Invariants that still bind
+
+Kobo columns stay `bigint`; every crate write stays business-scoped; ledger rows
+are append-only and go through the Outbox; a new/changed synced table is one
+`SyncedTable` entry; migration numbers are reserved late (ADR 0018 push /
+0019 van were reserved on unmerged branches, so this is **0020**).

--- a/lib/core/database/app_database.dart
+++ b/lib/core/database/app_database.dart
@@ -1,3 +1,7 @@
+// crate-seam-exempt-file: schema/DDL, append-only triggers, the v63 opening-
+// balance seed migration, and clearAllData — table lifecycle, not user-initiated
+// crate movements (ADR 0020 / crate_seam_ban_test). Movement writes live in the
+// CratePoolDao seam (daos_crates.dart).
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
@@ -1806,7 +1810,7 @@ class MigrationEvents extends Table {
     ManufacturerCrateBalancesDao,
     StoreCrateBalancesDao,
     OrderCrateLinesDao,
-    CrateLedgerDao,
+    CratePoolDao,
     SettingsDao,
     BusinessesDao,
     SystemConfigDao,
@@ -1853,7 +1857,7 @@ class AppDatabase extends _$AppDatabase {
   String? get currentAuthUserId => authUserIdResolver();
 
   @override
-  int get schemaVersion => 62;
+  int get schemaVersion => 63;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -4052,6 +4056,16 @@ class AppDatabase extends _$AppDatabase {
         // supabase/migrations/0151_products_unit_nullable.sql.
         await m.alterTable(TableMigration(products));
       }
+      if (from < 63) {
+        // v63 (#157 crate-pool prefactor): seed one reconciling opening-balance
+        // ledger row per non-zero crate cache so SUM(quantity_delta) == the
+        // existing displayed count at cutover. No schema change — data only.
+        // Without this, the later derive slices (#158–#160) would zero out every
+        // existing business's crate counts. LOCAL-ONLY (never enqueued): every
+        // device seeds from its own caches, so pushing these would double-count
+        // across devices (ADR 0020).
+        await _seedCrateOpeningLedger();
+      }
     },
     beforeOpen: (details) async {
       await customStatement('PRAGMA foreign_keys = ON');
@@ -4097,6 +4111,135 @@ class AppDatabase extends _$AppDatabase {
         await customStatement(stmt);
       }
     });
+  }
+
+  /// #157 opening-balance seed (v62→v63). Appends one reconciling `adjusted`
+  /// ledger row per non-zero crate cache so `SUM(quantity_delta)` equals the
+  /// existing cache value at cutover, per cache's own filter:
+  ///   • customer_crate_balances   ← crate_ledger by (customer, manufacturer)
+  ///   • store_crate_balances       ← crate_ledger by (store, manufacturer), customer-less
+  ///   • manufacturer_crate_balances← crate_ledger by manufacturer, store-less + customer-less
+  ///   • supplier_crate_balances    ← supplier_crate_ledger by (supplier, manufacturer)
+  /// The delta form (cache − current SUM) makes SUM==cache hold regardless of any
+  /// messy historical ledger rows, and skips zero-deltas. LOCAL-ONLY: a migration
+  /// write never enqueues, so these opening rows never sync (pushing them would
+  /// double-count across devices — see ADR 0020). Runs once, at v62→v63.
+  Future<void> _seedCrateOpeningLedger() async {
+    final nowSec = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+
+    // 1. Customer crate debt.
+    final customerRows = await customSelect(
+      'SELECT b.business_id AS business_id, b.customer_id AS customer_id, '
+      '       b.manufacturer_id AS manufacturer_id, '
+      '       b.balance - COALESCE((SELECT SUM(l.quantity_delta) FROM crate_ledger l '
+      '         WHERE l.business_id = b.business_id AND l.customer_id = b.customer_id '
+      '           AND l.manufacturer_id = b.manufacturer_id), 0) AS delta '
+      'FROM customer_crate_balances b',
+    ).get();
+    for (final r in customerRows) {
+      final delta = r.read<int>('delta');
+      if (delta == 0) continue;
+      await customStatement(
+        'INSERT INTO crate_ledger (id, business_id, customer_id, manufacturer_id, '
+        '  quantity_delta, movement_type, created_at, last_updated_at) '
+        'VALUES (?,?,?,?,?,?,?,?)',
+        [
+          UuidV7.generate(),
+          r.read<String>('business_id'),
+          r.read<String>('customer_id'),
+          r.read<String>('manufacturer_id'),
+          delta,
+          'adjusted',
+          nowSec,
+          nowSec,
+        ],
+      );
+    }
+
+    // 2. Per-store business pool (store-stamped, customer-less).
+    final storeRows = await customSelect(
+      'SELECT b.business_id AS business_id, b.store_id AS store_id, '
+      '       b.manufacturer_id AS manufacturer_id, '
+      '       b.balance - COALESCE((SELECT SUM(l.quantity_delta) FROM crate_ledger l '
+      '         WHERE l.business_id = b.business_id AND l.store_id = b.store_id '
+      '           AND l.manufacturer_id = b.manufacturer_id AND l.customer_id IS NULL), 0) AS delta '
+      'FROM store_crate_balances b',
+    ).get();
+    for (final r in storeRows) {
+      final delta = r.read<int>('delta');
+      if (delta == 0) continue;
+      await customStatement(
+        'INSERT INTO crate_ledger (id, business_id, manufacturer_id, store_id, '
+        '  quantity_delta, movement_type, created_at, last_updated_at) '
+        'VALUES (?,?,?,?,?,?,?,?)',
+        [
+          UuidV7.generate(),
+          r.read<String>('business_id'),
+          r.read<String>('manufacturer_id'),
+          r.read<String>('store_id'),
+          delta,
+          'adjusted',
+          nowSec,
+          nowSec,
+        ],
+      );
+    }
+
+    // 3. Business pool per manufacturer (store-less, customer-less).
+    final mfrRows = await customSelect(
+      'SELECT b.business_id AS business_id, b.manufacturer_id AS manufacturer_id, '
+      '       b.balance - COALESCE((SELECT SUM(l.quantity_delta) FROM crate_ledger l '
+      '         WHERE l.business_id = b.business_id AND l.manufacturer_id = b.manufacturer_id '
+      '           AND l.customer_id IS NULL AND l.store_id IS NULL), 0) AS delta '
+      'FROM manufacturer_crate_balances b',
+    ).get();
+    for (final r in mfrRows) {
+      final delta = r.read<int>('delta');
+      if (delta == 0) continue;
+      await customStatement(
+        'INSERT INTO crate_ledger (id, business_id, manufacturer_id, '
+        '  quantity_delta, movement_type, created_at, last_updated_at) '
+        'VALUES (?,?,?,?,?,?,?)',
+        [
+          UuidV7.generate(),
+          r.read<String>('business_id'),
+          r.read<String>('manufacturer_id'),
+          delta,
+          'adjusted',
+          nowSec,
+          nowSec,
+        ],
+      );
+    }
+
+    // 4. Supplier crate debt.
+    final supplierRows = await customSelect(
+      'SELECT b.business_id AS business_id, b.supplier_id AS supplier_id, '
+      '       b.manufacturer_id AS manufacturer_id, '
+      '       b.balance - COALESCE((SELECT SUM(l.quantity_delta) FROM supplier_crate_ledger l '
+      '         WHERE l.business_id = b.business_id AND l.supplier_id = b.supplier_id '
+      '           AND l.manufacturer_id = b.manufacturer_id), 0) AS delta '
+      'FROM supplier_crate_balances b',
+    ).get();
+    for (final r in supplierRows) {
+      final delta = r.read<int>('delta');
+      if (delta == 0) continue;
+      await customStatement(
+        'INSERT INTO supplier_crate_ledger (id, business_id, supplier_id, manufacturer_id, '
+        '  quantity_delta, movement_type, created_at, last_updated_at) '
+        'VALUES (?,?,?,?,?,?,?,?)',
+        [
+          UuidV7.generate(),
+          r.read<String>('business_id'),
+          r.read<String>('supplier_id'),
+          r.read<String>('manufacturer_id'),
+          delta,
+          'adjusted',
+          nowSec,
+          nowSec,
+        ],
+      );
+    }
   }
 
   Future<void> clearAllData() async {

--- a/lib/core/database/app_database.g.dart
+++ b/lib/core/database/app_database.g.dart
@@ -39116,9 +39116,7 @@ abstract class _$AppDatabase extends GeneratedDatabase {
   late final OrderCrateLinesDao orderCrateLinesDao = OrderCrateLinesDao(
     this as AppDatabase,
   );
-  late final CrateLedgerDao crateLedgerDao = CrateLedgerDao(
-    this as AppDatabase,
-  );
+  late final CratePoolDao cratePoolDao = CratePoolDao(this as AppDatabase);
   late final SettingsDao settingsDao = SettingsDao(this as AppDatabase);
   late final BusinessesDao businessesDao = BusinessesDao(this as AppDatabase);
   late final SystemConfigDao systemConfigDao = SystemConfigDao(

--- a/lib/core/database/daos.g.dart
+++ b/lib/core/database/daos.g.dart
@@ -958,7 +958,7 @@ class StoreCrateBalancesDaoManager {
       );
 }
 
-mixin _$CrateLedgerDaoMixin on DatabaseAccessor<AppDatabase> {
+mixin _$CratePoolDaoMixin on DatabaseAccessor<AppDatabase> {
   $BusinessesTable get businesses => attachedDatabase.businesses;
   $StoresTable get stores => attachedDatabase.stores;
   $CustomersTable get customers => attachedDatabase.customers;
@@ -973,12 +973,19 @@ mixin _$CrateLedgerDaoMixin on DatabaseAccessor<AppDatabase> {
       attachedDatabase.customerCrateBalances;
   $ManufacturerCrateBalancesTable get manufacturerCrateBalances =>
       attachedDatabase.manufacturerCrateBalances;
-  CrateLedgerDaoManager get managers => CrateLedgerDaoManager(this);
+  $StoreCrateBalancesTable get storeCrateBalances =>
+      attachedDatabase.storeCrateBalances;
+  $SuppliersTable get suppliers => attachedDatabase.suppliers;
+  $SupplierCrateLedgerTable get supplierCrateLedger =>
+      attachedDatabase.supplierCrateLedger;
+  $SupplierCrateBalancesTable get supplierCrateBalances =>
+      attachedDatabase.supplierCrateBalances;
+  CratePoolDaoManager get managers => CratePoolDaoManager(this);
 }
 
-class CrateLedgerDaoManager {
-  final _$CrateLedgerDaoMixin _db;
-  CrateLedgerDaoManager(this._db);
+class CratePoolDaoManager {
+  final _$CratePoolDaoMixin _db;
+  CratePoolDaoManager(this._db);
   $$BusinessesTableTableManager get businesses =>
       $$BusinessesTableTableManager(_db.attachedDatabase, _db.businesses);
   $$StoresTableTableManager get stores =>
@@ -1012,6 +1019,23 @@ class CrateLedgerDaoManager {
       $$ManufacturerCrateBalancesTableTableManager(
         _db.attachedDatabase,
         _db.manufacturerCrateBalances,
+      );
+  $$StoreCrateBalancesTableTableManager get storeCrateBalances =>
+      $$StoreCrateBalancesTableTableManager(
+        _db.attachedDatabase,
+        _db.storeCrateBalances,
+      );
+  $$SuppliersTableTableManager get suppliers =>
+      $$SuppliersTableTableManager(_db.attachedDatabase, _db.suppliers);
+  $$SupplierCrateLedgerTableTableManager get supplierCrateLedger =>
+      $$SupplierCrateLedgerTableTableManager(
+        _db.attachedDatabase,
+        _db.supplierCrateLedger,
+      );
+  $$SupplierCrateBalancesTableTableManager get supplierCrateBalances =>
+      $$SupplierCrateBalancesTableTableManager(
+        _db.attachedDatabase,
+        _db.supplierCrateBalances,
       );
 }
 

--- a/lib/core/database/daos_crates.dart
+++ b/lib/core/database/daos_crates.dart
@@ -204,12 +204,36 @@ class StoreCrateBalancesDao extends DatabaseAccessor<AppDatabase>
   }
 }
 
+/// The **Crate Pool seam** (#156 / ADR 0020) — the single module every empty-
+/// crate movement routes through. It is the *sole* writer of the crate tables
+/// (`crate_ledger`, `supplier_crate_ledger`, and the four `*_crate_balances`
+/// caches) and of the `manufacturers.empty_crate_stock` scalar; every other DAO
+/// or service that used to write those tables now delegates here (a
+/// `crate_seam_ban_test` fails the build if a crate write appears anywhere
+/// else). Each operation is a domain verb (issue-to-customer, return-from-
+/// customer, receive/return-supplier, record-damage, transfer-between-stores,
+/// reverse-order-issuance, record-manual-count-correction, add-empties-to-pool)
+/// that appends a correctly-signed, store-stamped, append-only ledger row in one
+/// transaction and enqueues it to the Outbox.
+///
+/// This slice (#157) is behavior-preserving: the balance caches are still
+/// written exactly as before. Later slices (#158–#163) derive the balances from
+/// `SUM(quantity_delta)` and demote the caches. The working name in the PRD is
+/// `CratePoolDao`; it absorbs the former `CrateLedgerDao`.
 @DriftAccessor(
-  tables: [CrateLedger, CustomerCrateBalances, ManufacturerCrateBalances],
+  tables: [
+    CrateLedger,
+    CustomerCrateBalances,
+    ManufacturerCrateBalances,
+    StoreCrateBalances,
+    SupplierCrateLedger,
+    SupplierCrateBalances,
+    Manufacturers,
+  ],
 )
-class CrateLedgerDao extends DatabaseAccessor<AppDatabase>
-    with _$CrateLedgerDaoMixin, BusinessScopedDao<AppDatabase> {
-  CrateLedgerDao(super.db);
+class CratePoolDao extends DatabaseAccessor<AppDatabase>
+    with _$CratePoolDaoMixin, BusinessScopedDao<AppDatabase> {
+  CratePoolDao(super.db);
 
   Future<void> recordCrateReceiveFromManufacturer({
     required String manufacturerId,
@@ -527,6 +551,68 @@ class CrateLedgerDao extends DatabaseAccessor<AppDatabase>
     await db.syncDao.enqueueUpsert('customer_crate_balances', updatedBalance);
   }
 
+  /// The crate legs of an APPROVED pending crate return (the approval-queue
+  /// flow). Same customer-return movement as [recordCrateReturnByCustomer] but
+  /// stamped with [returnId] (`referenceReturnId`). Runs inside the approval
+  /// service's transaction, which also flips `pending_crate_returns` → approved.
+  /// On the flagged path the caller dispatches the `pos_approve_crate_return`
+  /// envelope (which settles the ledger + pending row server-side), so this only
+  /// enqueues the per-table rows on the flag-off path.
+  Future<void> recordApprovedCustomerReturn({
+    required String customerId,
+    required String manufacturerId,
+    required String returnId,
+    required String ledgerId,
+    required int quantity,
+    required String approvedBy,
+    required bool useDomainRpc,
+  }) async {
+    final delta = -quantity; // returning reduces what the customer owes
+    final ledgerComp = CrateLedgerCompanion.insert(
+      id: Value(ledgerId),
+      businessId: requireBusinessId(),
+      customerId: Value(customerId),
+      manufacturerId: Value(manufacturerId),
+      quantityDelta: delta,
+      movementType: 'returned',
+      referenceReturnId: Value(returnId),
+      performedBy: Value(approvedBy),
+      lastUpdatedAt: Value(DateTime.now()),
+    );
+    await into(crateLedger).insert(ledgerComp);
+
+    await customInsert(
+      'INSERT INTO customer_crate_balances (id, business_id, customer_id, manufacturer_id, balance) '
+      'VALUES (?, ?, ?, ?, ?) '
+      'ON CONFLICT(business_id, customer_id, manufacturer_id) DO UPDATE SET '
+      'balance = balance + excluded.balance, '
+      "last_updated_at = CAST(strftime('%s', CURRENT_TIMESTAMP) AS INTEGER)",
+      variables: [
+        Variable(UuidV7.generate()),
+        Variable(requireBusinessId()),
+        Variable(customerId),
+        Variable(manufacturerId),
+        Variable(delta),
+      ],
+      updates: {customerCrateBalances},
+    );
+
+    if (!useDomainRpc) {
+      await db.syncDao.enqueueUpsert('crate_ledger', ledgerComp);
+      final updatedBalance =
+          await (select(customerCrateBalances)
+                ..where(
+                  (t) =>
+                      whereBusiness(t) &
+                      t.customerId.equals(customerId) &
+                      t.manufacturerId.equals(manufacturerId),
+                )
+                ..limit(1))
+              .getSingle();
+      await db.syncDao.enqueueUpsert('customer_crate_balances', updatedBalance);
+    }
+  }
+
   /// Oversell recovery — LOCAL reversal of the crates a REJECTED sale "issued".
   /// A rejected v2 sale never happened: its `+quantity` 'issued' crate_ledger
   /// rows and the `customer_crate_balances` increment were HELD then discarded
@@ -704,6 +790,405 @@ class CrateLedgerDao extends DatabaseAccessor<AppDatabase>
           'CRATE MISMATCH [Store]: store=$sid, mfr=$mfrId, Ledger: $sum, Cache: $cacheBalance',
         );
       }
+    }
+  }
+
+  // ───────────────────────────────────────────────────────────────────────
+  // Physical business pool (manufacturers.empty_crate_stock scalar + per-store)
+  // Moved here from InventoryDao (#157) so the pool has one writer.
+  // ───────────────────────────────────────────────────────────────────────
+
+  /// Credit the physical empty-crate pool for [manufacturerId] by [quantity]
+  /// (receive-delivery / customer-return physical crates). Bumps the business
+  /// scalar and, when a store is active, the per-store cache. #157: now ALWAYS
+  /// appends a store-stamped `adjusted` crate_ledger row — including the
+  /// store-less case, which previously skipped the ledger entirely.
+  Future<void> addEmptiesToPool(
+    String manufacturerId,
+    int quantity, {
+    String? storeId,
+  }) async {
+    if (quantity == 0) return;
+    await transaction(() async {
+      await customUpdate(
+        'UPDATE manufacturers SET empty_crate_stock = empty_crate_stock + ?, '
+        "last_updated_at = CAST(strftime('%s', CURRENT_TIMESTAMP) AS INTEGER) "
+        'WHERE id = ? AND business_id = ?',
+        variables: [
+          Variable(quantity),
+          Variable(manufacturerId),
+          Variable(requireBusinessId()),
+        ],
+        updates: {manufacturers},
+      );
+      await _enqueueFullManufacturer(manufacturerId);
+      if (storeId != null) {
+        await db.storeCrateBalancesDao.applyDelta(
+          storeId: storeId,
+          manufacturerId: manufacturerId,
+          delta: quantity,
+        );
+      }
+      await _appendPoolLedgerRow(
+        manufacturerId: manufacturerId,
+        storeId: storeId,
+        quantityDelta: quantity,
+        movementType: 'adjusted',
+      );
+    });
+  }
+
+  /// Debit the physical pool because STORED empties were damaged/lost (§17.2).
+  /// The scalar is clamped at zero. #157: appends a `damaged` crate_ledger row
+  /// even when no store is locked.
+  Future<void> recordDamage(
+    String manufacturerId,
+    int quantity, {
+    String? storeId,
+  }) async {
+    if (quantity <= 0) return;
+    await transaction(() async {
+      await customUpdate(
+        'UPDATE manufacturers SET empty_crate_stock = MAX(0, empty_crate_stock - ?), '
+        "last_updated_at = CAST(strftime('%s', CURRENT_TIMESTAMP) AS INTEGER) "
+        'WHERE id = ? AND business_id = ?',
+        variables: [
+          Variable(quantity),
+          Variable(manufacturerId),
+          Variable(requireBusinessId()),
+        ],
+        updates: {manufacturers},
+      );
+      await _enqueueFullManufacturer(manufacturerId);
+      if (storeId != null) {
+        await db.storeCrateBalancesDao.applyDelta(
+          storeId: storeId,
+          manufacturerId: manufacturerId,
+          delta: -quantity,
+        );
+      }
+      await _appendPoolLedgerRow(
+        manufacturerId: manufacturerId,
+        storeId: storeId,
+        quantityDelta: -quantity,
+        movementType: 'damaged',
+      );
+    });
+  }
+
+  /// Manually set a manufacturer's empty-crate count (management dialog). #157:
+  /// a manual "set to N" is recorded as a reconciling **delta** row (N − current)
+  /// so the correction has a traceable history instead of an off-ledger
+  /// overwrite. With a store active, the per-store cache is set absolutely and
+  /// the business total bumped by the same delta; the legacy (no-store) path
+  /// sets the business scalar absolutely.
+  Future<void> recordManualCountCorrection(
+    String manufacturerId,
+    int newStock, {
+    String? storeId,
+  }) async {
+    await transaction(() async {
+      final now = DateTime.now();
+      if (storeId != null) {
+        final currentBalance = await db.storeCrateBalancesDao.getBalance(
+          storeId: storeId,
+          manufacturerId: manufacturerId,
+        );
+        final delta = newStock - currentBalance;
+        await db.storeCrateBalancesDao.setBalance(
+          storeId: storeId,
+          manufacturerId: manufacturerId,
+          newBalance: newStock,
+        );
+        await customUpdate(
+          'UPDATE manufacturers SET empty_crate_stock = empty_crate_stock + ?, '
+          "last_updated_at = CAST(strftime('%s', CURRENT_TIMESTAMP) AS INTEGER) "
+          'WHERE id = ? AND business_id = ?',
+          variables: [
+            Variable(delta),
+            Variable(manufacturerId),
+            Variable(requireBusinessId()),
+          ],
+          updates: {manufacturers},
+        );
+        await _enqueueFullManufacturer(manufacturerId);
+        if (delta != 0) {
+          await _appendPoolLedgerRow(
+            manufacturerId: manufacturerId,
+            storeId: storeId,
+            quantityDelta: delta,
+            movementType: 'adjusted',
+          );
+        }
+      } else {
+        final mfr = await (select(
+          manufacturers,
+        )..where((t) => t.id.equals(manufacturerId) & whereBusiness(t))).getSingle();
+        final delta = newStock - mfr.emptyCrateStock;
+        await (update(manufacturers)
+              ..where((t) => t.id.equals(manufacturerId) & whereBusiness(t)))
+            .write(
+          ManufacturersCompanion(
+            id: Value(manufacturerId),
+            emptyCrateStock: Value(newStock),
+            lastUpdatedAt: Value(now),
+          ),
+        );
+        await _enqueueFullManufacturer(manufacturerId);
+        if (delta != 0) {
+          await _appendPoolLedgerRow(
+            manufacturerId: manufacturerId,
+            storeId: null,
+            quantityDelta: delta,
+            movementType: 'adjusted',
+          );
+        }
+      }
+    });
+  }
+
+  /// Move [quantity] empties of [manufacturerId] between two stores (§16.9),
+  /// executed at dispatch. Writes two store-stamped crate_ledger legs and
+  /// updates store_crate_balances locally; the cloud side is the single atomic
+  /// `domain:pos_transfer_crates` envelope (store_crate_balances is NOT
+  /// separately enqueued — the RPC is the sole cloud writer, preventing a
+  /// double-count). Moved verbatim from StockTransferDao (#157).
+  Future<void> transferBetweenStores({
+    required String transferId,
+    required String fromStoreId,
+    required String toStoreId,
+    required String manufacturerId,
+    required int quantity,
+    required String performedBy,
+  }) async {
+    final bizId = requireBusinessId();
+    final outLedgerId = UuidV7.generate();
+    final inLedgerId = UuidV7.generate();
+    final nowSec = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+
+    await customStatement(
+      'INSERT INTO crate_ledger '
+      '  (id, business_id, manufacturer_id, store_id, '
+      '   quantity_delta, movement_type, performed_by, created_at, last_updated_at) '
+      'VALUES (?,?,?,?,?,?,?,?,?)',
+      [
+        outLedgerId,
+        bizId,
+        manufacturerId,
+        fromStoreId,
+        -quantity,
+        'transferred_out',
+        performedBy,
+        nowSec,
+        nowSec,
+      ],
+    );
+    await customStatement(
+      'INSERT INTO crate_ledger '
+      '  (id, business_id, manufacturer_id, store_id, '
+      '   quantity_delta, movement_type, performed_by, created_at, last_updated_at) '
+      'VALUES (?,?,?,?,?,?,?,?,?)',
+      [
+        inLedgerId,
+        bizId,
+        manufacturerId,
+        toStoreId,
+        quantity,
+        'transferred_in',
+        performedBy,
+        nowSec,
+        nowSec,
+      ],
+    );
+
+    await customStatement(
+      'INSERT INTO store_crate_balances '
+      '  (id, business_id, store_id, manufacturer_id, balance, last_updated_at) '
+      'VALUES (?,?,?,?,?,?) '
+      'ON CONFLICT(business_id, store_id, manufacturer_id) DO UPDATE SET '
+      '  balance = balance + excluded.balance, '
+      '  last_updated_at = excluded.last_updated_at',
+      [
+        UuidV7.generate(),
+        bizId,
+        fromStoreId,
+        manufacturerId,
+        -quantity,
+        nowSec,
+      ],
+    );
+    await customStatement(
+      'INSERT INTO store_crate_balances '
+      '  (id, business_id, store_id, manufacturer_id, balance, last_updated_at) '
+      'VALUES (?,?,?,?,?,?) '
+      'ON CONFLICT(business_id, store_id, manufacturer_id) DO UPDATE SET '
+      '  balance = balance + excluded.balance, '
+      '  last_updated_at = excluded.last_updated_at',
+      [UuidV7.generate(), bizId, toStoreId, manufacturerId, quantity, nowSec],
+    );
+
+    final payload = <String, dynamic>{
+      'p_business_id': bizId,
+      'p_actor_id': performedBy,
+      'p_transfer_id': transferId,
+      'p_from_store_id': fromStoreId,
+      'p_to_store_id': toStoreId,
+      'p_manufacturer_id': manufacturerId,
+      'p_quantity': quantity,
+      'p_out_ledger_id': outLedgerId,
+      'p_in_ledger_id': inLedgerId,
+    };
+    await db.syncDao.enqueue(
+      'domain:pos_transfer_crates',
+      jsonEncode(payload),
+    );
+  }
+
+  // ───────────────────────────────────────────────────────────────────────
+  // Supplier crate movements (supplier_crate_ledger + supplier_crate_balances)
+  // Moved here from SupplierCrateLedgerDao (#157) so the seam owns every write.
+  // ───────────────────────────────────────────────────────────────────────
+
+  /// Full crates RECEIVED from a supplier (we now owe N empties), with an
+  /// optional refundable [depositPaidKobo] paid on the receipt.
+  Future<void> recordReceiveFromSupplier({
+    required String supplierId,
+    required String manufacturerId,
+    required int quantity,
+    required String performedBy,
+    String? storeId,
+    int depositPaidKobo = 0,
+    String? note,
+  }) async {
+    if (quantity <= 0) return;
+    await _appendSupplierMovement(
+      supplierId: supplierId,
+      manufacturerId: manufacturerId,
+      quantityDelta: quantity,
+      movementType: 'received',
+      performedBy: performedBy,
+      storeId: storeId,
+      depositPaidKobo: depositPaidKobo < 0 ? 0 : depositPaidKobo,
+      note: note,
+    );
+  }
+
+  /// Empties RETURNED to a supplier (reduces what we owe), with an optional
+  /// [depositRefundedKobo] refunded back to us on the return.
+  Future<void> recordReturnToSupplier({
+    required String supplierId,
+    required String manufacturerId,
+    required int quantity,
+    required String performedBy,
+    String? storeId,
+    int depositRefundedKobo = 0,
+    String? note,
+  }) async {
+    if (quantity <= 0) return;
+    await _appendSupplierMovement(
+      supplierId: supplierId,
+      manufacturerId: manufacturerId,
+      quantityDelta: -quantity,
+      movementType: 'returned',
+      performedBy: performedBy,
+      storeId: storeId,
+      depositPaidKobo: depositRefundedKobo < 0 ? 0 : depositRefundedKobo,
+      note: note,
+    );
+  }
+
+  Future<void> _appendSupplierMovement({
+    required String supplierId,
+    required String manufacturerId,
+    required int quantityDelta,
+    required String movementType,
+    required String performedBy,
+    required int depositPaidKobo,
+    String? storeId,
+    String? note,
+  }) async {
+    await transaction(() async {
+      final ledgerComp = SupplierCrateLedgerCompanion.insert(
+        id: Value(UuidV7.generate()),
+        businessId: requireBusinessId(),
+        supplierId: supplierId,
+        manufacturerId: manufacturerId,
+        storeId: Value(storeId),
+        quantityDelta: quantityDelta,
+        movementType: movementType,
+        depositPaidKobo: Value(depositPaidKobo),
+        note: Value(note),
+        performedBy: Value(performedBy),
+        lastUpdatedAt: Value(DateTime.now()),
+      );
+      await into(supplierCrateLedger).insert(ledgerComp);
+
+      await customInsert(
+        'INSERT INTO supplier_crate_balances '
+        '  (id, business_id, supplier_id, manufacturer_id, balance) '
+        'VALUES (?, ?, ?, ?, ?) '
+        'ON CONFLICT(business_id, supplier_id, manufacturer_id) DO UPDATE SET '
+        '  balance = balance + excluded.balance, '
+        "  last_updated_at = CAST(strftime('%s', CURRENT_TIMESTAMP) AS INTEGER)",
+        variables: [
+          Variable(UuidV7.generate()),
+          Variable(requireBusinessId()),
+          Variable(supplierId),
+          Variable(manufacturerId),
+          Variable(quantityDelta),
+        ],
+        updates: {supplierCrateBalances},
+      );
+
+      await db.syncDao.enqueueUpsert('supplier_crate_ledger', ledgerComp);
+      final updatedBalance =
+          await (select(supplierCrateBalances)
+                ..where(
+                  (t) =>
+                      whereBusiness(t) &
+                      t.supplierId.equals(supplierId) &
+                      t.manufacturerId.equals(manufacturerId),
+                )
+                ..limit(1))
+              .getSingle();
+      await db.syncDao.enqueueUpsert(
+        'supplier_crate_balances',
+        updatedBalance,
+      );
+    });
+  }
+
+  // ── Shared helpers ─────────────────────────────────────────────────────
+
+  /// Append an append-only, store-stamped business-pool ledger row and enqueue
+  /// it. Used by the physical-pool verbs above.
+  Future<void> _appendPoolLedgerRow({
+    required String manufacturerId,
+    String? storeId,
+    required int quantityDelta,
+    required String movementType,
+    String? performedBy,
+  }) async {
+    final ledgerComp = CrateLedgerCompanion.insert(
+      id: Value(UuidV7.generate()),
+      businessId: requireBusinessId(),
+      manufacturerId: Value(manufacturerId),
+      storeId: Value(storeId),
+      quantityDelta: quantityDelta,
+      movementType: movementType,
+      performedBy: Value(performedBy),
+      lastUpdatedAt: Value(DateTime.now()),
+    );
+    await into(crateLedger).insert(ledgerComp);
+    await db.syncDao.enqueueUpsert('crate_ledger', ledgerComp);
+  }
+
+  Future<void> _enqueueFullManufacturer(String id) async {
+    final row = await (select(
+      manufacturers,
+    )..where((t) => t.id.equals(id) & whereBusiness(t))).getSingleOrNull();
+    if (row != null) {
+      await db.syncDao.enqueueUpsert('manufacturers', row.toCompanion(true));
     }
   }
 }

--- a/lib/core/database/daos_inventory.dart
+++ b/lib/core/database/daos_inventory.dart
@@ -77,53 +77,19 @@ class InventoryDao extends DatabaseAccessor<AppDatabase>
     }
   }
 
+  /// Manually set a manufacturer's empty-crate count (management dialog).
+  /// Delegates to the Crate Pool seam (#157), which records the correction as a
+  /// reconciling ledger delta and maintains the scalar + per-store caches.
   Future<void> updateManufacturerStock(
     String id,
     int newStock, {
     String? storeId,
   }) async {
-    final now = DateTime.now();
-
-    if (storeId != null) {
-      // Per-store path (§16.8.1): set this store's balance and bump the
-      // business total by the delta so manufacturers.empty_crate_stock stays
-      // equal to the sum of all store balances.
-      final currentBalance = await db.storeCrateBalancesDao.getBalance(
-        storeId: storeId,
-        manufacturerId: id,
-      );
-      final delta = newStock - currentBalance;
-
-      await db.storeCrateBalancesDao.setBalance(
-        storeId: storeId,
-        manufacturerId: id,
-        newBalance: newStock,
-      );
-
-      // Bump business total by the same delta.
-      final mfr = await (select(
-        manufacturers,
-      )..where((t) => t.id.equals(id) & whereBusiness(t))).getSingle();
-      final comp = ManufacturersCompanion(
-        id: Value(id),
-        emptyCrateStock: Value(mfr.emptyCrateStock + delta),
-        lastUpdatedAt: Value(now),
-      );
-      await (update(
-        manufacturers,
-      )..where((t) => t.id.equals(id) & whereBusiness(t))).write(comp);
-    } else {
-      // Legacy path (no store dimension): absolute set on business total.
-      final comp = ManufacturersCompanion(
-        id: Value(id),
-        emptyCrateStock: Value(newStock),
-        lastUpdatedAt: Value(now),
-      );
-      await (update(
-        manufacturers,
-      )..where((t) => t.id.equals(id) & whereBusiness(t))).write(comp);
-    }
-    await _enqueueFullManufacturer(id);
+    await db.cratePoolDao.recordManualCountCorrection(
+      id,
+      newStock,
+      storeId: storeId,
+    );
   }
 
   Future<void> updateManufacturerDeposit(String id, int depositKobo) async {
@@ -451,102 +417,36 @@ class InventoryDao extends DatabaseAccessor<AppDatabase>
 
   /// Increment a manufacturer's empty-crate stock counter. Used by the
   /// receive-delivery and crate-return flows to credit the physical pool of
-  /// returnable crates held against a manufacturer.
+  /// returnable crates held against a manufacturer. Delegates to the Crate Pool
+  /// seam (#157).
   Future<void> addEmptyCrates(
     String manufacturerId,
     int quantity, {
     String? storeId,
   }) async {
-    if (quantity == 0) return;
-    await customUpdate(
-      'UPDATE manufacturers SET empty_crate_stock = empty_crate_stock + ?, '
-      'last_updated_at = CAST(strftime(\'%s\', CURRENT_TIMESTAMP) AS INTEGER) '
-      'WHERE id = ? AND business_id = ?',
-      variables: [
-        Variable(quantity),
-        Variable(manufacturerId),
-        Variable(requireBusinessId()),
-      ],
-      updates: {manufacturers},
+    await db.cratePoolDao.addEmptiesToPool(
+      manufacturerId,
+      quantity,
+      storeId: storeId,
     );
-    final mfrRow =
-        await (select(manufacturers)
-              ..where((t) => t.id.equals(manufacturerId) & whereBusiness(t)))
-            .getSingle();
-    await db.syncDao.enqueueUpsert('manufacturers', mfrRow);
-
-    // Per-store tracking (§16.8.1): if a store is provided, stamp the balance
-    // and write a store-scoped crate_ledger row.
-    if (storeId != null) {
-      await db.storeCrateBalancesDao.applyDelta(
-        storeId: storeId,
-        manufacturerId: manufacturerId,
-        delta: quantity,
-      );
-      final ledgerComp = CrateLedgerCompanion.insert(
-        id: Value(UuidV7.generate()),
-        businessId: requireBusinessId(),
-        manufacturerId: Value(manufacturerId),
-        storeId: Value(storeId),
-        quantityDelta: quantity,
-        movementType: 'adjusted',
-        lastUpdatedAt: Value(DateTime.now()),
-      );
-      await into(crateLedger).insert(ledgerComp);
-      await db.syncDao.enqueueUpsert('crate_ledger', ledgerComp);
-    }
   }
 
   /// Debit a manufacturer's empty-crate pool because STORED empties were
-  /// damaged/lost (§17.2 crate-aware damages, the `+crateempty` fate). Mirrors
-  /// [addEmptyCrates] but subtracts and stamps a `damaged` crate_ledger
-  /// movement. The pool is clamped at zero. Note: the "full crate lost"
-  /// (`+cratelost`) fate does NOT call this — that container was never in the
-  /// returned-empties pool, so it only forfeits the deposit on the Statement
-  /// (derived from the damage reason in `computeReconData`).
+  /// damaged/lost (§17.2 crate-aware damages, the `+crateempty` fate). The pool
+  /// is clamped at zero. Note: the "full crate lost" (`+cratelost`) fate does
+  /// NOT call this — that container was never in the returned-empties pool, so
+  /// it only forfeits the deposit on the Statement (derived from the damage
+  /// reason in `computeReconData`). Delegates to the Crate Pool seam (#157).
   Future<void> recordEmptyCrateDamage(
     String manufacturerId,
     int quantity, {
     String? storeId,
   }) async {
-    if (quantity <= 0) return;
-    await customUpdate(
-      'UPDATE manufacturers SET empty_crate_stock = MAX(0, empty_crate_stock - ?), '
-      'last_updated_at = CAST(strftime(\'%s\', CURRENT_TIMESTAMP) AS INTEGER) '
-      'WHERE id = ? AND business_id = ?',
-      variables: [
-        Variable(quantity),
-        Variable(manufacturerId),
-        Variable(requireBusinessId()),
-      ],
-      updates: {manufacturers},
+    await db.cratePoolDao.recordDamage(
+      manufacturerId,
+      quantity,
+      storeId: storeId,
     );
-    final mfrRow =
-        await (select(manufacturers)
-              ..where((t) => t.id.equals(manufacturerId) & whereBusiness(t)))
-            .getSingle();
-    await db.syncDao.enqueueUpsert('manufacturers', mfrRow);
-
-    // Per-store tracking (§16.8.1): mirror the balance + a store-scoped
-    // crate_ledger row tagged `damaged`.
-    if (storeId != null) {
-      await db.storeCrateBalancesDao.applyDelta(
-        storeId: storeId,
-        manufacturerId: manufacturerId,
-        delta: -quantity,
-      );
-      final ledgerComp = CrateLedgerCompanion.insert(
-        id: Value(UuidV7.generate()),
-        businessId: requireBusinessId(),
-        manufacturerId: Value(manufacturerId),
-        storeId: Value(storeId),
-        quantityDelta: -quantity,
-        movementType: 'damaged',
-        lastUpdatedAt: Value(DateTime.now()),
-      );
-      await into(crateLedger).insert(ledgerComp);
-      await db.syncDao.enqueueUpsert('crate_ledger', ledgerComp);
-    }
   }
 
   /// Stream the per-manufacturer count of full bottles in stock, derived
@@ -1455,116 +1355,8 @@ class StockTransferDao extends DatabaseAccessor<AppDatabase>
   /// Moves [quantity] empty crates of [manufacturerId] from [fromStoreId] to
   /// [toStoreId] atomically (Phase 3, §16.9). Executed at dispatch time — no
   /// separate confirm step for crates (they travel with the product shipment).
-  ///
-  /// Local: writes two store-stamped crate_ledger rows and updates
-  /// store_crate_balances for immediate UI feedback. Cloud: a single atomic
-  /// `domain:pos_transfer_crates` envelope (idempotent via ledger IDs).
-  /// store_crate_balances is NOT separately enqueued — the domain RPC is the
-  /// sole cloud writer (prevents double-count).
-  Future<void> _writeCrateTransferLegs({
-    required String transferId,
-    required String fromStoreId,
-    required String toStoreId,
-    required String manufacturerId,
-    required int quantity,
-    required String performedBy,
-  }) async {
-    final bizId = requireBusinessId();
-    final outLedgerId = UuidV7.generate();
-    final inLedgerId = UuidV7.generate();
-    final nowSec = DateTime.now().millisecondsSinceEpoch ~/ 1000;
-
-    // 1. Local crate_ledger rows (append-only; store-stamped §v44).
-    await customStatement(
-      'INSERT INTO crate_ledger '
-      '  (id, business_id, manufacturer_id, store_id, '
-      '   quantity_delta, movement_type, performed_by, created_at, last_updated_at) '
-      'VALUES (?,?,?,?,?,?,?,?,?)',
-      [
-        outLedgerId,
-        bizId,
-        manufacturerId,
-        fromStoreId,
-        -quantity,
-        'transferred_out',
-        performedBy,
-        nowSec,
-        nowSec,
-      ],
-    );
-    await customStatement(
-      'INSERT INTO crate_ledger '
-      '  (id, business_id, manufacturer_id, store_id, '
-      '   quantity_delta, movement_type, performed_by, created_at, last_updated_at) '
-      'VALUES (?,?,?,?,?,?,?,?,?)',
-      [
-        inLedgerId,
-        bizId,
-        manufacturerId,
-        toStoreId,
-        quantity,
-        'transferred_in',
-        performedBy,
-        nowSec,
-        nowSec,
-      ],
-    );
-
-    // 2. Local store_crate_balances — immediate UI feedback only.
-    //    NOT enqueued directly; the domain RPC is the sole cloud writer.
-    await customStatement(
-      'INSERT INTO store_crate_balances '
-      '  (id, business_id, store_id, manufacturer_id, balance, last_updated_at) '
-      'VALUES (?,?,?,?,?,?) '
-      'ON CONFLICT(business_id, store_id, manufacturer_id) DO UPDATE SET '
-      '  balance = balance + excluded.balance, '
-      '  last_updated_at = excluded.last_updated_at',
-      [
-        UuidV7.generate(),
-        bizId,
-        fromStoreId,
-        manufacturerId,
-        -quantity,
-        nowSec,
-      ],
-    );
-    await customStatement(
-      'INSERT INTO store_crate_balances '
-      '  (id, business_id, store_id, manufacturer_id, balance, last_updated_at) '
-      'VALUES (?,?,?,?,?,?) '
-      'ON CONFLICT(business_id, store_id, manufacturer_id) DO UPDATE SET '
-      '  balance = balance + excluded.balance, '
-      '  last_updated_at = excluded.last_updated_at',
-      [UuidV7.generate(), bizId, toStoreId, manufacturerId, quantity, nowSec],
-    );
-
-    // 3. Enqueue the domain RPC (handles cloud crate_ledger + store_crate_balances atomically).
-    final payload = <String, dynamic>{
-      'p_business_id': bizId,
-      'p_actor_id': performedBy,
-      'p_transfer_id': transferId,
-      'p_from_store_id': fromStoreId,
-      'p_to_store_id': toStoreId,
-      'p_manufacturer_id': manufacturerId,
-      'p_quantity': quantity,
-      'p_out_ledger_id': outLedgerId,
-      'p_in_ledger_id': inLedgerId,
-    };
-    await db.syncDao.enqueue(
-      'domain:pos_transfer_crates',
-      jsonEncode(payload),
-    );
-  }
-
-  /// Moves [quantity] empty crates of [manufacturerId] from [fromStoreId] to
-  /// [toStoreId] atomically (Phase 3, §16.9). Executed at dispatch time — no
-  /// separate confirm step for crates (they travel with the product shipment).
-  ///
-  /// Local: writes two store-stamped crate_ledger rows and updates
-  /// store_crate_balances for immediate UI feedback. Cloud: a single atomic
-  /// `domain:pos_transfer_crates` envelope (idempotent via ledger IDs).
-  /// store_crate_balances is NOT separately enqueued — the domain RPC is the
-  /// sole cloud writer (prevents double-count).
+  /// Delegates to the Crate Pool seam (#157), which owns the crate_ledger +
+  /// store_crate_balances writes and the `domain:pos_transfer_crates` envelope.
   Future<void> transferCrates({
     required String transferId,
     required String fromStoreId,
@@ -1574,7 +1366,7 @@ class StockTransferDao extends DatabaseAccessor<AppDatabase>
     required String performedBy,
   }) async {
     await transaction(() async {
-      await _writeCrateTransferLegs(
+      await db.cratePoolDao.transferBetweenStores(
         transferId: transferId,
         fromStoreId: fromStoreId,
         toStoreId: toStoreId,
@@ -1749,7 +1541,7 @@ class StockTransferDao extends DatabaseAccessor<AppDatabase>
           throw StateError('Product ${product.name} does not have a manufacturerId.');
         }
 
-        await _writeCrateTransferLegs(
+        await db.cratePoolDao.transferBetweenStores(
           transferId: transferId,
           fromStoreId: fromStoreId!,
           toStoreId: toStoreId!,

--- a/lib/core/database/daos_orders.dart
+++ b/lib/core/database/daos_orders.dart
@@ -695,7 +695,7 @@ class OrdersDao extends DatabaseAccessor<AppDatabase>
           );
 
           if (depositPaid == 0) {
-            await db.crateLedgerDao.recordCrateIssueByCustomer(
+            await db.cratePoolDao.recordCrateIssueByCustomer(
               customerId: customerId,
               manufacturerId: mfrId,
               quantity: crates,
@@ -1411,7 +1411,7 @@ class OrdersDao extends DatabaseAccessor<AppDatabase>
       // customer_crate_balances is an LWW cache that won't self-heal on pull —
       // so undo the "issued" balance here. Walk-in / money-track sales issue no
       // customer crate balance, so this is a no-op for them.
-      await db.crateLedgerDao.reverseIssuedByCustomerLocal(
+      await db.cratePoolDao.reverseIssuedByCustomerLocal(
         orderId: orderId,
         staffId: staffId,
       );

--- a/lib/core/database/daos_suppliers.dart
+++ b/lib/core/database/daos_suppliers.dart
@@ -350,7 +350,7 @@ class SupplierCrateBalanceWithManufacturer {
 }
 
 /// §3.13 — append-only ledger of empty-crate movements between the store and a
-/// supplier. The supplier-side mirror of [CrateLedgerDao]'s customer methods.
+/// supplier. The supplier-side mirror of [CratePoolDao]'s customer methods.
 /// `received` (+) = full crates arrived from the supplier (we now owe N
 /// empties); `returned` (−) = empties handed back to the supplier. Both append
 /// one [SupplierCrateLedger] row, upsert the [SupplierCrateBalances] cache, and
@@ -364,7 +364,8 @@ class SupplierCrateLedgerDao extends DatabaseAccessor<AppDatabase>
 
   /// Record full crates RECEIVED from a supplier (we now owe N empties).
   /// [depositPaidKobo] is the refundable deposit money paid on this receipt
-  /// (>= 0); pass 0 when no deposit changed hands.
+  /// (>= 0); pass 0 when no deposit changed hands. Delegates to the Crate Pool
+  /// seam (#157), the sole writer of supplier_crate_ledger / _balances.
   Future<void> recordCrateReceiptFromSupplier({
     required String supplierId,
     required String manufacturerId,
@@ -374,15 +375,13 @@ class SupplierCrateLedgerDao extends DatabaseAccessor<AppDatabase>
     int depositPaidKobo = 0,
     String? note,
   }) async {
-    if (quantity <= 0) return;
-    await _appendMovement(
+    await db.cratePoolDao.recordReceiveFromSupplier(
       supplierId: supplierId,
       manufacturerId: manufacturerId,
-      quantityDelta: quantity,
-      movementType: 'received',
+      quantity: quantity,
       performedBy: performedBy,
       storeId: storeId,
-      depositPaidKobo: depositPaidKobo < 0 ? 0 : depositPaidKobo,
+      depositPaidKobo: depositPaidKobo,
       note: note,
     );
   }
@@ -390,6 +389,7 @@ class SupplierCrateLedgerDao extends DatabaseAccessor<AppDatabase>
   /// Record empties RETURNED to a supplier (reduces what we owe them).
   /// [depositRefundedKobo] is the deposit money refunded back to us on this
   /// return (>= 0), recorded so the net deposit held by the supplier nets out.
+  /// Delegates to the Crate Pool seam (#157).
   Future<void> recordCrateReturnToSupplier({
     required String supplierId,
     required String manufacturerId,
@@ -399,80 +399,15 @@ class SupplierCrateLedgerDao extends DatabaseAccessor<AppDatabase>
     int depositRefundedKobo = 0,
     String? note,
   }) async {
-    if (quantity <= 0) return;
-    await _appendMovement(
+    await db.cratePoolDao.recordReturnToSupplier(
       supplierId: supplierId,
       manufacturerId: manufacturerId,
-      quantityDelta: -quantity,
-      movementType: 'returned',
+      quantity: quantity,
       performedBy: performedBy,
       storeId: storeId,
-      depositPaidKobo: depositRefundedKobo < 0 ? 0 : depositRefundedKobo,
+      depositRefundedKobo: depositRefundedKobo,
       note: note,
     );
-  }
-
-  Future<void> _appendMovement({
-    required String supplierId,
-    required String manufacturerId,
-    required int quantityDelta,
-    required String movementType,
-    required String performedBy,
-    required int depositPaidKobo,
-    String? storeId,
-    String? note,
-  }) async {
-    await transaction(() async {
-      final ledgerComp = SupplierCrateLedgerCompanion.insert(
-        id: Value(UuidV7.generate()),
-        businessId: requireBusinessId(),
-        supplierId: supplierId,
-        manufacturerId: manufacturerId,
-        storeId: Value(storeId),
-        quantityDelta: quantityDelta,
-        movementType: movementType,
-        depositPaidKobo: Value(depositPaidKobo),
-        note: Value(note),
-        performedBy: Value(performedBy),
-        lastUpdatedAt: Value(DateTime.now()),
-      );
-      await into(supplierCrateLedger).insert(ledgerComp);
-
-      // customInsert (not customStatement) so the watching streams refresh on
-      // commit — a raw customStatement write is invisible to Drift's tracker.
-      await customInsert(
-        'INSERT INTO supplier_crate_balances '
-        '  (id, business_id, supplier_id, manufacturer_id, balance) '
-        'VALUES (?, ?, ?, ?, ?) '
-        'ON CONFLICT(business_id, supplier_id, manufacturer_id) DO UPDATE SET '
-        '  balance = balance + excluded.balance, '
-        "  last_updated_at = CAST(strftime('%s', CURRENT_TIMESTAMP) AS INTEGER)",
-        variables: [
-          Variable(UuidV7.generate()),
-          Variable(requireBusinessId()),
-          Variable(supplierId),
-          Variable(manufacturerId),
-          Variable(quantityDelta),
-        ],
-        updates: {supplierCrateBalances},
-      );
-
-      await db.syncDao.enqueueUpsert('supplier_crate_ledger', ledgerComp);
-      final updatedBalance =
-          await (select(supplierCrateBalances)
-                ..where(
-                  (t) =>
-                      whereBusiness(t) &
-                      t.supplierId.equals(supplierId) &
-                      t.manufacturerId.equals(manufacturerId),
-                )
-                ..limit(1))
-              .getSingle();
-      await db.syncDao.enqueueUpsert(
-        'supplier_crate_balances',
-        updatedBalance,
-      );
-    });
   }
 
   /// Full ledger history for one supplier, newest first.

--- a/lib/core/services/supabase_sync_service.dart
+++ b/lib/core/services/supabase_sync_service.dart
@@ -1,3 +1,6 @@
+// crate-seam-exempt-file: the sync engine restores cloud-authoritative crate
+// rows (pull/reconcile), not user-initiated movements — it is not a crate write
+// path (ADR 0020 / crate_seam_ban_test).
 import 'dart:async';
 import 'dart:convert';
 import 'package:drift/drift.dart';

--- a/lib/features/customers/screens/customer_detail_screen.dart
+++ b/lib/features/customers/screens/customer_detail_screen.dart
@@ -2366,7 +2366,7 @@ class _CustomerDetailScreenState extends ConsumerState<CustomerDetailScreen> {
                         qty,
                         storeId: creditStoreId,
                       );
-                      await db.crateLedgerDao.recordCrateReturnByCustomer(
+                      await db.cratePoolDao.recordCrateReturnByCustomer(
                         customerId: id,
                         manufacturerId: mfrId,
                         quantity: qty,

--- a/lib/shared/services/crate_return_approval_service.dart
+++ b/lib/shared/services/crate_return_approval_service.dart
@@ -31,9 +31,6 @@ class CrateReturnApprovalService {
     await db.transaction(() async {
       final now = DateTime.now();
       final ledgerId = UuidV7.generate();
-      // Returning crates reduces what the customer owes. pending.quantity
-      // is positive; negate for the ledger + balance increment.
-      final delta = -pending.quantity;
 
       final pcrComp = PendingCrateReturnsCompanion(
         id: Value(returnId),
@@ -46,37 +43,22 @@ class CrateReturnApprovalService {
         db.pendingCrateReturns,
       )..where((t) => t.id.equals(returnId))).write(pcrComp);
 
-      // v29: a customer crate row sets both customer_id (owner) and
-      // manufacturer_id (whose crates); keyed by manufacturer.
-      final ledgerComp = CrateLedgerCompanion.insert(
-        id: Value(ledgerId),
-        businessId: pending.businessId,
-        customerId: Value(pending.customerId),
-        manufacturerId: Value(pending.manufacturerId),
-        quantityDelta: delta,
-        movementType: 'returned',
-        referenceReturnId: Value(returnId),
-        performedBy: Value(approvedBy),
-        lastUpdatedAt: Value(now),
-      );
-      await db.into(db.crateLedger).insert(ledgerComp);
-
-      await db.customStatement(
-        'INSERT INTO customer_crate_balances (id, business_id, customer_id, manufacturer_id, balance) '
-        'VALUES (?, ?, ?, ?, ?) '
-        'ON CONFLICT(business_id, customer_id, manufacturer_id) DO UPDATE SET '
-        'balance = balance + excluded.balance, '
-        'last_updated_at = CAST(strftime(\'%s\', CURRENT_TIMESTAMP) AS INTEGER)',
-        [
-          UuidV7.generate(),
-          pending.businessId,
-          pending.customerId,
-          pending.manufacturerId,
-          delta,
-        ],
+      // Crate legs (crate_ledger + customer_crate_balances) go through the Crate
+      // Pool seam (#157) — the sole writer of the crate tables. It records the
+      // return stamped with referenceReturnId and, on the flag-off path,
+      // enqueues the per-table rows.
+      await db.cratePoolDao.recordApprovedCustomerReturn(
+        customerId: pending.customerId,
+        manufacturerId: pending.manufacturerId,
+        returnId: returnId,
+        ledgerId: ledgerId,
+        quantity: pending.quantity,
+        approvedBy: approvedBy,
+        useDomainRpc: useDomainRpc,
       );
 
       if (useDomainRpc) {
+        // One envelope settles the ledger + pending row server-side.
         final payload = <String, dynamic>{
           'p_business_id': pending.businessId,
           'p_actor_id': approvedBy,
@@ -101,16 +83,6 @@ class CrateReturnApprovalService {
                 lastUpdatedAt: Value(now),
               ),
         );
-        await db.syncDao.enqueueUpsert('crate_ledger', ledgerComp);
-        final balRow =
-            await (db.select(db.customerCrateBalances)..where(
-                  (t) =>
-                      t.businessId.equals(pending.businessId) &
-                      t.customerId.equals(pending.customerId) &
-                      t.manufacturerId.equals(pending.manufacturerId),
-                ))
-                .getSingle();
-        await db.syncDao.enqueueUpsert('customer_crate_balances', balRow);
       }
     });
   }

--- a/lib/shared/services/orders/order_commands.dart
+++ b/lib/shared/services/orders/order_commands.dart
@@ -260,7 +260,7 @@ class OrderCommands {
         } else if (line.returnedCrates > 0) {
           // crate-track (no deposit): net the issued balance. Leftover (taken −
           // returned) stays as crate debt on the crates tab.
-          await _db.crateLedgerDao.recordCrateReturnByCustomer(
+          await _db.cratePoolDao.recordCrateReturnByCustomer(
             customerId: customerId,
             manufacturerId: line.manufacturerId,
             quantity: line.returnedCrates,

--- a/lib/shared/services/receive_stock_service.dart
+++ b/lib/shared/services/receive_stock_service.dart
@@ -127,7 +127,7 @@ class ReceiveStockService {
       };
       for (final entry in emptiesReturnedByManufacturer.entries) {
         if (entry.value > 0 && eligibleManufacturerIds.contains(entry.key)) {
-          await _db.crateLedgerDao.recordCrateReturnByManufacturer(
+          await _db.cratePoolDao.recordCrateReturnByManufacturer(
             manufacturerId: entry.key,
             quantity: entry.value,
             performedBy: staffId,

--- a/lib/shared/services/supplier_crate_service.dart
+++ b/lib/shared/services/supplier_crate_service.dart
@@ -2,12 +2,12 @@ import 'package:reebaplus_pos/core/database/app_database.dart';
 import 'package:reebaplus_pos/core/utils/number_format.dart';
 
 /// §3.13 — records empty-crate activity against a SUPPLIER. The supplier-side
-/// mirror of the customer crate flow (`CrateLedgerDao.recordCrateReturnByCustomer`),
+/// mirror of the customer crate flow (`CratePoolDao.recordCrateReturnByCustomer`),
 /// wrapped with Activity-Log writes. A *receipt* means full crates arrived from
 /// the supplier (we now owe them N empties); a *return* means we handed empties
 /// back (reduces what we owe). Each appends one append-only
 /// [SupplierCrateLedger] row and upserts the [SupplierCrateBalances] cache via
-/// [SupplierCrateLedgerDao]; this layer adds the audit trail.
+/// the Crate Pool seam ([CratePoolDao]); this layer adds the audit trail.
 class SupplierCrateService {
   final AppDatabase _db;
 

--- a/test/crates/crate_issue_at_sale_test.dart
+++ b/test/crates/crate_issue_at_sale_test.dart
@@ -135,14 +135,14 @@ void main() {
       final (storeId, staffId, customerId) = await seedBase();
       final (mfrId, _) = await seedCrateProduct(storeId);
 
-      await db.crateLedgerDao.recordCrateIssueByCustomer(
+      await db.cratePoolDao.recordCrateIssueByCustomer(
           customerId: customerId,
           manufacturerId: mfrId,
           quantity: 10,
           performedBy: staffId);
       expect(await crateBalance(customerId, mfrId), 10, reason: '10 owed');
 
-      await db.crateLedgerDao.recordCrateReturnByCustomer(
+      await db.cratePoolDao.recordCrateReturnByCustomer(
           customerId: customerId,
           manufacturerId: mfrId,
           quantity: 10,
@@ -155,12 +155,12 @@ void main() {
       final (storeId, staffId, customerId) = await seedBase();
       final (mfrId, _) = await seedCrateProduct(storeId);
 
-      await db.crateLedgerDao.recordCrateIssueByCustomer(
+      await db.cratePoolDao.recordCrateIssueByCustomer(
           customerId: customerId,
           manufacturerId: mfrId,
           quantity: 10,
           performedBy: staffId);
-      await db.crateLedgerDao.recordCrateReturnByCustomer(
+      await db.cratePoolDao.recordCrateReturnByCustomer(
           customerId: customerId,
           manufacturerId: mfrId,
           quantity: 7,
@@ -190,7 +190,7 @@ void main() {
       expect(issued.first.manufacturerId, mfrId);
 
       // Returning all 5 nets to "not owing".
-      await db.crateLedgerDao.recordCrateReturnByCustomer(
+      await db.cratePoolDao.recordCrateReturnByCustomer(
           customerId: customerId,
           manufacturerId: mfrId,
           quantity: 5,

--- a/test/crates/crate_logic_test.dart
+++ b/test/crates/crate_logic_test.dart
@@ -47,7 +47,7 @@ void main() {
       final fkStatus = await db.customSelect('PRAGMA foreign_keys').getSingle();
       expect(fkStatus.read<int>('foreign_keys'), 1);
 
-      await db.crateLedgerDao.recordCrateReturnByManufacturer(
+      await db.cratePoolDao.recordCrateReturnByManufacturer(
         manufacturerId: manufacturerId,
         quantity: 10,
         performedBy: userId,
@@ -75,7 +75,7 @@ void main() {
   group('recordCrateReturnByCustomer', () {
     test('customer row carries both owner + manufacturer; balance per mfr',
         () async {
-      await db.crateLedgerDao.recordCrateReturnByCustomer(
+      await db.cratePoolDao.recordCrateReturnByCustomer(
         customerId: customerId,
         manufacturerId: manufacturerId,
         quantity: 3,
@@ -114,7 +114,7 @@ void main() {
       await pumpEventQueue();
       expect(emissions.last, isEmpty, reason: 'no crate activity yet');
 
-      await db.crateLedgerDao.recordCrateReturnByCustomer(
+      await db.cratePoolDao.recordCrateReturnByCustomer(
         customerId: customerId,
         manufacturerId: manufacturerId,
         quantity: 4,
@@ -430,7 +430,7 @@ void main() {
     test('second customer return hits ON CONFLICT path and re-reads cleanly',
         () async {
       // First return: INSERT path (uses the integer column default).
-      await db.crateLedgerDao.recordCrateReturnByCustomer(
+      await db.cratePoolDao.recordCrateReturnByCustomer(
         customerId: customerId,
         manufacturerId: manufacturerId,
         quantity: 2,
@@ -439,7 +439,7 @@ void main() {
       // Second return for the SAME (customer, manufacturer): the DO UPDATE SET
       // branch ran `last_updated_at = CURRENT_TIMESTAMP` before the fix and
       // corrupted the row; the read-back inside the method threw.
-      await db.crateLedgerDao.recordCrateReturnByCustomer(
+      await db.cratePoolDao.recordCrateReturnByCustomer(
         customerId: customerId,
         manufacturerId: manufacturerId,
         quantity: 3,

--- a/test/crates/crate_pool_seam_test.dart
+++ b/test/crates/crate_pool_seam_test.dart
@@ -1,0 +1,278 @@
+import 'dart:io';
+
+import 'package:drift/drift.dart' hide isNull, isNotNull;
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reebaplus_pos/core/database/app_database.dart';
+
+/// #157 — the Crate Pool seam (`CratePoolDao`). Covers the two NEW ledger-
+/// completeness behaviors this slice adds (a manual "set to N" becomes a
+/// reconciling delta row; a store-less pool credit/debit now writes a row too)
+/// and the v62→v63 opening-balance seed that guarantees `SUM(quantity_delta)`
+/// equals the existing cache value at cutover.
+void main() {
+  const businessId = 'biz-1';
+  const userId = 'user-1';
+  const customerId = 'cust-1';
+  const manufacturerId = 'mfr-1';
+  const storeId = 'store-1';
+  const supplierId = 'sup-1';
+
+  group('ledger completeness (in-memory)', () {
+    late AppDatabase db;
+
+    setUp(() async {
+      db = AppDatabase.forTesting(NativeDatabase.memory());
+      db.businessIdResolver = () => businessId;
+      await db.into(db.businesses).insert(
+            BusinessesCompanion.insert(
+              id: const Value(businessId),
+              name: 'Biz',
+            ),
+          );
+      await db.into(db.users).insert(
+            UsersCompanion.insert(
+              id: const Value(userId),
+              businessId: businessId,
+              name: 'U',
+              pin: '1234',
+            ),
+          );
+      await db.into(db.stores).insert(
+            StoresCompanion.insert(
+              id: const Value(storeId),
+              businessId: businessId,
+              name: 'Store',
+            ),
+          );
+      await db.into(db.manufacturers).insert(
+            ManufacturersCompanion.insert(
+              id: const Value(manufacturerId),
+              businessId: businessId,
+              name: 'Mfr',
+            ),
+          );
+    });
+
+    tearDown(() => db.close());
+
+    Future<int> scalar() async {
+      final m = await (db.select(db.manufacturers)
+            ..where((t) => t.id.equals(manufacturerId)))
+          .getSingle();
+      return m.emptyCrateStock;
+    }
+
+    Future<List<CrateLedgerData>> ledger() =>
+        db.select(db.crateLedger).get();
+
+    test('addEmptiesToPool (store-less) bumps the scalar AND appends a ledger row',
+        () async {
+      await db.cratePoolDao.addEmptiesToPool(manufacturerId, 8);
+
+      expect(await scalar(), 8);
+      final rows = await ledger();
+      expect(rows.length, 1);
+      expect(rows.single.quantityDelta, 8);
+      expect(rows.single.movementType, 'adjusted');
+      expect(rows.single.manufacturerId, manufacturerId);
+      expect(rows.single.storeId, isNull);
+      expect(rows.single.customerId, isNull);
+    });
+
+    test('recordDamage (store-less) debits the scalar AND appends a damaged row',
+        () async {
+      await db.cratePoolDao.addEmptiesToPool(manufacturerId, 8);
+      await db.cratePoolDao.recordDamage(manufacturerId, 3);
+
+      expect(await scalar(), 5);
+      final damaged =
+          (await ledger()).where((r) => r.movementType == 'damaged').toList();
+      expect(damaged.length, 1);
+      expect(damaged.single.quantityDelta, -3);
+      expect(damaged.single.storeId, isNull);
+    });
+
+    test('recordManualCountCorrection (store-less) records a DELTA row (N-current)',
+        () async {
+      await db.cratePoolDao.recordManualCountCorrection(manufacturerId, 15);
+      expect(await scalar(), 15);
+
+      // A second correction downward records the negative delta, not an overwrite.
+      await db.cratePoolDao.recordManualCountCorrection(manufacturerId, 10);
+      expect(await scalar(), 10);
+
+      final rows = await ledger();
+      expect(rows.map((r) => r.quantityDelta).toList(), [15, -5]);
+      // The ledger sums to the current displayed count.
+      expect(rows.fold<int>(0, (s, r) => s + r.quantityDelta), 10);
+    });
+
+    test('recordManualCountCorrection (store) sets store balance + a store row',
+        () async {
+      await db.cratePoolDao.recordManualCountCorrection(
+        manufacturerId,
+        12,
+        storeId: storeId,
+      );
+
+      final bal = await db.storeCrateBalancesDao.getBalance(
+        storeId: storeId,
+        manufacturerId: manufacturerId,
+      );
+      expect(bal, 12);
+      expect(await scalar(), 12); // business total bumped by the same delta
+
+      final storeRows =
+          (await ledger()).where((r) => r.storeId == storeId).toList();
+      expect(storeRows.length, 1);
+      expect(storeRows.single.quantityDelta, 12);
+      expect(storeRows.single.movementType, 'adjusted');
+    });
+  });
+
+  group('v62->v63 opening-balance seed (file-backed migration)', () {
+    late Directory tmpDir;
+    late File dbFile;
+
+    setUp(() async {
+      tmpDir = await Directory.systemTemp.createTemp('reeba_crate_seed');
+      dbFile = File('${tmpDir.path}/app.db');
+    });
+
+    tearDown(() async {
+      if (await tmpDir.exists()) await tmpDir.delete(recursive: true);
+    });
+
+    test('after upgrade, SUM(ledger) == each cache value at cutover', () async {
+      // 1. Fresh current-schema DB; seed the FK parents + drifted caches.
+      final db1 = AppDatabase.forTesting(NativeDatabase(dbFile));
+      await db1.customSelect('SELECT 1').get();
+      await db1.into(db1.businesses).insert(
+            BusinessesCompanion.insert(id: const Value(businessId), name: 'B'),
+          );
+      await db1.into(db1.customers).insert(
+            CustomersCompanion.insert(
+              id: const Value(customerId),
+              businessId: businessId,
+              name: 'C',
+            ),
+          );
+      await db1.into(db1.stores).insert(
+            StoresCompanion.insert(
+              id: const Value(storeId),
+              businessId: businessId,
+              name: 'S',
+            ),
+          );
+      await db1.into(db1.manufacturers).insert(
+            ManufacturersCompanion.insert(
+              id: const Value(manufacturerId),
+              businessId: businessId,
+              name: 'M',
+            ),
+          );
+      await db1.into(db1.suppliers).insert(
+            SuppliersCompanion.insert(
+              id: const Value(supplierId),
+              businessId: businessId,
+              name: 'Sup',
+            ),
+          );
+
+      // Drifted caches (a mature business): a balance with no / partial ledger.
+      await db1.into(db1.customerCrateBalances).insert(
+            CustomerCrateBalancesCompanion.insert(
+              businessId: businessId,
+              customerId: customerId,
+              manufacturerId: manufacturerId,
+              balance: const Value(10),
+            ),
+          );
+      // A partial ledger of +3 already exists → the seed must reconcile +7.
+      await db1.into(db1.crateLedger).insert(
+            CrateLedgerCompanion.insert(
+              businessId: businessId,
+              customerId: const Value(customerId),
+              manufacturerId: const Value(manufacturerId),
+              quantityDelta: 3,
+              movementType: 'issued',
+            ),
+          );
+      await db1.into(db1.storeCrateBalances).insert(
+            StoreCrateBalancesCompanion.insert(
+              businessId: businessId,
+              storeId: storeId,
+              manufacturerId: manufacturerId,
+              balance: const Value(5),
+            ),
+          );
+      await db1.into(db1.manufacturerCrateBalances).insert(
+            ManufacturerCrateBalancesCompanion.insert(
+              businessId: businessId,
+              manufacturerId: manufacturerId,
+              balance: const Value(20),
+            ),
+          );
+      await db1.into(db1.supplierCrateBalances).insert(
+            SupplierCrateBalancesCompanion.insert(
+              businessId: businessId,
+              supplierId: supplierId,
+              manufacturerId: manufacturerId,
+              balance: const Value(4),
+            ),
+          );
+
+      // 2. Stamp user_version back to 62 (v62->v63 is data-only, no schema
+      //    delta to revert), close, and re-open to drive the real onUpgrade.
+      await db1.customStatement('PRAGMA user_version = 62');
+      await db1.close();
+
+      final db2 = AppDatabase.forTesting(NativeDatabase(dbFile));
+      await db2.customSelect('SELECT 1').get(); // forces onUpgrade
+
+      Future<int> sum(String where) async {
+        final r = await db2
+            .customSelect(
+              'SELECT COALESCE(SUM(quantity_delta),0) AS s FROM crate_ledger '
+              'WHERE business_id = ? AND $where',
+              variables: const [Variable(businessId)],
+            )
+            .getSingle();
+        return r.read<int>('s');
+      }
+
+      // customer: SUM by (customer, manufacturer) == 10.
+      expect(
+        await sum("customer_id = '$customerId' AND manufacturer_id = "
+            "'$manufacturerId'"),
+        10,
+      );
+      // store: SUM by (store, manufacturer), customer-less == 5.
+      expect(
+        await sum("store_id = '$storeId' AND manufacturer_id = "
+            "'$manufacturerId' AND customer_id IS NULL"),
+        5,
+      );
+      // manufacturer: SUM by manufacturer, store-less + customer-less == 20.
+      expect(
+        await sum("manufacturer_id = '$manufacturerId' AND customer_id IS NULL "
+            "AND store_id IS NULL"),
+        20,
+      );
+
+      // supplier: SUM over supplier_crate_ledger by (supplier, manufacturer) == 4.
+      final sup = await db2
+          .customSelect(
+            'SELECT COALESCE(SUM(quantity_delta),0) AS s FROM supplier_crate_ledger '
+            "WHERE business_id = ? AND supplier_id = '$supplierId' "
+            "AND manufacturer_id = '$manufacturerId'",
+            variables: const [Variable(businessId)],
+          )
+          .getSingle();
+      expect(sup.read<int>('s'), 4);
+
+      await db2.close();
+    });
+  });
+}

--- a/test/crates/crate_seam_ban_test.dart
+++ b/test/crates/crate_seam_ban_test.dart
@@ -1,0 +1,135 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// Crate Pool seam guard (#157 / ADR 0020). The empty-crate pool has exactly ONE
+/// writer: `CratePoolDao` in `lib/core/database/daos_crates.dart`. This test
+/// fails the build if any other file writes a crate table — `crate_ledger`,
+/// `supplier_crate_ledger`, or a `*_crate_balances` cache — or mutates the
+/// `manufacturers.empty_crate_stock` scalar. That single-writer rule is what
+/// keeps the ledger the source of truth: a new surface (report, van, screen) has
+/// exactly one place to call and cannot reintroduce the balance drift the whole
+/// refactor removes.
+///
+/// Scope: every `lib/**/*.dart` except the seam file itself, generated
+/// `*.g.dart`, and files carrying a `// crate-seam-exempt-file:` marker — the
+/// sync engine (restores cloud-authoritative rows on pull, not user movements)
+/// and `app_database.dart` (crate writes there are DDL / append-only triggers /
+/// the v63 opening-balance seed / clearAllData — table lifecycle, not
+/// movements). A single line may opt out with a `// crate-seam-exempt:` marker
+/// for a documented one-off.
+///
+/// Modeled on `test/sync/sync_raw_write_leak_test.dart`.
+void main() {
+  const seamFile = 'lib/core/database/daos_crates.dart';
+
+  // The six crate tables — SQL names + their Drift table getters.
+  const crateSqlTables = {
+    'crate_ledger',
+    'supplier_crate_ledger',
+    'customer_crate_balances',
+    'manufacturer_crate_balances',
+    'store_crate_balances',
+    'supplier_crate_balances',
+  };
+  const crateGetters = {
+    'crateLedger',
+    'supplierCrateLedger',
+    'customerCrateBalances',
+    'manufacturerCrateBalances',
+    'storeCrateBalances',
+    'supplierCrateBalances',
+  };
+
+  // Builder writes: into(t) / update(t) / delete(t), optionally db.-/_db.-qualified.
+  final builderWrite =
+      RegExp(r'\b(?:into|update|delete)\(\s*(?:_?db\.)?(\w+)\s*\)');
+  // Raw-SQL writes to a crate table.
+  final sqlWrite = RegExp(r'(?:INSERT\s+INTO|UPDATE|DELETE\s+FROM)\s+(\w+)');
+  // A SET on the physical-pool scalar (a movement). Manufacturer *creation* via
+  // a companion insert (`emptyCrateStock:`) is allowed — only the `= ...` SET
+  // form is a mutation.
+  final scalarMutation = RegExp(r'empty_crate_stock\s*=');
+  // The Drift-builder form of a scalar mutation: a BARE `ManufacturersCompanion(`
+  // — the update companion, distinct from `ManufacturersCompanion.insert(`
+  // (creation, allowed) — that sets `emptyCrateStock`. Matched against the whole
+  // source (the companion spans lines), so a future
+  // `update(manufacturers).write(ManufacturersCompanion(emptyCrateStock: …))`
+  // outside the seam is caught, not just the raw-SQL form.
+  final updateCompanion = RegExp(r'ManufacturersCompanion\(');
+
+  test('no crate table (or the empty_crate_stock scalar) is written outside the '
+      'seam', () {
+    final leaks = <String>[];
+    for (final file in _dartFilesUnder('lib')) {
+      final path = file.path;
+      if (path.endsWith('.g.dart')) continue;
+      if (path == seamFile) continue;
+      final src = file.readAsStringSync();
+      if (src.contains('// crate-seam-exempt-file:')) continue;
+
+      final lines = src.split('\n');
+      for (var i = 0; i < lines.length; i++) {
+        final line = lines[i];
+        final trimmed = line.trimLeft();
+        // Skip comment lines (a doc/inline comment naming a crate table is not a
+        // write) — but the exempt marker itself is honored first.
+        if (line.contains('// crate-seam-exempt:')) continue;
+        if (trimmed.startsWith('//') || trimmed.startsWith('*')) continue;
+
+        for (final m in builderWrite.allMatches(line)) {
+          if (crateGetters.contains(m.group(1))) {
+            leaks.add('$path:${i + 1}  builder write to "${m.group(1)}"');
+          }
+        }
+        for (final m in sqlWrite.allMatches(line)) {
+          if (crateSqlTables.contains(m.group(1))) {
+            leaks.add('$path:${i + 1}  raw-SQL write to "${m.group(1)}"');
+          }
+        }
+        if (scalarMutation.hasMatch(line)) {
+          leaks.add(
+            '$path:${i + 1}  mutation of manufacturers.empty_crate_stock',
+          );
+        }
+      }
+
+      // Builder-form scalar mutation: a bare update companion that sets the
+      // scalar. Scanned over the whole source since the companion spans lines.
+      for (final m in updateCompanion.allMatches(src)) {
+        final window = src.substring(
+          m.start,
+          (m.start + 250).clamp(0, src.length),
+        );
+        if (window.contains('emptyCrateStock')) {
+          final lineNo = '\n'.allMatches(src.substring(0, m.start)).length + 1;
+          leaks.add(
+            '$path:$lineNo  builder mutation of manufacturers.empty_crate_stock '
+            '(update companion)',
+          );
+        }
+      }
+    }
+
+    expect(
+      leaks,
+      isEmpty,
+      reason:
+          'Crate write(s) outside the CratePoolDao seam ($seamFile). Route the '
+          'movement through a CratePoolDao domain verb — or, for a documented '
+          'non-movement, add a `// crate-seam-exempt:` line marker (or '
+          '`// crate-seam-exempt-file:` for a whole infra file):\n  '
+          '${leaks.join('\n  ')}',
+    );
+  });
+}
+
+List<File> _dartFilesUnder(String dir) {
+  final d = Directory(dir);
+  if (!d.existsSync()) return const [];
+  return d
+      .listSync(recursive: true)
+      .whereType<File>()
+      .where((f) => f.path.endsWith('.dart'))
+      .toList();
+}

--- a/test/sync/dispatch/crate_ledger_dao_dispatch_test.dart
+++ b/test/sync/dispatch/crate_ledger_dao_dispatch_test.dart
@@ -68,7 +68,7 @@ void main() {
           on: false);
       final fx = await _seedCrateFixtures(db, businessId);
 
-      await db.crateLedgerDao.recordCrateReturnByCustomer(
+      await db.cratePoolDao.recordCrateReturnByCustomer(
         customerId: fx.customerId,
         manufacturerId: fx.manufacturerId,
         quantity: 5,
@@ -95,7 +95,7 @@ void main() {
       await setFlag(db, 'feature.domain_rpcs_v2.record_crate_return', on: true);
       final fx = await _seedCrateFixtures(db, businessId);
 
-      await db.crateLedgerDao.recordCrateReturnByCustomer(
+      await db.cratePoolDao.recordCrateReturnByCustomer(
         customerId: fx.customerId,
         manufacturerId: fx.manufacturerId,
         quantity: 3,
@@ -150,7 +150,7 @@ void main() {
             ),
           );
 
-      await db.crateLedgerDao.recordCrateReturnByCustomer(
+      await db.cratePoolDao.recordCrateReturnByCustomer(
         customerId: fx.customerId,
         manufacturerId: fx.manufacturerId,
         quantity: 1,
@@ -170,7 +170,7 @@ void main() {
           on: false);
       final fx = await _seedCrateFixtures(db, businessId);
 
-      await db.crateLedgerDao.recordCrateReturnByManufacturer(
+      await db.cratePoolDao.recordCrateReturnByManufacturer(
         manufacturerId: fx.manufacturerId,
         quantity: 7,
         performedBy: fx.staffId,
@@ -192,7 +192,7 @@ void main() {
       await setFlag(db, 'feature.domain_rpcs_v2.record_crate_return', on: true);
       final fx = await _seedCrateFixtures(db, businessId);
 
-      await db.crateLedgerDao.recordCrateReturnByManufacturer(
+      await db.cratePoolDao.recordCrateReturnByManufacturer(
         manufacturerId: fx.manufacturerId,
         quantity: 4,
         performedBy: fx.staffId,


### PR DESCRIPTION
Closes #157 — first slice of the crate-pool ledger-as-truth refactor (PRD #156, ADR **0020**).

**Behavior-preserving prefactor.** The balance caches are still written exactly as before, so nothing the user sees changes. This slice only centralizes the writes, completes the ledger, and seeds opening balances so the later derive slices (#158–#160) don't zero out existing counts.

## What changed
- **The seam.** `CrateLedgerDao` → **`CratePoolDao`** (`daos_crates.dart`) is now the **sole writer** of the six crate tables (`crate_ledger`, `supplier_crate_ledger`, the four `*_crate_balances`) and the `manufacturers.empty_crate_stock` scalar. It absorbed the supplier-crate write path, the physical-pool verbs (`addEmptiesToPool` / `recordDamage` / `recordManualCountCorrection`, from `InventoryDao`) and the store-transfer legs (`transferBetweenStores`, from `StockTransferDao`). Every former writer (Inventory, `SupplierCrateLedgerDao`, `StockTransferDao`, `CrateReturnApprovalService`, checkout / confirm / receive / customer-return) is now a thin delegator — public method names kept, so callers and the existing crate test suite are unchanged. Accessor renamed `crateLedgerDao` → `cratePoolDao`.
- **Ledger completeness.** A manual "set to N" records a reconciling **delta** row (N − current); a store-less `addEmptyCrates`/damage now writes a row too.
- **Migration (Drift v62→v63).** Data-only `_seedCrateOpeningLedger()` appends one reconciling opening row per non-zero crate cache so `SUM(quantity_delta)` == the displayed count at cutover. **Local-only** (a migration write never enqueues; every device seeds from its own caches — pushing would double-count). No cloud migration.
- **Guard.** `test/crates/crate_seam_ban_test.dart` fails the build if any crate-table write or `empty_crate_stock` mutation (raw-SQL **or** the `ManufacturersCompanion` builder form) appears outside the seam.
- **Docs.** ADR `0020-crate-pool-ledger-as-truth`; CONTEXT.md `### Crates` glossary; progress-tracker + BUILD_LOG.

## Verification
- `flutter analyze` **0/0**; full suite **979 pass / 110 skip** (the 1 failure, `who_is_working_screen_test`, is pre-existing — confirmed at base with changes stashed).
- New `crate_pool_seam_test` (5, incl. the real v62→v63 seed proving `SUM==cache`) + ban test green; existing crate/wallet/supplier/dispatch suites (77) pass unchanged.
- Two-axis review: no hard standards violations; spec-faithful (all 8 verbs routed, seed filters correct). The one finding (ban test missed the builder-form scalar mutation) is fixed in this PR.

## Out of scope (noted, not fixed)
`StockTransferDao.cancelTransfer` restores product stock but not crate legs (pre-existing gap); `recordCrateReceiveFromManufacturer` is dead; `manufacturer_crate_balances` and the scalar remain two disjoint business-side tallies — unifying and deriving the pool is #159.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved crate and empty-container tracking across customer returns, supplier receipts, store transfers, damage, and manual adjustments.
  * Crate balances now maintain a more complete movement history, including store-less actions and count corrections.
  * Existing crate balances are preserved and reconciled during app upgrades.
  * Improved consistency of crate balances across stores, suppliers, manufacturers, and customers.
* **Testing**
  * Added coverage for crate movements, balance reconciliation, migrations, and data integrity safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->