### PR TITLE
feat(money): payments compensating-row seam + sync/schema plumbing (#169)

### DIFF
--- a/CONTEXT/architecture.md
+++ b/CONTEXT/architecture.md
@@ -165,9 +165,11 @@ Each chunk has a 15 s timeout. On a timeout the chunk size is halved; after 3 co
 > auto-retried.
 
 > **Append-only ledger rule:** for `payment_transactions`, `wallet_transactions`,
-> and `supplier_ledger_entries`, void re-pushes drop `created_at` at the push
-> boundary (`_ledgerCreatedAtScrubTables`) because the cloud owns it and treats
-> it as immutable. See `[[project_ledger_void_created_at_scrub]]`.
+> `supplier_ledger_entries`, and — since #169 (preemptively) — `crate_ledger`
+> and `supplier_crate_ledger`, void re-pushes drop `created_at` at the push
+> boundary (`_ledgerCreatedAtScrubTables`, derived from the registry's
+> `scrubCreatedAt` flag) because the cloud owns it and treats it as immutable.
+> See `[[project_ledger_void_created_at_scrub]]`.
 
 > **Not implemented:** there is currently no push Edge Function, no server-side
 > `413 Payload Too Large` cap, and no `sync_audit_rejected` operator table. An

--- a/CONTEXT/progress-tracker.md
+++ b/CONTEXT/progress-tracker.md
@@ -10,6 +10,56 @@ The human updates it when resolving open questions or making architectural decis
 
 152 sessions logged. Codebase is live and being verified on-device.
 
+### Money integrity #1 (#169) — payments compensating-row seam + sync/schema plumbing (prefactor) — CODE-COMPLETE (2026-07-24)
+Root prefactor of the #155 money-integrity PRD (ADR **0021**). Behavior-preserving:
+introduces the seam + schema/flag plumbing every later correction slice depends on,
+with NO user-visible flow change. Branch `feat/money-integrity-1-payments-seam` off
+`main` (HEAD 757a18e).
+- **The seam.** New `PaymentTransactionsDao.postReversalPayment` (part file
+  `daos_payments.dart`, registered in the `@DriftDatabase` daos list) posts a DATED
+  compensating `payment_transactions` row: the ORIGINAL row is left untouched, the
+  reversal lands on its OWN `created_at` day (the correction day), copies the
+  original's single typed reference (so the exactly-one CHECK holds), inherits/
+  overrides `store_id`, and enqueues for sync. Legacy in-place void columns stay
+  read-only. The correction paths (cancel / expense reject-delete / top-up void) are
+  wired to CALL it in later slices — this prefactor only introduces the verb.
+- **Schema (Drift v63→**v64**, cloud `0153_money_integrity_payments_seam.sql`).**
+  `payment_transactions` gains nullable `store_id` (stamped on new sale / expense /
+  crate-refund rows; joins the ledger immutable-column set); `orders` gains nullable
+  `confirmed_by` (unused until #171); the payment-type CHECK is widened via the
+  established constraint-migration pattern (rebuild locally, DROP+re-add CHECK on
+  cloud) to add the deposit-distinct **`crate_deposit`** type (unused until #175).
+  The new type CHECK string:
+  `CHECK (type IN ('sale','purchase','expense','refund','wallet_topup','crate_deposit'))`.
+  All `*_kobo` columns stay bigint. v64 addColumn(store_id) BEFORE the TableMigration
+  rebuild (else drift fills the new column with the literal name), then recreates the
+  two indexes + three triggers (bump + immutable + no-delete). Cloud re-bakes the
+  payment append-only trigger so `store_id` is immutable there too.
+- **scrubCreatedAt for the crate ledgers.** `crate_ledger` + `supplier_crate_ledger`
+  were NOT previously flagged (only wallet / supplier-ledger / payment were) — ADDED
+  `scrubCreatedAt: true` in `sync_registry.dart`, closing the latent void-push P0001
+  orphan trap before any crate-void feature ships. Golden test's frozen scrub set
+  widened to match.
+- **Cash-flow day-basis invariant (no-op today).** Verified the reconciliation
+  cash-flow summary already counts each payment row on its OWN `created_at` day
+  (`inSpan(p.createdAt)`), and no report sums cash by sale-day — the invariant the
+  correction slices rely on. Comment updated; no code change needed.
+- **Tests (TDD).** `test/payments/reversal_payment_seam_test.dart` (3: original
+  untouched + lands on own day; enqueued as upsert; store/amount overridable);
+  `test/database/migration_upgrade_test.dart` v63→v64 (confirmed_by + store_id added,
+  widened CHECK admits crate_deposit, legacy row store_id NULL, triggers/indexes
+  recreated, store_id now immutable); `test/sync/normalize_payload_whitelist_test.dart`
+  crate-ledger + supplier-crate-ledger void re-push drops created_at.
+- **Verification.** `flutter analyze` clean (0/0 project-wide). Full `flutter test` =
+  **1023 pass / 110 skip / 1 fail** — the lone failure `who_is_working_screen_test` is
+  the pre-existing environmental Supabase-400 flake (auth code untouched here).
+- **Deviations / follow-ups.** `store_id` is stamped where a store is trivially in
+  scope (sale / expense / crate-refund payment rows + the seam); the wallet top-up
+  path (`CreditLedgerService.topUp/recordRepayment`) has NO store param today, so
+  those new rows stay `store_id`-null (still valid → business-wide) until a later
+  slice threads store context — a feature-layer change out of this prefactor's scope.
+  DO NOT push/deploy the cloud migration; the orchestrator sequences merge/deploy.
+
 ### Crate pool #6 (#163) — net-position honesty (subtract held deposits + supplier debt) — CODE-COMPLETE (2026-07-24)
 Sixth slice of the crate-pool ledger-as-truth refactor (PRD #156, ADR 0020).
 Branch `feat/crate-pool-net-position-honesty` off `feat/crate-pool-cancel-completes-ledger`

--- a/docs/adr/0021-money-integrity-compensating-rows-and-day-close.md
+++ b/docs/adr/0021-money-integrity-compensating-rows-and-day-close.md
@@ -1,0 +1,103 @@
+# Money corrections are compensating rows; a reviewed day is a persisted snapshot
+
+**Status:** accepted (2026-07-24)
+
+The shop owner cannot follow their money because the app's money records and the
+physical reality drift apart during normal use, with no durable trace of when or
+why:
+
+- A refund makes cash leave the till **today**, but the app records nothing
+  today — it voids the original sale's payment row in place, silently shrinking a
+  past day the owner may have already reviewed and banked against. The
+  reconciliation's "Refunds" figure reads an order status nothing ever writes, so
+  it shows ₦0 forever.
+- Rejected and deleted expenses keep draining cash forever because their payment
+  records are never reversed; a mistyped customer repayment can only be
+  "corrected" by fabricating an offsetting sale.
+- Every past day's report is **recomputed live** and mutates under late syncs,
+  cancels, and backdated entries, with no record that it changed.
+
+The full evidence trail is `MONEY_FLOW_AUDIT.md` (§8 Alternatives A/B/C, §10) and
+its crate companion `CRATE_TRACKING_AUDIT.md`; the parent PRD is #155.
+
+The codebase already proves the fix elsewhere. The customer wallet and supplier
+ledgers are **append-only**: a balance is derived by summing signed rows, and a
+correction is a **new compensating row**, never an in-place edit (architecture
+invariant #3). This makes those balances conflict-free under sync and gives every
+figure a durable row to trace to. ADR 0020 extended the same discipline to the
+crate pool.
+
+## Decision
+
+**1. Every money correction is a dated compensating `payment_transactions` row —
+the payment ledger becomes append-only in practice.** Cancelling a sale, rejecting
+or deleting an expense, and voiding a customer top-up each post a NEW reversal row
+through one shared seam (`PaymentTransactionsDao.postReversalPayment`) instead of
+mutating the original row. The seam:
+
+- leaves the original row **untouched**,
+- lands the reversal on its **own `created_at` day** (the correction day),
+- copies the original's single typed reference (order / shipment / expense /
+  wallet_txn / delivery) so the exactly-one-reference CHECK holds, and
+- stamps a nullable `store_id`.
+
+The legacy in-place void columns (`voided_at` / `voided_by` / `void_reason`) are
+retained **read-only for rows written before this discipline**. Cash-flow
+reporting counts every payment row on its **own `created_at` day** — so a
+later-cancelled sale's cash stays on its original day and the cancel's refund row
+lands on the cancel day. A day the owner already banked against never changes
+behind their back, and the reconciliation's Refunds figure derives from real
+refund rows rather than an order status.
+
+This ADR (issue #169) is the **behavior-preserving prefactor**: it introduces the
+seam and the schema/flag plumbing without changing any user-visible flow. The
+correction paths are wired to call the seam in the follow-on slices.
+
+**2. A reviewed day is a persisted snapshot (deferred to its own slice, decided
+here).** The first time a permitted user opens a finished day's detail, the
+computed figure set is frozen as a synced `daily_closings` row (one per business ×
+calendar day, natural-key first-writer-wins). The report thereafter renders live
+figures alongside the snapshot with a per-card delta badge when they diverge —
+**silent history mutation becomes visible history mutation.** The snapshot is
+purely observational; no money flow changes. This implements the option ADR 0014
+deferred. (The table and UI land in a later slice; this ADR records the decision
+so the prefactor's schema/sync groundwork is coherent.)
+
+## Schema & sync plumbing landed by the prefactor (#169)
+
+- `payment_transactions` gains a nullable `store_id`, stamped on all new rows
+  (sale / expense / crate-refund paths + the reversal seam); legacy rows stay
+  null and report business-wide as today. It joins the payment ledger's
+  immutable-column set (fixed at insert).
+- `orders` gains a nullable `confirmed_by` (unused until #171, which stops
+  Confirm overwriting `staff_id` — keeping the sale attributed to the seller).
+- The `payment_transactions.type` CHECK is widened (established
+  constraint-migration pattern) to add a **deposit-distinct `crate_deposit`**
+  type (unused until #175), so a refundable crate deposit can be excluded from
+  "Cash sales".
+- All `*_kobo` columns remain `bigint` on the cloud.
+- `crate_ledger` and `supplier_crate_ledger` get the `scrubCreatedAt` registry
+  flag **preemptively**, dropping `created_at` on every push so a future void
+  re-push cannot trip the immutable-column trigger (P0001) and orphan the row —
+  closing the trap before any crate-void feature ships.
+
+Drift `schemaVersion` 63 → 64; cloud migration
+`0153_money_integrity_payments_seam.sql`.
+
+## Consequences
+
+- Money reports read like a ledger: every naira traces to a durable row, and a
+  correction is a visible entry rather than a retroactive edit — disputes can be
+  settled from the record.
+- Reversals sync conflict-free (append-only, id-keyed), exactly like the wallet.
+- The prefactor is inert on its own: no correction path calls the seam yet, no
+  new type/flow is exercised, and no report reads `store_id` or `confirmed_by` —
+  so the recon and payments suites stay green with identical figures.
+
+## Alternatives rejected
+
+- **A single money-events / full double-entry journal.** The long-term direction,
+  but a large migration; this decision converges toward it (append-only,
+  derived, compensating) without the rewrite. (PRD #155 "Out of scope".)
+- **A counted cash drawer / opening float.** Hard Rule #8 stands; the fix makes
+  the *recorded* flows complete and immutable instead of introducing a float.

--- a/lib/core/database/app_database.dart
+++ b/lib/core/database/app_database.dart
@@ -967,6 +967,11 @@ class Orders extends Table {
   TextColumn get barcode => text().nullable()();
   TextColumn get staffId => text().nullable().references(Users, #id)();
   TextColumn get storeId => text().nullable().references(Stores, #id)();
+  // Who tapped Confirm, recorded separately from [staffId] (the seller) so
+  // best-staff / commission figures stay attributed to the seller (#169 lands
+  // the column; #171 stops Confirm overwriting staffId and starts stamping it).
+  // Nullable; unused until #171. Mirrors 0153_money_integrity_payments_seam.sql.
+  TextColumn get confirmedBy => text().nullable().references(Users, #id)();
   IntColumn get crateDepositPaidKobo =>
       integer().withDefault(const Constant(0))();
   DateTimeColumn get completedAt => dateTime().nullable()();
@@ -1237,6 +1242,11 @@ class PendingCrateReturns extends Table {
 class PaymentTransactions extends Table {
   TextColumn get id => text().clientDefault(() => UuidV7.generate())();
   TextColumn get businessId => text().references(Businesses, #id)();
+  // Nullable store where this tender happened (#169 / PRD #155). Stamped on all
+  // NEW rows; legacy rows stay null and report business-wide exactly as before.
+  // The cash-flow reconciliation does not yet filter on it (a later slice does),
+  // so adding it is behavior-preserving.
+  TextColumn get storeId => text().nullable().references(Stores, #id)();
   IntColumn get amountKobo => integer()();
   TextColumn get method => text()();
   TextColumn get type => text()();
@@ -1261,7 +1271,14 @@ class PaymentTransactions extends Table {
   @override
   List<String> get customConstraints => [
     "CHECK (method IN ('cash','transfer','card','wallet','pos','other'))",
-    "CHECK (type IN ('sale','purchase','expense','refund','wallet_topup'))",
+    // #169 widened the type CHECK to admit the deposit-distinct `crate_deposit`
+    // type (unused until #175 / PRD #155): a refundable crate deposit is its own
+    // money type so it can be excluded from "Cash sales". Widening a CHECK is a
+    // runtime-resolved change (customConstraints is not baked into the generated
+    // code); existing installs rebuild the table under the new CHECK via the
+    // schemaVersion 64 upgrade step. Mirrors 0153_money_integrity_payments_seam.sql.
+    "CHECK (type IN "
+        "('sale','purchase','expense','refund','wallet_topup','crate_deposit'))",
     '''CHECK (
           (CASE WHEN order_id IS NOT NULL THEN 1 ELSE 0 END) +
           (CASE WHEN shipment_id IS NOT NULL THEN 1 ELSE 0 END) +
@@ -1784,6 +1801,7 @@ class MigrationEvents extends Table {
     InventoryDao,
     CostBatchesDao,
     OrdersDao,
+    PaymentTransactionsDao,
     CustomersDao,
     ShipmentsDao,
     ExpensesDao,
@@ -1857,7 +1875,7 @@ class AppDatabase extends _$AppDatabase {
   String? get currentAuthUserId => authUserIdResolver();
 
   @override
-  int get schemaVersion => 63;
+  int get schemaVersion => 64;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -4066,6 +4084,76 @@ class AppDatabase extends _$AppDatabase {
         // across devices (ADR 0020).
         await _seedCrateOpeningLedger();
       }
+      if (from < 64) {
+        // v64 (#169 money-integrity prefactor, PRD #155). Mirrors
+        // supabase/migrations/0153_money_integrity_payments_seam.sql.
+        //
+        // (1) orders.confirmed_by — the staff who tapped Confirm, recorded
+        //     separately from the seller (staff_id). Nullable, unused until
+        //     #171. Simple add-column (no CHECK/NOT NULL change on orders).
+        //     Idempotency guard for a DB stepped back to < 64 by the
+        //     revert-then-re-upgrade tests (same pattern as v59/v60).
+        final hasConfirmedBy = await customSelect(
+          "SELECT 1 FROM pragma_table_info('orders') "
+          "WHERE name = 'confirmed_by'",
+        ).get();
+        if (hasConfirmedBy.isEmpty) {
+          await m.addColumn(orders, orders.confirmedBy);
+        }
+
+        // (2) payment_transactions.store_id (nullable) + widen the type CHECK to
+        //     admit the deposit-distinct `crate_deposit` type. SQLite can't ALTER
+        //     a CHECK in place, so rebuild the table from the current Drift schema
+        //     (which now carries store_id AND the 6-value type CHECK) and copy
+        //     every row 1:1. WIDENING the CHECK keeps every existing sale/refund/
+        //     expense/wallet_topup row valid, and store_id is a new NULLABLE
+        //     column, so the copy never fails — no backfill, legacy rows stay
+        //     null. drift's alterTable re-applies the table's EXISTING indexes;
+        //     DROP-then-CREATE each AFTER the rebuild to stay idempotent (same
+        //     fix as the v29/v61 rebuilds). Triggers are NOT re-applied by
+        //     alterTable, so DROP IF EXISTS + CREATE the two append-only ledger
+        //     triggers (immutable + no-delete, now guarding store_id too) and the
+        //     last_updated_at bump trigger — emitting the immutable trigger from
+        //     the single `_ledgerTables` source so it can't drift from onCreate.
+        await m.alterTable(TableMigration(paymentTransactions));
+        await customStatement(
+          'DROP INDEX IF EXISTS idx_payment_transactions_business_lua',
+        );
+        await customStatement(
+          'CREATE INDEX idx_payment_transactions_business_lua '
+          'ON payment_transactions (business_id, last_updated_at)',
+        );
+        await customStatement(
+          'DROP INDEX IF EXISTS idx_payment_txn_business_type',
+        );
+        await customStatement(
+          'CREATE INDEX idx_payment_txn_business_type '
+          'ON payment_transactions (business_id, type, created_at)',
+        );
+        await customStatement(
+          'DROP TRIGGER IF EXISTS bump_payment_transactions_last_updated_at',
+        );
+        await customStatement(
+          'CREATE TRIGGER bump_payment_transactions_last_updated_at '
+          'AFTER UPDATE ON payment_transactions '
+          'FOR EACH ROW '
+          'WHEN OLD.last_updated_at IS NEW.last_updated_at '
+          'BEGIN '
+          "UPDATE payment_transactions SET last_updated_at = CAST(strftime('%s', 'now') AS INTEGER) WHERE id = OLD.id; "
+          'END',
+        );
+        await customStatement(
+          'DROP TRIGGER IF EXISTS payment_transactions_immutable',
+        );
+        await customStatement(
+          'DROP TRIGGER IF EXISTS payment_transactions_no_delete',
+        );
+        for (final stmt in _ledgerTriggerStatements(
+          _ledgerTables.firstWhere((l) => l.table == 'payment_transactions'),
+        )) {
+          await customStatement(stmt);
+        }
+      }
     },
     beforeOpen: (details) async {
       await customStatement('PRAGMA foreign_keys = ON');
@@ -4609,6 +4697,7 @@ const List<_LedgerImmutability> _ledgerTables = [
   _LedgerImmutability('payment_transactions', [
     'id',
     'business_id',
+    'store_id',
     'amount_kobo',
     'method',
     'type',

--- a/lib/core/database/app_database.dart
+++ b/lib/core/database/app_database.dart
@@ -4102,19 +4102,30 @@ class AppDatabase extends _$AppDatabase {
         }
 
         // (2) payment_transactions.store_id (nullable) + widen the type CHECK to
-        //     admit the deposit-distinct `crate_deposit` type. SQLite can't ALTER
-        //     a CHECK in place, so rebuild the table from the current Drift schema
-        //     (which now carries store_id AND the 6-value type CHECK) and copy
+        //     admit the deposit-distinct `crate_deposit` type.
+        //
+        //     First ADD the store_id column (guarded), so the rebuild below can
+        //     copy it 1:1 — drift's TableMigration needs a new column to already
+        //     exist on the old table (or a columnTransformer), else it fills the
+        //     column with the literal column name. Legacy rows get NULL.
+        final hasPayStore = await customSelect(
+          "SELECT 1 FROM pragma_table_info('payment_transactions') "
+          "WHERE name = 'store_id'",
+        ).get();
+        if (hasPayStore.isEmpty) {
+          await m.addColumn(paymentTransactions, paymentTransactions.storeId);
+        }
+        //     SQLite can't ALTER a CHECK in place, so rebuild the table from the
+        //     current Drift schema (store_id + the 6-value type CHECK) and copy
         //     every row 1:1. WIDENING the CHECK keeps every existing sale/refund/
-        //     expense/wallet_topup row valid, and store_id is a new NULLABLE
-        //     column, so the copy never fails — no backfill, legacy rows stay
-        //     null. drift's alterTable re-applies the table's EXISTING indexes;
-        //     DROP-then-CREATE each AFTER the rebuild to stay idempotent (same
-        //     fix as the v29/v61 rebuilds). Triggers are NOT re-applied by
-        //     alterTable, so DROP IF EXISTS + CREATE the two append-only ledger
-        //     triggers (immutable + no-delete, now guarding store_id too) and the
-        //     last_updated_at bump trigger — emitting the immutable trigger from
-        //     the single `_ledgerTables` source so it can't drift from onCreate.
+        //     expense/wallet_topup row valid, so the copy never fails. drift's
+        //     alterTable re-applies the table's EXISTING indexes; DROP-then-CREATE
+        //     each AFTER the rebuild to stay idempotent (same fix as the v29/v61
+        //     rebuilds). Triggers are NOT re-applied by alterTable, so DROP IF
+        //     EXISTS + CREATE the two append-only ledger triggers (immutable +
+        //     no-delete, now guarding store_id too) and the last_updated_at bump
+        //     trigger — emitting the immutable trigger from the single
+        //     `_ledgerTables` source so it can't drift from onCreate.
         await m.alterTable(TableMigration(paymentTransactions));
         await customStatement(
           'DROP INDEX IF EXISTS idx_payment_transactions_business_lua',

--- a/lib/core/database/app_database.g.dart
+++ b/lib/core/database/app_database.g.dart
@@ -11100,6 +11100,20 @@ class $OrdersTable extends Orders with TableInfo<$OrdersTable, OrderData> {
       'REFERENCES stores (id)',
     ),
   );
+  static const VerificationMeta _confirmedByMeta = const VerificationMeta(
+    'confirmedBy',
+  );
+  @override
+  late final GeneratedColumn<String> confirmedBy = GeneratedColumn<String>(
+    'confirmed_by',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'REFERENCES users (id)',
+    ),
+  );
   static const VerificationMeta _crateDepositPaidKoboMeta =
       const VerificationMeta('crateDepositPaidKobo');
   @override
@@ -11175,6 +11189,7 @@ class $OrdersTable extends Orders with TableInfo<$OrdersTable, OrderData> {
     barcode,
     staffId,
     storeId,
+    confirmedBy,
     crateDepositPaidKobo,
     completedAt,
     cancelledAt,
@@ -11313,6 +11328,15 @@ class $OrdersTable extends Orders with TableInfo<$OrdersTable, OrderData> {
         storeId.isAcceptableOrUnknown(data['store_id']!, _storeIdMeta),
       );
     }
+    if (data.containsKey('confirmed_by')) {
+      context.handle(
+        _confirmedByMeta,
+        confirmedBy.isAcceptableOrUnknown(
+          data['confirmed_by']!,
+          _confirmedByMeta,
+        ),
+      );
+    }
     if (data.containsKey('crate_deposit_paid_kobo')) {
       context.handle(
         _crateDepositPaidKoboMeta,
@@ -11424,6 +11448,10 @@ class $OrdersTable extends Orders with TableInfo<$OrdersTable, OrderData> {
         DriftSqlType.string,
         data['${effectivePrefix}store_id'],
       ),
+      confirmedBy: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}confirmed_by'],
+      ),
       crateDepositPaidKobo: attachedDatabase.typeMapping.read(
         DriftSqlType.int,
         data['${effectivePrefix}crate_deposit_paid_kobo'],
@@ -11469,6 +11497,7 @@ class OrderData extends DataClass implements Insertable<OrderData> {
   final String? barcode;
   final String? staffId;
   final String? storeId;
+  final String? confirmedBy;
   final int crateDepositPaidKobo;
   final DateTime? completedAt;
   final DateTime? cancelledAt;
@@ -11490,6 +11519,7 @@ class OrderData extends DataClass implements Insertable<OrderData> {
     this.barcode,
     this.staffId,
     this.storeId,
+    this.confirmedBy,
     required this.crateDepositPaidKobo,
     this.completedAt,
     this.cancelledAt,
@@ -11523,6 +11553,9 @@ class OrderData extends DataClass implements Insertable<OrderData> {
     }
     if (!nullToAbsent || storeId != null) {
       map['store_id'] = Variable<String>(storeId);
+    }
+    if (!nullToAbsent || confirmedBy != null) {
+      map['confirmed_by'] = Variable<String>(confirmedBy);
     }
     map['crate_deposit_paid_kobo'] = Variable<int>(crateDepositPaidKobo);
     if (!nullToAbsent || completedAt != null) {
@@ -11563,6 +11596,9 @@ class OrderData extends DataClass implements Insertable<OrderData> {
       storeId: storeId == null && nullToAbsent
           ? const Value.absent()
           : Value(storeId),
+      confirmedBy: confirmedBy == null && nullToAbsent
+          ? const Value.absent()
+          : Value(confirmedBy),
       crateDepositPaidKobo: Value(crateDepositPaidKobo),
       completedAt: completedAt == null && nullToAbsent
           ? const Value.absent()
@@ -11598,6 +11634,7 @@ class OrderData extends DataClass implements Insertable<OrderData> {
       barcode: serializer.fromJson<String?>(json['barcode']),
       staffId: serializer.fromJson<String?>(json['staffId']),
       storeId: serializer.fromJson<String?>(json['storeId']),
+      confirmedBy: serializer.fromJson<String?>(json['confirmedBy']),
       crateDepositPaidKobo: serializer.fromJson<int>(
         json['crateDepositPaidKobo'],
       ),
@@ -11626,6 +11663,7 @@ class OrderData extends DataClass implements Insertable<OrderData> {
       'barcode': serializer.toJson<String?>(barcode),
       'staffId': serializer.toJson<String?>(staffId),
       'storeId': serializer.toJson<String?>(storeId),
+      'confirmedBy': serializer.toJson<String?>(confirmedBy),
       'crateDepositPaidKobo': serializer.toJson<int>(crateDepositPaidKobo),
       'completedAt': serializer.toJson<DateTime?>(completedAt),
       'cancelledAt': serializer.toJson<DateTime?>(cancelledAt),
@@ -11650,6 +11688,7 @@ class OrderData extends DataClass implements Insertable<OrderData> {
     Value<String?> barcode = const Value.absent(),
     Value<String?> staffId = const Value.absent(),
     Value<String?> storeId = const Value.absent(),
+    Value<String?> confirmedBy = const Value.absent(),
     int? crateDepositPaidKobo,
     Value<DateTime?> completedAt = const Value.absent(),
     Value<DateTime?> cancelledAt = const Value.absent(),
@@ -11673,6 +11712,7 @@ class OrderData extends DataClass implements Insertable<OrderData> {
     barcode: barcode.present ? barcode.value : this.barcode,
     staffId: staffId.present ? staffId.value : this.staffId,
     storeId: storeId.present ? storeId.value : this.storeId,
+    confirmedBy: confirmedBy.present ? confirmedBy.value : this.confirmedBy,
     crateDepositPaidKobo: crateDepositPaidKobo ?? this.crateDepositPaidKobo,
     completedAt: completedAt.present ? completedAt.value : this.completedAt,
     cancelledAt: cancelledAt.present ? cancelledAt.value : this.cancelledAt,
@@ -11714,6 +11754,9 @@ class OrderData extends DataClass implements Insertable<OrderData> {
       barcode: data.barcode.present ? data.barcode.value : this.barcode,
       staffId: data.staffId.present ? data.staffId.value : this.staffId,
       storeId: data.storeId.present ? data.storeId.value : this.storeId,
+      confirmedBy: data.confirmedBy.present
+          ? data.confirmedBy.value
+          : this.confirmedBy,
       crateDepositPaidKobo: data.crateDepositPaidKobo.present
           ? data.crateDepositPaidKobo.value
           : this.crateDepositPaidKobo,
@@ -11748,6 +11791,7 @@ class OrderData extends DataClass implements Insertable<OrderData> {
           ..write('barcode: $barcode, ')
           ..write('staffId: $staffId, ')
           ..write('storeId: $storeId, ')
+          ..write('confirmedBy: $confirmedBy, ')
           ..write('crateDepositPaidKobo: $crateDepositPaidKobo, ')
           ..write('completedAt: $completedAt, ')
           ..write('cancelledAt: $cancelledAt, ')
@@ -11758,7 +11802,7 @@ class OrderData extends DataClass implements Insertable<OrderData> {
   }
 
   @override
-  int get hashCode => Object.hash(
+  int get hashCode => Object.hashAll([
     id,
     businessId,
     orderNumber,
@@ -11774,12 +11818,13 @@ class OrderData extends DataClass implements Insertable<OrderData> {
     barcode,
     staffId,
     storeId,
+    confirmedBy,
     crateDepositPaidKobo,
     completedAt,
     cancelledAt,
     createdAt,
     lastUpdatedAt,
-  );
+  ]);
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
@@ -11799,6 +11844,7 @@ class OrderData extends DataClass implements Insertable<OrderData> {
           other.barcode == this.barcode &&
           other.staffId == this.staffId &&
           other.storeId == this.storeId &&
+          other.confirmedBy == this.confirmedBy &&
           other.crateDepositPaidKobo == this.crateDepositPaidKobo &&
           other.completedAt == this.completedAt &&
           other.cancelledAt == this.cancelledAt &&
@@ -11822,6 +11868,7 @@ class OrdersCompanion extends UpdateCompanion<OrderData> {
   final Value<String?> barcode;
   final Value<String?> staffId;
   final Value<String?> storeId;
+  final Value<String?> confirmedBy;
   final Value<int> crateDepositPaidKobo;
   final Value<DateTime?> completedAt;
   final Value<DateTime?> cancelledAt;
@@ -11844,6 +11891,7 @@ class OrdersCompanion extends UpdateCompanion<OrderData> {
     this.barcode = const Value.absent(),
     this.staffId = const Value.absent(),
     this.storeId = const Value.absent(),
+    this.confirmedBy = const Value.absent(),
     this.crateDepositPaidKobo = const Value.absent(),
     this.completedAt = const Value.absent(),
     this.cancelledAt = const Value.absent(),
@@ -11867,6 +11915,7 @@ class OrdersCompanion extends UpdateCompanion<OrderData> {
     this.barcode = const Value.absent(),
     this.staffId = const Value.absent(),
     this.storeId = const Value.absent(),
+    this.confirmedBy = const Value.absent(),
     this.crateDepositPaidKobo = const Value.absent(),
     this.completedAt = const Value.absent(),
     this.cancelledAt = const Value.absent(),
@@ -11895,6 +11944,7 @@ class OrdersCompanion extends UpdateCompanion<OrderData> {
     Expression<String>? barcode,
     Expression<String>? staffId,
     Expression<String>? storeId,
+    Expression<String>? confirmedBy,
     Expression<int>? crateDepositPaidKobo,
     Expression<DateTime>? completedAt,
     Expression<DateTime>? cancelledAt,
@@ -11918,6 +11968,7 @@ class OrdersCompanion extends UpdateCompanion<OrderData> {
       if (barcode != null) 'barcode': barcode,
       if (staffId != null) 'staff_id': staffId,
       if (storeId != null) 'store_id': storeId,
+      if (confirmedBy != null) 'confirmed_by': confirmedBy,
       if (crateDepositPaidKobo != null)
         'crate_deposit_paid_kobo': crateDepositPaidKobo,
       if (completedAt != null) 'completed_at': completedAt,
@@ -11944,6 +11995,7 @@ class OrdersCompanion extends UpdateCompanion<OrderData> {
     Value<String?>? barcode,
     Value<String?>? staffId,
     Value<String?>? storeId,
+    Value<String?>? confirmedBy,
     Value<int>? crateDepositPaidKobo,
     Value<DateTime?>? completedAt,
     Value<DateTime?>? cancelledAt,
@@ -11967,6 +12019,7 @@ class OrdersCompanion extends UpdateCompanion<OrderData> {
       barcode: barcode ?? this.barcode,
       staffId: staffId ?? this.staffId,
       storeId: storeId ?? this.storeId,
+      confirmedBy: confirmedBy ?? this.confirmedBy,
       crateDepositPaidKobo: crateDepositPaidKobo ?? this.crateDepositPaidKobo,
       completedAt: completedAt ?? this.completedAt,
       cancelledAt: cancelledAt ?? this.cancelledAt,
@@ -12024,6 +12077,9 @@ class OrdersCompanion extends UpdateCompanion<OrderData> {
     if (storeId.present) {
       map['store_id'] = Variable<String>(storeId.value);
     }
+    if (confirmedBy.present) {
+      map['confirmed_by'] = Variable<String>(confirmedBy.value);
+    }
     if (crateDepositPaidKobo.present) {
       map['crate_deposit_paid_kobo'] = Variable<int>(
         crateDepositPaidKobo.value,
@@ -12065,6 +12121,7 @@ class OrdersCompanion extends UpdateCompanion<OrderData> {
           ..write('barcode: $barcode, ')
           ..write('staffId: $staffId, ')
           ..write('storeId: $storeId, ')
+          ..write('confirmedBy: $confirmedBy, ')
           ..write('crateDepositPaidKobo: $crateDepositPaidKobo, ')
           ..write('completedAt: $completedAt, ')
           ..write('cancelledAt: $cancelledAt, ')
@@ -27290,6 +27347,20 @@ class $PaymentTransactionsTable extends PaymentTransactions
       'REFERENCES businesses (id)',
     ),
   );
+  static const VerificationMeta _storeIdMeta = const VerificationMeta(
+    'storeId',
+  );
+  @override
+  late final GeneratedColumn<String> storeId = GeneratedColumn<String>(
+    'store_id',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'REFERENCES stores (id)',
+    ),
+  );
   static const VerificationMeta _amountKoboMeta = const VerificationMeta(
     'amountKobo',
   );
@@ -27468,6 +27539,7 @@ class $PaymentTransactionsTable extends PaymentTransactions
   List<GeneratedColumn> get $columns => [
     id,
     businessId,
+    storeId,
     amountKobo,
     method,
     type,
@@ -27505,6 +27577,12 @@ class $PaymentTransactionsTable extends PaymentTransactions
       );
     } else if (isInserting) {
       context.missing(_businessIdMeta);
+    }
+    if (data.containsKey('store_id')) {
+      context.handle(
+        _storeIdMeta,
+        storeId.isAcceptableOrUnknown(data['store_id']!, _storeIdMeta),
+      );
     }
     if (data.containsKey('amount_kobo')) {
       context.handle(
@@ -27622,6 +27700,10 @@ class $PaymentTransactionsTable extends PaymentTransactions
         DriftSqlType.string,
         data['${effectivePrefix}business_id'],
       )!,
+      storeId: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}store_id'],
+      ),
       amountKobo: attachedDatabase.typeMapping.read(
         DriftSqlType.int,
         data['${effectivePrefix}amount_kobo'],
@@ -27691,6 +27773,7 @@ class PaymentTransactionData extends DataClass
     implements Insertable<PaymentTransactionData> {
   final String id;
   final String businessId;
+  final String? storeId;
   final int amountKobo;
   final String method;
   final String type;
@@ -27708,6 +27791,7 @@ class PaymentTransactionData extends DataClass
   const PaymentTransactionData({
     required this.id,
     required this.businessId,
+    this.storeId,
     required this.amountKobo,
     required this.method,
     required this.type,
@@ -27728,6 +27812,9 @@ class PaymentTransactionData extends DataClass
     final map = <String, Expression>{};
     map['id'] = Variable<String>(id);
     map['business_id'] = Variable<String>(businessId);
+    if (!nullToAbsent || storeId != null) {
+      map['store_id'] = Variable<String>(storeId);
+    }
     map['amount_kobo'] = Variable<int>(amountKobo);
     map['method'] = Variable<String>(method);
     map['type'] = Variable<String>(type);
@@ -27767,6 +27854,9 @@ class PaymentTransactionData extends DataClass
     return PaymentTransactionsCompanion(
       id: Value(id),
       businessId: Value(businessId),
+      storeId: storeId == null && nullToAbsent
+          ? const Value.absent()
+          : Value(storeId),
       amountKobo: Value(amountKobo),
       method: Value(method),
       type: Value(type),
@@ -27810,6 +27900,7 @@ class PaymentTransactionData extends DataClass
     return PaymentTransactionData(
       id: serializer.fromJson<String>(json['id']),
       businessId: serializer.fromJson<String>(json['businessId']),
+      storeId: serializer.fromJson<String?>(json['storeId']),
       amountKobo: serializer.fromJson<int>(json['amountKobo']),
       method: serializer.fromJson<String>(json['method']),
       type: serializer.fromJson<String>(json['type']),
@@ -27832,6 +27923,7 @@ class PaymentTransactionData extends DataClass
     return <String, dynamic>{
       'id': serializer.toJson<String>(id),
       'businessId': serializer.toJson<String>(businessId),
+      'storeId': serializer.toJson<String?>(storeId),
       'amountKobo': serializer.toJson<int>(amountKobo),
       'method': serializer.toJson<String>(method),
       'type': serializer.toJson<String>(type),
@@ -27852,6 +27944,7 @@ class PaymentTransactionData extends DataClass
   PaymentTransactionData copyWith({
     String? id,
     String? businessId,
+    Value<String?> storeId = const Value.absent(),
     int? amountKobo,
     String? method,
     String? type,
@@ -27869,6 +27962,7 @@ class PaymentTransactionData extends DataClass
   }) => PaymentTransactionData(
     id: id ?? this.id,
     businessId: businessId ?? this.businessId,
+    storeId: storeId.present ? storeId.value : this.storeId,
     amountKobo: amountKobo ?? this.amountKobo,
     method: method ?? this.method,
     type: type ?? this.type,
@@ -27890,6 +27984,7 @@ class PaymentTransactionData extends DataClass
       businessId: data.businessId.present
           ? data.businessId.value
           : this.businessId,
+      storeId: data.storeId.present ? data.storeId.value : this.storeId,
       amountKobo: data.amountKobo.present
           ? data.amountKobo.value
           : this.amountKobo,
@@ -27926,6 +28021,7 @@ class PaymentTransactionData extends DataClass
     return (StringBuffer('PaymentTransactionData(')
           ..write('id: $id, ')
           ..write('businessId: $businessId, ')
+          ..write('storeId: $storeId, ')
           ..write('amountKobo: $amountKobo, ')
           ..write('method: $method, ')
           ..write('type: $type, ')
@@ -27948,6 +28044,7 @@ class PaymentTransactionData extends DataClass
   int get hashCode => Object.hash(
     id,
     businessId,
+    storeId,
     amountKobo,
     method,
     type,
@@ -27969,6 +28066,7 @@ class PaymentTransactionData extends DataClass
       (other is PaymentTransactionData &&
           other.id == this.id &&
           other.businessId == this.businessId &&
+          other.storeId == this.storeId &&
           other.amountKobo == this.amountKobo &&
           other.method == this.method &&
           other.type == this.type &&
@@ -27989,6 +28087,7 @@ class PaymentTransactionsCompanion
     extends UpdateCompanion<PaymentTransactionData> {
   final Value<String> id;
   final Value<String> businessId;
+  final Value<String?> storeId;
   final Value<int> amountKobo;
   final Value<String> method;
   final Value<String> type;
@@ -28007,6 +28106,7 @@ class PaymentTransactionsCompanion
   const PaymentTransactionsCompanion({
     this.id = const Value.absent(),
     this.businessId = const Value.absent(),
+    this.storeId = const Value.absent(),
     this.amountKobo = const Value.absent(),
     this.method = const Value.absent(),
     this.type = const Value.absent(),
@@ -28026,6 +28126,7 @@ class PaymentTransactionsCompanion
   PaymentTransactionsCompanion.insert({
     this.id = const Value.absent(),
     required String businessId,
+    this.storeId = const Value.absent(),
     required int amountKobo,
     required String method,
     required String type,
@@ -28048,6 +28149,7 @@ class PaymentTransactionsCompanion
   static Insertable<PaymentTransactionData> custom({
     Expression<String>? id,
     Expression<String>? businessId,
+    Expression<String>? storeId,
     Expression<int>? amountKobo,
     Expression<String>? method,
     Expression<String>? type,
@@ -28067,6 +28169,7 @@ class PaymentTransactionsCompanion
     return RawValuesInsertable({
       if (id != null) 'id': id,
       if (businessId != null) 'business_id': businessId,
+      if (storeId != null) 'store_id': storeId,
       if (amountKobo != null) 'amount_kobo': amountKobo,
       if (method != null) 'method': method,
       if (type != null) 'type': type,
@@ -28088,6 +28191,7 @@ class PaymentTransactionsCompanion
   PaymentTransactionsCompanion copyWith({
     Value<String>? id,
     Value<String>? businessId,
+    Value<String?>? storeId,
     Value<int>? amountKobo,
     Value<String>? method,
     Value<String>? type,
@@ -28107,6 +28211,7 @@ class PaymentTransactionsCompanion
     return PaymentTransactionsCompanion(
       id: id ?? this.id,
       businessId: businessId ?? this.businessId,
+      storeId: storeId ?? this.storeId,
       amountKobo: amountKobo ?? this.amountKobo,
       method: method ?? this.method,
       type: type ?? this.type,
@@ -28133,6 +28238,9 @@ class PaymentTransactionsCompanion
     }
     if (businessId.present) {
       map['business_id'] = Variable<String>(businessId.value);
+    }
+    if (storeId.present) {
+      map['store_id'] = Variable<String>(storeId.value);
     }
     if (amountKobo.present) {
       map['amount_kobo'] = Variable<int>(amountKobo.value);
@@ -28187,6 +28295,7 @@ class PaymentTransactionsCompanion
     return (StringBuffer('PaymentTransactionsCompanion(')
           ..write('id: $id, ')
           ..write('businessId: $businessId, ')
+          ..write('storeId: $storeId, ')
           ..write('amountKobo: $amountKobo, ')
           ..write('method: $method, ')
           ..write('type: $type, ')
@@ -39060,6 +39169,8 @@ abstract class _$AppDatabase extends GeneratedDatabase {
     this as AppDatabase,
   );
   late final OrdersDao ordersDao = OrdersDao(this as AppDatabase);
+  late final PaymentTransactionsDao paymentTransactionsDao =
+      PaymentTransactionsDao(this as AppDatabase);
   late final CustomersDao customersDao = CustomersDao(this as AppDatabase);
   late final ShipmentsDao shipmentsDao = ShipmentsDao(this as AppDatabase);
   late final ExpensesDao expensesDao = ExpensesDao(this as AppDatabase);
@@ -47254,6 +47365,33 @@ final class $$StoresTableReferences
     );
   }
 
+  static MultiTypedResultKey<
+    $PaymentTransactionsTable,
+    List<PaymentTransactionData>
+  >
+  _paymentTransactionsRefsTable(_$AppDatabase db) =>
+      MultiTypedResultKey.fromTable(
+        db.paymentTransactions,
+        aliasName: $_aliasNameGenerator(
+          db.stores.id,
+          db.paymentTransactions.storeId,
+        ),
+      );
+
+  $$PaymentTransactionsTableProcessedTableManager get paymentTransactionsRefs {
+    final manager = $$PaymentTransactionsTableTableManager(
+      $_db,
+      $_db.paymentTransactions,
+    ).filter((f) => f.storeId.id.sqlEquals($_itemColumn<String>('id')!));
+
+    final cache = $_typedResult.readTableOrNull(
+      _paymentTransactionsRefsTable($_db),
+    );
+    return ProcessedTableManager(
+      manager.$state.copyWith(prefetchedData: cache),
+    );
+  }
+
   static MultiTypedResultKey<$StockCountsTable, List<StockCountData>>
   _stockCountsRefsTable(_$AppDatabase db) => MultiTypedResultKey.fromTable(
     db.stockCounts,
@@ -47835,6 +47973,31 @@ class $$StoresTableFilterComposer
           }) => $$SavedCartsTableFilterComposer(
             $db: $db,
             $table: $db.savedCarts,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return f(composer);
+  }
+
+  Expression<bool> paymentTransactionsRefs(
+    Expression<bool> Function($$PaymentTransactionsTableFilterComposer f) f,
+  ) {
+    final $$PaymentTransactionsTableFilterComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.id,
+      referencedTable: $db.paymentTransactions,
+      getReferencedColumn: (t) => t.storeId,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$PaymentTransactionsTableFilterComposer(
+            $db: $db,
+            $table: $db.paymentTransactions,
             $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
             joinBuilder: joinBuilder,
             $removeJoinBuilderFromRootComposer:
@@ -48517,6 +48680,32 @@ class $$StoresTableAnnotationComposer
     return f(composer);
   }
 
+  Expression<T> paymentTransactionsRefs<T extends Object>(
+    Expression<T> Function($$PaymentTransactionsTableAnnotationComposer a) f,
+  ) {
+    final $$PaymentTransactionsTableAnnotationComposer composer =
+        $composerBuilder(
+          composer: this,
+          getCurrentColumn: (t) => t.id,
+          referencedTable: $db.paymentTransactions,
+          getReferencedColumn: (t) => t.storeId,
+          builder:
+              (
+                joinBuilder, {
+                $addJoinBuilderToRootComposer,
+                $removeJoinBuilderFromRootComposer,
+              }) => $$PaymentTransactionsTableAnnotationComposer(
+                $db: $db,
+                $table: $db.paymentTransactions,
+                $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+                joinBuilder: joinBuilder,
+                $removeJoinBuilderFromRootComposer:
+                    $removeJoinBuilderFromRootComposer,
+              ),
+        );
+    return f(composer);
+  }
+
   Expression<T> stockCountsRefs<T extends Object>(
     Expression<T> Function($$StockCountsTableAnnotationComposer a) f,
   ) {
@@ -48676,6 +48865,7 @@ class $$StoresTableTableManager
             bool expensesRefs,
             bool expenseBudgetsRefs,
             bool savedCartsRefs,
+            bool paymentTransactionsRefs,
             bool stockCountsRefs,
             bool activityLogsRefs,
             bool storeRolePermissionsRefs,
@@ -48760,6 +48950,7 @@ class $$StoresTableTableManager
                 expensesRefs = false,
                 expenseBudgetsRefs = false,
                 savedCartsRefs = false,
+                paymentTransactionsRefs = false,
                 stockCountsRefs = false,
                 activityLogsRefs = false,
                 storeRolePermissionsRefs = false,
@@ -48786,6 +48977,7 @@ class $$StoresTableTableManager
                     if (expensesRefs) db.expenses,
                     if (expenseBudgetsRefs) db.expenseBudgets,
                     if (savedCartsRefs) db.savedCarts,
+                    if (paymentTransactionsRefs) db.paymentTransactions,
                     if (stockCountsRefs) db.stockCounts,
                     if (activityLogsRefs) db.activityLogs,
                     if (storeRolePermissionsRefs) db.storeRolePermissions,
@@ -49175,6 +49367,27 @@ class $$StoresTableTableManager
                               ),
                           typedResults: items,
                         ),
+                      if (paymentTransactionsRefs)
+                        await $_getPrefetchedData<
+                          StoreData,
+                          $StoresTable,
+                          PaymentTransactionData
+                        >(
+                          currentTable: table,
+                          referencedTable: $$StoresTableReferences
+                              ._paymentTransactionsRefsTable(db),
+                          managerFromTypedResult: (p0) =>
+                              $$StoresTableReferences(
+                                db,
+                                table,
+                                p0,
+                              ).paymentTransactionsRefs,
+                          referencedItemsForCurrentItem:
+                              (item, referencedItems) => referencedItems.where(
+                                (e) => e.storeId == item.id,
+                              ),
+                          typedResults: items,
+                        ),
                       if (stockCountsRefs)
                         await $_getPrefetchedData<
                           StoreData,
@@ -49319,6 +49532,7 @@ typedef $$StoresTableProcessedTableManager =
         bool expensesRefs,
         bool expenseBudgetsRefs,
         bool savedCartsRefs,
+        bool paymentTransactionsRefs,
         bool stockCountsRefs,
         bool activityLogsRefs,
         bool storeRolePermissionsRefs,
@@ -49405,25 +49619,6 @@ final class $$UsersTableReferences
     if (item == null) return manager;
     return ProcessedTableManager(
       manager.$state.copyWith(prefetchedData: [item]),
-    );
-  }
-
-  static MultiTypedResultKey<$OrdersTable, List<OrderData>> _ordersRefsTable(
-    _$AppDatabase db,
-  ) => MultiTypedResultKey.fromTable(
-    db.orders,
-    aliasName: $_aliasNameGenerator(db.users.id, db.orders.staffId),
-  );
-
-  $$OrdersTableProcessedTableManager get ordersRefs {
-    final manager = $$OrdersTableTableManager(
-      $_db,
-      $_db.orders,
-    ).filter((f) => f.staffId.id.sqlEquals($_itemColumn<String>('id')!));
-
-    final cache = $_typedResult.readTableOrNull(_ordersRefsTable($_db));
-    return ProcessedTableManager(
-      manager.$state.copyWith(prefetchedData: cache),
     );
   }
 
@@ -49717,31 +49912,6 @@ class $$UsersTableFilterComposer extends Composer<_$AppDatabase, $UsersTable> {
           ),
     );
     return composer;
-  }
-
-  Expression<bool> ordersRefs(
-    Expression<bool> Function($$OrdersTableFilterComposer f) f,
-  ) {
-    final $$OrdersTableFilterComposer composer = $composerBuilder(
-      composer: this,
-      getCurrentColumn: (t) => t.id,
-      referencedTable: $db.orders,
-      getReferencedColumn: (t) => t.staffId,
-      builder:
-          (
-            joinBuilder, {
-            $addJoinBuilderToRootComposer,
-            $removeJoinBuilderFromRootComposer,
-          }) => $$OrdersTableFilterComposer(
-            $db: $db,
-            $table: $db.orders,
-            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
-            joinBuilder: joinBuilder,
-            $removeJoinBuilderFromRootComposer:
-                $removeJoinBuilderFromRootComposer,
-          ),
-    );
-    return f(composer);
   }
 
   Expression<bool> stockAdjustmentsRefs(
@@ -50189,31 +50359,6 @@ class $$UsersTableAnnotationComposer
     return composer;
   }
 
-  Expression<T> ordersRefs<T extends Object>(
-    Expression<T> Function($$OrdersTableAnnotationComposer a) f,
-  ) {
-    final $$OrdersTableAnnotationComposer composer = $composerBuilder(
-      composer: this,
-      getCurrentColumn: (t) => t.id,
-      referencedTable: $db.orders,
-      getReferencedColumn: (t) => t.staffId,
-      builder:
-          (
-            joinBuilder, {
-            $addJoinBuilderToRootComposer,
-            $removeJoinBuilderFromRootComposer,
-          }) => $$OrdersTableAnnotationComposer(
-            $db: $db,
-            $table: $db.orders,
-            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
-            joinBuilder: joinBuilder,
-            $removeJoinBuilderFromRootComposer:
-                $removeJoinBuilderFromRootComposer,
-          ),
-    );
-    return f(composer);
-  }
-
   Expression<T> stockAdjustmentsRefs<T extends Object>(
     Expression<T> Function($$StockAdjustmentsTableAnnotationComposer a) f,
   ) {
@@ -50433,7 +50578,6 @@ class $$UsersTableTableManager
           PrefetchHooks Function({
             bool businessId,
             bool storeId,
-            bool ordersRefs,
             bool stockAdjustmentsRefs,
             bool stockCountsRefs,
             bool errorLogsRefs,
@@ -50545,7 +50689,6 @@ class $$UsersTableTableManager
               ({
                 businessId = false,
                 storeId = false,
-                ordersRefs = false,
                 stockAdjustmentsRefs = false,
                 stockCountsRefs = false,
                 errorLogsRefs = false,
@@ -50558,7 +50701,6 @@ class $$UsersTableTableManager
                 return PrefetchHooks(
                   db: db,
                   explicitlyWatchedTables: [
-                    if (ordersRefs) db.orders,
                     if (stockAdjustmentsRefs) db.stockAdjustments,
                     if (stockCountsRefs) db.stockCounts,
                     if (errorLogsRefs) db.errorLogs,
@@ -50615,23 +50757,6 @@ class $$UsersTableTableManager
                       },
                   getPrefetchedDataCallback: (items) async {
                     return [
-                      if (ordersRefs)
-                        await $_getPrefetchedData<
-                          UserData,
-                          $UsersTable,
-                          OrderData
-                        >(
-                          currentTable: table,
-                          referencedTable: $$UsersTableReferences
-                              ._ordersRefsTable(db),
-                          managerFromTypedResult: (p0) =>
-                              $$UsersTableReferences(db, table, p0).ordersRefs,
-                          referencedItemsForCurrentItem:
-                              (item, referencedItems) => referencedItems.where(
-                                (e) => e.staffId == item.id,
-                              ),
-                          typedResults: items,
-                        ),
                       if (stockAdjustmentsRefs)
                         await $_getPrefetchedData<
                           UserData,
@@ -50823,7 +50948,6 @@ typedef $$UsersTableProcessedTableManager =
       PrefetchHooks Function({
         bool businessId,
         bool storeId,
-        bool ordersRefs,
         bool stockAdjustmentsRefs,
         bool stockCountsRefs,
         bool errorLogsRefs,
@@ -59460,6 +59584,7 @@ typedef $$OrdersTableCreateCompanionBuilder =
       Value<String?> barcode,
       Value<String?> staffId,
       Value<String?> storeId,
+      Value<String?> confirmedBy,
       Value<int> crateDepositPaidKobo,
       Value<DateTime?> completedAt,
       Value<DateTime?> cancelledAt,
@@ -59484,6 +59609,7 @@ typedef $$OrdersTableUpdateCompanionBuilder =
       Value<String?> barcode,
       Value<String?> staffId,
       Value<String?> storeId,
+      Value<String?> confirmedBy,
       Value<int> crateDepositPaidKobo,
       Value<DateTime?> completedAt,
       Value<DateTime?> cancelledAt,
@@ -59562,6 +59688,23 @@ final class $$OrdersTableReferences
       $_db.stores,
     ).filter((f) => f.id.sqlEquals($_column));
     final item = $_typedResult.readTableOrNull(_storeIdTable($_db));
+    if (item == null) return manager;
+    return ProcessedTableManager(
+      manager.$state.copyWith(prefetchedData: [item]),
+    );
+  }
+
+  static $UsersTable _confirmedByTable(_$AppDatabase db) => db.users
+      .createAlias($_aliasNameGenerator(db.orders.confirmedBy, db.users.id));
+
+  $$UsersTableProcessedTableManager? get confirmedBy {
+    final $_column = $_itemColumn<String>('confirmed_by');
+    if ($_column == null) return null;
+    final manager = $$UsersTableTableManager(
+      $_db,
+      $_db.users,
+    ).filter((f) => f.id.sqlEquals($_column));
+    final item = $_typedResult.readTableOrNull(_confirmedByTable($_db));
     if (item == null) return manager;
     return ProcessedTableManager(
       manager.$state.copyWith(prefetchedData: [item]),
@@ -59928,6 +60071,29 @@ class $$OrdersTableFilterComposer
           }) => $$StoresTableFilterComposer(
             $db: $db,
             $table: $db.stores,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
+
+  $$UsersTableFilterComposer get confirmedBy {
+    final $$UsersTableFilterComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.confirmedBy,
+      referencedTable: $db.users,
+      getReferencedColumn: (t) => t.id,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$UsersTableFilterComposer(
+            $db: $db,
+            $table: $db.users,
             $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
             joinBuilder: joinBuilder,
             $removeJoinBuilderFromRootComposer:
@@ -60318,6 +60484,29 @@ class $$OrdersTableOrderingComposer
     );
     return composer;
   }
+
+  $$UsersTableOrderingComposer get confirmedBy {
+    final $$UsersTableOrderingComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.confirmedBy,
+      referencedTable: $db.users,
+      getReferencedColumn: (t) => t.id,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$UsersTableOrderingComposer(
+            $db: $db,
+            $table: $db.users,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
 }
 
 class $$OrdersTableAnnotationComposer
@@ -60482,6 +60671,29 @@ class $$OrdersTableAnnotationComposer
           }) => $$StoresTableAnnotationComposer(
             $db: $db,
             $table: $db.stores,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
+
+  $$UsersTableAnnotationComposer get confirmedBy {
+    final $$UsersTableAnnotationComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.confirmedBy,
+      referencedTable: $db.users,
+      getReferencedColumn: (t) => t.id,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$UsersTableAnnotationComposer(
+            $db: $db,
+            $table: $db.users,
             $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
             joinBuilder: joinBuilder,
             $removeJoinBuilderFromRootComposer:
@@ -60714,6 +60926,7 @@ class $$OrdersTableTableManager
             bool customerId,
             bool staffId,
             bool storeId,
+            bool confirmedBy,
             bool walletTransactionsRefs,
             bool pendingCrateReturnsRefs,
             bool crateLedgerRefs,
@@ -60752,6 +60965,7 @@ class $$OrdersTableTableManager
                 Value<String?> barcode = const Value.absent(),
                 Value<String?> staffId = const Value.absent(),
                 Value<String?> storeId = const Value.absent(),
+                Value<String?> confirmedBy = const Value.absent(),
                 Value<int> crateDepositPaidKobo = const Value.absent(),
                 Value<DateTime?> completedAt = const Value.absent(),
                 Value<DateTime?> cancelledAt = const Value.absent(),
@@ -60774,6 +60988,7 @@ class $$OrdersTableTableManager
                 barcode: barcode,
                 staffId: staffId,
                 storeId: storeId,
+                confirmedBy: confirmedBy,
                 crateDepositPaidKobo: crateDepositPaidKobo,
                 completedAt: completedAt,
                 cancelledAt: cancelledAt,
@@ -60798,6 +61013,7 @@ class $$OrdersTableTableManager
                 Value<String?> barcode = const Value.absent(),
                 Value<String?> staffId = const Value.absent(),
                 Value<String?> storeId = const Value.absent(),
+                Value<String?> confirmedBy = const Value.absent(),
                 Value<int> crateDepositPaidKobo = const Value.absent(),
                 Value<DateTime?> completedAt = const Value.absent(),
                 Value<DateTime?> cancelledAt = const Value.absent(),
@@ -60820,6 +61036,7 @@ class $$OrdersTableTableManager
                 barcode: barcode,
                 staffId: staffId,
                 storeId: storeId,
+                confirmedBy: confirmedBy,
                 crateDepositPaidKobo: crateDepositPaidKobo,
                 completedAt: completedAt,
                 cancelledAt: cancelledAt,
@@ -60839,6 +61056,7 @@ class $$OrdersTableTableManager
                 customerId = false,
                 staffId = false,
                 storeId = false,
+                confirmedBy = false,
                 walletTransactionsRefs = false,
                 pendingCrateReturnsRefs = false,
                 crateLedgerRefs = false,
@@ -60924,6 +61142,19 @@ class $$OrdersTableTableManager
                                         ._storeIdTable(db),
                                     referencedColumn: $$OrdersTableReferences
                                         ._storeIdTable(db)
+                                        .id,
+                                  )
+                                  as T;
+                        }
+                        if (confirmedBy) {
+                          state =
+                              state.withJoin(
+                                    currentTable: table,
+                                    currentColumn: table.confirmedBy,
+                                    referencedTable: $$OrdersTableReferences
+                                        ._confirmedByTable(db),
+                                    referencedColumn: $$OrdersTableReferences
+                                        ._confirmedByTable(db)
                                         .id,
                                   )
                                   as T;
@@ -61126,6 +61357,7 @@ typedef $$OrdersTableProcessedTableManager =
         bool customerId,
         bool staffId,
         bool storeId,
+        bool confirmedBy,
         bool walletTransactionsRefs,
         bool pendingCrateReturnsRefs,
         bool crateLedgerRefs,
@@ -78695,6 +78927,7 @@ typedef $$PaymentTransactionsTableCreateCompanionBuilder =
     PaymentTransactionsCompanion Function({
       Value<String> id,
       required String businessId,
+      Value<String?> storeId,
       required int amountKobo,
       required String method,
       required String type,
@@ -78715,6 +78948,7 @@ typedef $$PaymentTransactionsTableUpdateCompanionBuilder =
     PaymentTransactionsCompanion Function({
       Value<String> id,
       Value<String> businessId,
+      Value<String?> storeId,
       Value<int> amountKobo,
       Value<String> method,
       Value<String> type,
@@ -78761,6 +78995,24 @@ final class $$PaymentTransactionsTableReferences
       $_db.businesses,
     ).filter((f) => f.id.sqlEquals($_column));
     final item = $_typedResult.readTableOrNull(_businessIdTable($_db));
+    if (item == null) return manager;
+    return ProcessedTableManager(
+      manager.$state.copyWith(prefetchedData: [item]),
+    );
+  }
+
+  static $StoresTable _storeIdTable(_$AppDatabase db) => db.stores.createAlias(
+    $_aliasNameGenerator(db.paymentTransactions.storeId, db.stores.id),
+  );
+
+  $$StoresTableProcessedTableManager? get storeId {
+    final $_column = $_itemColumn<String>('store_id');
+    if ($_column == null) return null;
+    final manager = $$StoresTableTableManager(
+      $_db,
+      $_db.stores,
+    ).filter((f) => f.id.sqlEquals($_column));
+    final item = $_typedResult.readTableOrNull(_storeIdTable($_db));
     if (item == null) return manager;
     return ProcessedTableManager(
       manager.$state.copyWith(prefetchedData: [item]),
@@ -78971,6 +79223,29 @@ class $$PaymentTransactionsTableFilterComposer
           }) => $$BusinessesTableFilterComposer(
             $db: $db,
             $table: $db.businesses,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
+
+  $$StoresTableFilterComposer get storeId {
+    final $$StoresTableFilterComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.storeId,
+      referencedTable: $db.stores,
+      getReferencedColumn: (t) => t.id,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$StoresTableFilterComposer(
+            $db: $db,
+            $table: $db.stores,
             $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
             joinBuilder: joinBuilder,
             $removeJoinBuilderFromRootComposer:
@@ -79214,6 +79489,29 @@ class $$PaymentTransactionsTableOrderingComposer
     return composer;
   }
 
+  $$StoresTableOrderingComposer get storeId {
+    final $$StoresTableOrderingComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.storeId,
+      referencedTable: $db.stores,
+      getReferencedColumn: (t) => t.id,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$StoresTableOrderingComposer(
+            $db: $db,
+            $table: $db.stores,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
+
   $$OrdersTableOrderingComposer get orderId {
     final $$OrdersTableOrderingComposer composer = $composerBuilder(
       composer: this,
@@ -79438,6 +79736,29 @@ class $$PaymentTransactionsTableAnnotationComposer
     return composer;
   }
 
+  $$StoresTableAnnotationComposer get storeId {
+    final $$StoresTableAnnotationComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.storeId,
+      referencedTable: $db.stores,
+      getReferencedColumn: (t) => t.id,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$StoresTableAnnotationComposer(
+            $db: $db,
+            $table: $db.stores,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
+
   $$OrdersTableAnnotationComposer get orderId {
     final $$OrdersTableAnnotationComposer composer = $composerBuilder(
       composer: this,
@@ -79616,6 +79937,7 @@ class $$PaymentTransactionsTableTableManager
           PaymentTransactionData,
           PrefetchHooks Function({
             bool businessId,
+            bool storeId,
             bool orderId,
             bool shipmentId,
             bool expenseId,
@@ -79648,6 +79970,7 @@ class $$PaymentTransactionsTableTableManager
               ({
                 Value<String> id = const Value.absent(),
                 Value<String> businessId = const Value.absent(),
+                Value<String?> storeId = const Value.absent(),
                 Value<int> amountKobo = const Value.absent(),
                 Value<String> method = const Value.absent(),
                 Value<String> type = const Value.absent(),
@@ -79666,6 +79989,7 @@ class $$PaymentTransactionsTableTableManager
               }) => PaymentTransactionsCompanion(
                 id: id,
                 businessId: businessId,
+                storeId: storeId,
                 amountKobo: amountKobo,
                 method: method,
                 type: type,
@@ -79686,6 +80010,7 @@ class $$PaymentTransactionsTableTableManager
               ({
                 Value<String> id = const Value.absent(),
                 required String businessId,
+                Value<String?> storeId = const Value.absent(),
                 required int amountKobo,
                 required String method,
                 required String type,
@@ -79704,6 +80029,7 @@ class $$PaymentTransactionsTableTableManager
               }) => PaymentTransactionsCompanion.insert(
                 id: id,
                 businessId: businessId,
+                storeId: storeId,
                 amountKobo: amountKobo,
                 method: method,
                 type: type,
@@ -79731,6 +80057,7 @@ class $$PaymentTransactionsTableTableManager
           prefetchHooksCallback:
               ({
                 businessId = false,
+                storeId = false,
                 orderId = false,
                 shipmentId = false,
                 expenseId = false,
@@ -79769,6 +80096,21 @@ class $$PaymentTransactionsTableTableManager
                                     referencedColumn:
                                         $$PaymentTransactionsTableReferences
                                             ._businessIdTable(db)
+                                            .id,
+                                  )
+                                  as T;
+                        }
+                        if (storeId) {
+                          state =
+                              state.withJoin(
+                                    currentTable: table,
+                                    currentColumn: table.storeId,
+                                    referencedTable:
+                                        $$PaymentTransactionsTableReferences
+                                            ._storeIdTable(db),
+                                    referencedColumn:
+                                        $$PaymentTransactionsTableReferences
+                                            ._storeIdTable(db)
                                             .id,
                                   )
                                   as T;
@@ -79904,6 +80246,7 @@ typedef $$PaymentTransactionsTableProcessedTableManager =
       PaymentTransactionData,
       PrefetchHooks Function({
         bool businessId,
+        bool storeId,
         bool orderId,
         bool shipmentId,
         bool expenseId,

--- a/lib/core/database/daos.dart
+++ b/lib/core/database/daos.dart
@@ -18,6 +18,7 @@ part 'daos_catalog.dart';
 part 'daos_inventory.dart';
 part 'daos_costing.dart';
 part 'daos_orders.dart';
+part 'daos_payments.dart';
 part 'daos_customers.dart';
 part 'daos_suppliers.dart';
 part 'daos_crates.dart';

--- a/lib/core/database/daos.g.dart
+++ b/lib/core/database/daos.g.dart
@@ -532,6 +532,83 @@ class QuickSaleRequestsDaoManager {
       );
 }
 
+mixin _$PaymentTransactionsDaoMixin on DatabaseAccessor<AppDatabase> {
+  $BusinessesTable get businesses => attachedDatabase.businesses;
+  $StoresTable get stores => attachedDatabase.stores;
+  $CustomersTable get customers => attachedDatabase.customers;
+  $UsersTable get users => attachedDatabase.users;
+  $OrdersTable get orders => attachedDatabase.orders;
+  $CrateSizeGroupsTable get crateSizeGroups => attachedDatabase.crateSizeGroups;
+  $SuppliersTable get suppliers => attachedDatabase.suppliers;
+  $ShipmentsTable get shipments => attachedDatabase.shipments;
+  $ExpenseCategoriesTable get expenseCategories =>
+      attachedDatabase.expenseCategories;
+  $ExpensesTable get expenses => attachedDatabase.expenses;
+  $CustomerWalletsTable get customerWallets => attachedDatabase.customerWallets;
+  $WalletTransactionsTable get walletTransactions =>
+      attachedDatabase.walletTransactions;
+  $DriversTable get drivers => attachedDatabase.drivers;
+  $DeliveryReceiptsTable get deliveryReceipts =>
+      attachedDatabase.deliveryReceipts;
+  $PaymentTransactionsTable get paymentTransactions =>
+      attachedDatabase.paymentTransactions;
+  PaymentTransactionsDaoManager get managers =>
+      PaymentTransactionsDaoManager(this);
+}
+
+class PaymentTransactionsDaoManager {
+  final _$PaymentTransactionsDaoMixin _db;
+  PaymentTransactionsDaoManager(this._db);
+  $$BusinessesTableTableManager get businesses =>
+      $$BusinessesTableTableManager(_db.attachedDatabase, _db.businesses);
+  $$StoresTableTableManager get stores =>
+      $$StoresTableTableManager(_db.attachedDatabase, _db.stores);
+  $$CustomersTableTableManager get customers =>
+      $$CustomersTableTableManager(_db.attachedDatabase, _db.customers);
+  $$UsersTableTableManager get users =>
+      $$UsersTableTableManager(_db.attachedDatabase, _db.users);
+  $$OrdersTableTableManager get orders =>
+      $$OrdersTableTableManager(_db.attachedDatabase, _db.orders);
+  $$CrateSizeGroupsTableTableManager get crateSizeGroups =>
+      $$CrateSizeGroupsTableTableManager(
+        _db.attachedDatabase,
+        _db.crateSizeGroups,
+      );
+  $$SuppliersTableTableManager get suppliers =>
+      $$SuppliersTableTableManager(_db.attachedDatabase, _db.suppliers);
+  $$ShipmentsTableTableManager get shipments =>
+      $$ShipmentsTableTableManager(_db.attachedDatabase, _db.shipments);
+  $$ExpenseCategoriesTableTableManager get expenseCategories =>
+      $$ExpenseCategoriesTableTableManager(
+        _db.attachedDatabase,
+        _db.expenseCategories,
+      );
+  $$ExpensesTableTableManager get expenses =>
+      $$ExpensesTableTableManager(_db.attachedDatabase, _db.expenses);
+  $$CustomerWalletsTableTableManager get customerWallets =>
+      $$CustomerWalletsTableTableManager(
+        _db.attachedDatabase,
+        _db.customerWallets,
+      );
+  $$WalletTransactionsTableTableManager get walletTransactions =>
+      $$WalletTransactionsTableTableManager(
+        _db.attachedDatabase,
+        _db.walletTransactions,
+      );
+  $$DriversTableTableManager get drivers =>
+      $$DriversTableTableManager(_db.attachedDatabase, _db.drivers);
+  $$DeliveryReceiptsTableTableManager get deliveryReceipts =>
+      $$DeliveryReceiptsTableTableManager(
+        _db.attachedDatabase,
+        _db.deliveryReceipts,
+      );
+  $$PaymentTransactionsTableTableManager get paymentTransactions =>
+      $$PaymentTransactionsTableTableManager(
+        _db.attachedDatabase,
+        _db.paymentTransactions,
+      );
+}
+
 mixin _$CustomersDaoMixin on DatabaseAccessor<AppDatabase> {
   $BusinessesTable get businesses => attachedDatabase.businesses;
   $StoresTable get stores => attachedDatabase.stores;

--- a/lib/core/database/daos_expenses.dart
+++ b/lib/core/database/daos_expenses.dart
@@ -136,6 +136,9 @@ class ExpensesDao extends DatabaseAccessor<AppDatabase>
       final payComp = PaymentTransactionsCompanion.insert(
         id: Value(paymentId),
         businessId: requireBusinessId(),
+        // #169: stamp the expense's store on this new payment row (nullable;
+        // unread by reports yet, so behavior-preserving).
+        storeId: Value(storeId),
         amountKobo: amountKobo,
         method: effectivePaymentMethod,
         type: 'expense',

--- a/lib/core/database/daos_orders.dart
+++ b/lib/core/database/daos_orders.dart
@@ -28,8 +28,9 @@ class OrdersDao extends DatabaseAccessor<AppDatabase>
   /// Every `payment_transactions` row for this business — the unified physical-
   /// cash tender ledger (`type` in {sale, wallet_topup, refund, expense}, each
   /// carrying its `method`). Newest first. Voided rows are kept; callers filter
-  /// on `voidedAt`. This table has no `storeId`, so the Daily Reconciliation
-  /// cash-flow summary that reads it (ADR 0014) is business-wide.
+  /// on `voidedAt`. New rows carry a nullable `storeId` (#169); legacy rows are
+  /// null, so the Daily Reconciliation cash-flow summary that reads it (ADR
+  /// 0014) still reports business-wide until a later slice filters on it.
   Stream<List<PaymentTransactionData>> watchAllPaymentTransactions() {
     return (select(paymentTransactions)
           ..where((p) => whereBusiness(p))
@@ -827,6 +828,10 @@ class OrdersDao extends DatabaseAccessor<AppDatabase>
         final payComp = PaymentTransactionsCompanion.insert(
           id: Value(payId),
           businessId: requireBusinessId(),
+          // #169: stamp the sale-level store on this new payment row (the same
+          // store the header + stock movements use). Nullable; unread by reports
+          // yet, so behavior-preserving.
+          storeId: Value(storeId ?? items.first.storeId.value),
           amountKobo: amountPaidKobo,
           method: paymentMethod,
           type: 'sale',
@@ -1106,12 +1111,19 @@ class OrdersDao extends DatabaseAccessor<AppDatabase>
         await db.syncDao.enqueueUpsert('wallet_transactions', refundedComp);
 
         if (refundAsCash) {
+          // #169: stamp the order's store on this new refund payment row
+          // (nullable; unread by reports yet, so behavior-preserving).
+          final settleStore =
+              await (select(orders)
+                    ..where((o) => o.id.equals(orderId) & whereBusiness(o)))
+                  .getSingleOrNull();
           // payment_transactions requires EXACTLY ONE reference (order/shipment/
           // expense/wallet_txn/delivery). Link via the wallet txn — which itself
           // carries the orderId — mirroring WalletService's topup payment row.
           final payComp = PaymentTransactionsCompanion.insert(
             id: Value(UuidV7.generate()),
             businessId: requireBusinessId(),
+            storeId: Value(settleStore?.storeId),
             amountKobo: refundAmount,
             method: 'cash',
             type: 'refund',

--- a/lib/core/database/daos_payments.dart
+++ b/lib/core/database/daos_payments.dart
@@ -1,0 +1,79 @@
+part of 'daos.dart';
+
+/// Owns the compensating-reversal seam for the append-only
+/// `payment_transactions` ledger (#169 / PRD #155).
+///
+/// The payment ledger becomes append-only *in practice*: every money
+/// correction (cancelling a sale, rejecting/deleting an expense, voiding a
+/// customer top-up) posts a NEW dated reversal row through
+/// [postReversalPayment] instead of mutating the original row's in-place void
+/// columns. The legacy `voided_at` / `voided_by` / `void_reason` columns are
+/// retained read-only for rows written before this discipline landed. Because
+/// cash-flow reporting counts every payment row on its own `created_at` day,
+/// a later-day correction lands its cash movement on the correction day and
+/// never rewrites a day the owner already reviewed and banked against.
+///
+/// This is the single seam every correction path shares; the paths themselves
+/// (OrdersDao cancel, ExpensesDao reject/delete, CreditLedgerService top-up
+/// void) are wired to call it in later slices — this prefactor only introduces
+/// the verb, behavior-preservingly.
+@DriftAccessor(tables: [PaymentTransactions])
+class PaymentTransactionsDao extends DatabaseAccessor<AppDatabase>
+    with _$PaymentTransactionsDaoMixin, BusinessScopedDao<AppDatabase> {
+  PaymentTransactionsDao(super.db);
+
+  /// Posts a DATED compensating reversal of [original] into the append-only
+  /// payment ledger, enqueues it for sync, and returns the stored row.
+  ///
+  /// Invariants this holds:
+  /// - The [original] row is left **untouched** — no in-place void, no edit.
+  /// - The reversal lands on its **own** `created_at` day ([at], defaults to
+  ///   now), so the original day's cash figures never change retroactively.
+  /// - It copies [original]'s single typed reference (order / shipment /
+  ///   expense / wallet_txn / delivery) so the exactly-one-reference CHECK
+  ///   holds; the reversal therefore links back to the same source record.
+  /// - It is stamped with a [storeId] (defaults to the original's store —
+  ///   nullable, so a legacy store-less original yields a store-less reversal
+  ///   that reports business-wide, exactly as today).
+  ///
+  /// [reversalType] is the payment `type` of the compensating row (a valid
+  /// `payment_transactions.type`, e.g. `'refund'` for a cancelled sale).
+  /// [amountKobo] defaults to the original's amount. [reason] is recorded in
+  /// the reversal's `void_reason` free-text column as the correction reason
+  /// (this row is not itself voided — the column is reused as the only audit
+  /// note field on the table).
+  Future<PaymentTransactionData> postReversalPayment({
+    required PaymentTransactionData original,
+    required String reversalType,
+    required String performedBy,
+    int? amountKobo,
+    String? storeId,
+    String? reason,
+    DateTime? at,
+  }) async {
+    final now = at ?? DateTime.now();
+    final reversalId = UuidV7.generate();
+    final comp = PaymentTransactionsCompanion.insert(
+      id: Value(reversalId),
+      businessId: original.businessId,
+      storeId: Value(storeId ?? original.storeId),
+      amountKobo: amountKobo ?? original.amountKobo,
+      method: original.method,
+      type: reversalType,
+      orderId: Value(original.orderId),
+      shipmentId: Value(original.shipmentId),
+      expenseId: Value(original.expenseId),
+      walletTxnId: Value(original.walletTxnId),
+      deliveryId: Value(original.deliveryId),
+      performedBy: Value(performedBy),
+      voidReason: Value(reason),
+      createdAt: Value(now),
+      lastUpdatedAt: Value(now),
+    );
+    await into(paymentTransactions).insert(comp);
+    await db.syncDao.enqueueUpsert('payment_transactions', comp);
+    return (select(paymentTransactions)
+          ..where((p) => p.id.equals(reversalId)))
+        .getSingle();
+  }
+}

--- a/lib/core/database/sync_registry.dart
+++ b/lib/core/database/sync_registry.dart
@@ -999,6 +999,11 @@ final List<SyncedTable> kSyncRegistry = [
   SyncedTable(
     name: 'supplier_crate_ledger',
     tenantScoped: true,
+    // #169: preemptively drop `created_at` on every push so a future void
+    // re-push (the money-integrity slices) can't trip the immutable-column
+    // trigger (P0001) and orphan the row — same trap already closed for the
+    // wallet / supplier / payment ledgers.
+    scrubCreatedAt: true,
     restore: Restore.ledger(
       (db) => db.supplierCrateLedger,
       SupplierCrateLedgerEntryData.fromJson,
@@ -1092,6 +1097,10 @@ final List<SyncedTable> kSyncRegistry = [
   SyncedTable(
     name: 'crate_ledger',
     tenantScoped: true,
+    // #169: preemptively drop `created_at` on every push (see supplier_crate_
+    // ledger above) — closes the latent void-push orphan trap before any void
+    // feature ships.
+    scrubCreatedAt: true,
     restore: Restore.ledger(
       (db) => db.crateLedger,
       CrateLedgerData.fromJson,

--- a/lib/features/dashboard/reconciliation/recon_data.dart
+++ b/lib/features/dashboard/reconciliation/recon_data.dart
@@ -918,7 +918,10 @@ ReconData computeReconData(
   // Expected cash MOVEMENT for the period from recorded cash tenders — NOT a
   // drawer count (Hard Rule #8: no float, no counted cash). payment_transactions
   // is the unified physical-cash ledger (sale / wallet_topup / refund / expense,
-  // each with a `method`) and has no storeId, so this card is business-wide.
+  // each with a `method`). New rows carry a nullable storeId (#169) but this
+  // card does not filter on it yet (legacy rows are null), so it stays
+  // business-wide. Each row is counted on its OWN `created_at` day (inSpan
+  // below), the invariant the money-correction slices rely on.
   // Crate deposits (a refundable held liability) are deliberately excluded — the
   // ask is operating cash (sales + debts collected). `method` casing drifts
   // ('Cash'/'cash'), so match case-insensitively.

--- a/supabase/migrations/0153_money_integrity_payments_seam.sql
+++ b/supabase/migrations/0153_money_integrity_payments_seam.sql
@@ -1,0 +1,113 @@
+-- 0153_money_integrity_payments_seam.sql
+--
+-- #169 / PRD #155 — money-integrity prefactor (compensating-row seam +
+-- sync/schema plumbing). Behavior-preserving: adds columns and widens a CHECK;
+-- no data is rewritten, no flow changes. Mirrors the Drift schemaVersion 64
+-- upgrade step in lib/core/database/app_database.dart.
+--
+-- Deploy-ordering: this must land on the cloud BEFORE any client on Drift
+-- schema v64 pushes a payment_transactions row carrying `store_id`, an orders
+-- row carrying `confirmed_by`, or a payment row of the new `crate_deposit`
+-- type — otherwise the upsert references an unknown column / trips the old
+-- CHECK and jams the outbox.
+--
+-- All `*_kobo` columns are untouched here and remain bigint (0130).
+
+-- =========================================================================
+-- 1. payment_transactions.store_id — nullable store where the tender happened.
+--    Stamped on all NEW rows (client v64); legacy rows stay NULL and report
+--    business-wide exactly as today. Additive + nullable, so existing rows are
+--    untouched.
+-- =========================================================================
+ALTER TABLE public.payment_transactions
+  ADD COLUMN IF NOT EXISTS store_id uuid REFERENCES public.stores(id);
+
+-- =========================================================================
+-- 2. orders.confirmed_by — who tapped Confirm, recorded separately from the
+--    seller (staff_id). Nullable, unused until #171. Additive + nullable.
+-- =========================================================================
+ALTER TABLE public.orders
+  ADD COLUMN IF NOT EXISTS confirmed_by uuid REFERENCES public.users(id);
+
+-- =========================================================================
+-- 3. Widen the payment_transactions.type CHECK to admit the deposit-distinct
+--    `crate_deposit` type (unused until #175): a refundable crate deposit is
+--    its own money type, so it can be excluded from "Cash sales". Postgres
+--    alters a CHECK in place (no table rebuild), so there are no index/trigger
+--    concerns. The constraint is unnamed (inline in 0001), so drop it by its
+--    system-generated name via a catalog lookup, then re-add the widened form
+--    under a stable name. Idempotent: if a CHECK already admits `crate_deposit`,
+--    do nothing. (Same pattern as 0149's status-CHECK widening.)
+-- =========================================================================
+DO $$
+DECLARE
+  v_conname text;
+  v_def     text;
+BEGIN
+  SELECT c.conname, pg_get_constraintdef(c.oid)
+    INTO v_conname, v_def
+    FROM pg_constraint c
+   WHERE c.conrelid = 'public.payment_transactions'::regclass
+     AND c.contype  = 'c'
+     AND pg_get_constraintdef(c.oid) ILIKE '%type%'
+     AND pg_get_constraintdef(c.oid) ILIKE '%sale%'
+   LIMIT 1;
+
+  -- Already widened (idempotent re-run) — nothing to do.
+  IF v_def IS NOT NULL AND v_def ILIKE '%crate_deposit%' THEN
+    RETURN;
+  END IF;
+
+  IF v_conname IS NOT NULL THEN
+    EXECUTE format(
+      'ALTER TABLE public.payment_transactions DROP CONSTRAINT %I', v_conname
+    );
+  END IF;
+
+  ALTER TABLE public.payment_transactions
+    ADD CONSTRAINT payment_transactions_type_check
+    CHECK (type IN
+      ('sale','purchase','expense','refund','wallet_topup','crate_deposit'));
+END $$;
+
+-- =========================================================================
+-- 4. Re-bake the payment_transactions append-only trigger so `store_id` joins
+--    the immutable-column set (it is set at insert and never changes), matching
+--    the local ledger-immutability trigger. The guard bakes its column list
+--    into TG_ARGV at CREATE time (0110), so a newly-added column is otherwise
+--    unguarded. Rebuild from information_schema minus the void columns — the
+--    exact 0110 recipe, scoped to this one table. Idempotent.
+-- =========================================================================
+DO $$
+DECLARE
+  cols text;
+BEGIN
+  SELECT string_agg(quote_literal(column_name), ',' ORDER BY ordinal_position)
+    INTO cols
+    FROM information_schema.columns
+   WHERE table_schema = 'public'
+     AND table_name   = 'payment_transactions'
+     AND column_name NOT IN
+         ('voided_at','voided_by','void_reason','last_updated_at');
+
+  EXECUTE format(
+    'DROP TRIGGER IF EXISTS trg_payment_transactions_append_only '
+    'ON public.payment_transactions'
+  );
+  EXECUTE format(
+    'CREATE TRIGGER trg_payment_transactions_append_only '
+    'BEFORE UPDATE ON public.payment_transactions '
+    'FOR EACH ROW EXECUTE FUNCTION public.enforce_append_only(%s)',
+    cols
+  );
+END $$;
+
+-- =========================================================================
+-- Verification (manual):
+--   \d public.payment_transactions   -- store_id present; type CHECK 6 values
+--   \d public.orders                 -- confirmed_by present
+--   SELECT pg_get_constraintdef(oid) FROM pg_constraint
+--     WHERE conname = 'payment_transactions_type_check';
+--     -- expect: CHECK (type IN ('sale','purchase','expense','refund',
+--     --                         'wallet_topup','crate_deposit'))
+-- =========================================================================

--- a/test/database/migration_upgrade_test.dart
+++ b/test/database/migration_upgrade_test.dart
@@ -979,4 +979,156 @@ void main() {
       );
     });
   });
+
+  group('onUpgrade v63 → v64 (money-integrity prefactor #169)', () {
+    Future<bool> objectExists(AppDatabase db, String type, String name) async {
+      final r = await db
+          .customSelect(
+            "SELECT 1 FROM sqlite_master WHERE type='$type' AND name='$name'",
+          )
+          .get();
+      return r.isNotEmpty;
+    }
+
+    test(
+        'adds orders.confirmed_by + payment_transactions.store_id, widens the '
+        'type CHECK to admit crate_deposit, and recreates the append-only '
+        'triggers/indexes (legacy payment rows keep store_id NULL)', () async {
+      final biz = UuidV7.generate();
+      final orderId = UuidV7.generate();
+      final legacyPayId = UuidV7.generate();
+
+      final db1 = await openAndInit();
+
+      // Real FK targets that survive the payment_transactions revert (only that
+      // table is dropped/recreated). The order lets the post-upgrade
+      // crate_deposit insert satisfy the (real) order_id FK.
+      await db1.customStatement(
+        "INSERT INTO businesses (id, name) VALUES (?, 'Biz')",
+        [biz],
+      );
+      await db1.customStatement(
+        'INSERT INTO orders (id, business_id, order_number, total_amount_kobo, '
+        'net_amount_kobo, payment_type, status) '
+        "VALUES (?, ?, 'ORD-000001-AAAAAA', 100000, 100000, 'cash', 'completed')",
+        [orderId, biz],
+      );
+
+      // (1) Revert orders to the pre-v64 shape: drop confirmed_by.
+      await db1.customStatement('ALTER TABLE orders DROP COLUMN confirmed_by');
+
+      // (2) Revert payment_transactions to the pre-v64 shape: no store_id and
+      //     the old 5-value type CHECK. Recreate WITHOUT FKs (mirrors the v61
+      //     user_businesses revert) so the copy is unconstrained; the migration
+      //     rebuilds the real, FK-carrying table from the Drift schema.
+      await db1.customStatement('PRAGMA foreign_keys = OFF');
+      await db1.customStatement('DROP TABLE IF EXISTS payment_transactions');
+      await db1.customStatement(
+        'CREATE TABLE payment_transactions ('
+        'id TEXT NOT NULL PRIMARY KEY, business_id TEXT NOT NULL, '
+        'amount_kobo INTEGER NOT NULL, method TEXT NOT NULL, type TEXT NOT NULL, '
+        'order_id TEXT, shipment_id TEXT, expense_id TEXT, wallet_txn_id TEXT, '
+        'delivery_id TEXT, performed_by TEXT, voided_at INTEGER, '
+        'voided_by TEXT, void_reason TEXT, '
+        'created_at INTEGER NOT NULL DEFAULT 0, '
+        'last_updated_at INTEGER NOT NULL DEFAULT 0, '
+        "CHECK (method IN ('cash','transfer','card','wallet','pos','other')), "
+        "CHECK (type IN ('sale','purchase','expense','refund','wallet_topup')))",
+      );
+      await db1.customStatement('PRAGMA foreign_keys = ON');
+
+      // A pre-existing (legacy) sale payment on the reverted table — no store_id.
+      await db1.customStatement(
+        'INSERT INTO payment_transactions '
+        '(id, business_id, amount_kobo, method, type, order_id, created_at, '
+        'last_updated_at) '
+        "VALUES (?, ?, 100000, 'cash', 'sale', ?, 0, 0)",
+        [legacyPayId, biz, orderId],
+      );
+
+      // The old 5-value CHECK rejects the new crate_deposit type — teeth for the
+      // widening.
+      await expectLater(
+        db1.customStatement(
+          'INSERT INTO payment_transactions '
+          '(id, business_id, amount_kobo, method, type, order_id) '
+          "VALUES (?, ?, 1, 'cash', 'crate_deposit', ?)",
+          [UuidV7.generate(), biz, orderId],
+        ),
+        throwsA(anything),
+        reason: 'the pre-v64 5-value type CHECK must reject crate_deposit',
+      );
+
+      await db1.customStatement('PRAGMA user_version = 63');
+      await db1.close();
+
+      // Re-open → onUpgrade(63 → 64).
+      final db2 = await openAndInit();
+      addTearDown(db2.close);
+
+      // (1) orders.confirmed_by re-added.
+      expect(
+        (await columnsOf(db2, 'orders')).contains('confirmed_by'),
+        isTrue,
+        reason: 'v64 must add orders.confirmed_by',
+      );
+
+      // (2) payment_transactions.store_id added; the legacy row keeps it NULL.
+      expect(
+        (await columnsOf(db2, 'payment_transactions')).contains('store_id'),
+        isTrue,
+        reason: 'v64 must add payment_transactions.store_id',
+      );
+      final legacy = await db2
+          .customSelect(
+            'SELECT store_id FROM payment_transactions WHERE id = ?',
+            variables: [Variable<String>(legacyPayId)],
+          )
+          .getSingle();
+      expect(legacy.read<String?>('store_id'), isNull,
+          reason: 'legacy rows report business-wide (store_id NULL)');
+
+      // (3) The widened CHECK now accepts a crate_deposit row.
+      await db2.customStatement(
+        'INSERT INTO payment_transactions '
+        '(id, business_id, amount_kobo, method, type, order_id) '
+        "VALUES (?, ?, 5000, 'cash', 'crate_deposit', ?)",
+        [UuidV7.generate(), biz, orderId],
+      );
+
+      // (4) Append-only triggers + sync/hot-path indexes recreated.
+      expect(await objectExists(db2, 'trigger', 'payment_transactions_immutable'),
+          isTrue, reason: 'v64 must recreate the immutable ledger trigger');
+      expect(await objectExists(db2, 'trigger', 'payment_transactions_no_delete'),
+          isTrue, reason: 'v64 must recreate the no-delete ledger trigger');
+      expect(
+        await objectExists(
+            db2, 'trigger', 'bump_payment_transactions_last_updated_at'),
+        isTrue,
+        reason: 'v64 must recreate the last_updated_at bump trigger',
+      );
+      expect(
+        await objectExists(
+            db2, 'index', 'idx_payment_transactions_business_lua'),
+        isTrue,
+        reason: 'v64 must recreate the (business_id, last_updated_at) sync index',
+      );
+      expect(
+        await objectExists(db2, 'index', 'idx_payment_txn_business_type'),
+        isTrue,
+        reason: 'v64 must recreate the (business_id, type, created_at) index',
+      );
+
+      // (5) The immutable trigger now guards store_id (added to the set): a
+      //     store_id edit on an existing row aborts.
+      await expectLater(
+        db2.customStatement(
+          'UPDATE payment_transactions SET store_id = ? WHERE id = ?',
+          [UuidV7.generate(), legacyPayId],
+        ),
+        throwsA(anything),
+        reason: 'store_id is immutable after insert (append-only ledger)',
+      );
+    });
+  });
 }

--- a/test/payments/reversal_payment_seam_test.dart
+++ b/test/payments/reversal_payment_seam_test.dart
@@ -1,0 +1,210 @@
+// reversal_payment_seam_test.dart
+//
+// #169 / PRD #155 — the compensating-payment-row seam
+// (`PaymentTransactionsDao.postReversalPayment`). Pins the behavior every
+// money-correction slice depends on:
+//   1. the ORIGINAL row is left untouched (no in-place void, no edit);
+//   2. the reversal lands on its OWN created_at day (the correction day),
+//      never the original's;
+//   3. it copies the original's single typed reference (so the exactly-one
+//      CHECK holds) and inherits/overrides store_id;
+//   4. the reversal is enqueued for sync as a normal payment_transactions row.
+
+import 'package:drift/drift.dart' hide isNull, isNotNull;
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:reebaplus_pos/core/database/app_database.dart';
+import 'package:reebaplus_pos/core/database/uuid_v7.dart';
+
+import '../helpers/dispatch_test_utils.dart';
+
+Future<({String storeId, String staffId, String orderId})> _seed(
+  AppDatabase db,
+  String businessId, {
+  String? storeId,
+}) async {
+  final theStoreId = storeId ?? UuidV7.generate();
+  await db.into(db.stores).insert(
+        StoresCompanion.insert(
+          id: Value(theStoreId),
+          businessId: businessId,
+          name: 'Main',
+        ),
+      );
+  final staffId = UuidV7.generate();
+  await db.into(db.users).insert(
+        UsersCompanion.insert(
+          id: Value(staffId),
+          businessId: businessId,
+          name: 'Cashier',
+          pin: '0000',
+        ),
+      );
+  final orderId = UuidV7.generate();
+  await db.into(db.orders).insert(
+        OrdersCompanion.insert(
+          id: Value(orderId),
+          businessId: businessId,
+          orderNumber: 'ORD-000001-AAAAAA',
+          totalAmountKobo: 100000,
+          netAmountKobo: 100000,
+          paymentType: 'cash',
+          status: 'completed',
+          storeId: Value(theStoreId),
+        ),
+      );
+  return (storeId: theStoreId, staffId: staffId, orderId: orderId);
+}
+
+Future<PaymentTransactionData> _insertOriginal(
+  AppDatabase db,
+  String businessId, {
+  required String orderId,
+  required String staffId,
+  required String storeId,
+  required DateTime createdAt,
+  int amountKobo = 100000,
+}) async {
+  final id = UuidV7.generate();
+  await db.into(db.paymentTransactions).insert(
+        PaymentTransactionsCompanion.insert(
+          id: Value(id),
+          businessId: businessId,
+          storeId: Value(storeId),
+          amountKobo: amountKobo,
+          method: 'cash',
+          type: 'sale',
+          orderId: Value(orderId),
+          performedBy: Value(staffId),
+          createdAt: Value(createdAt),
+          lastUpdatedAt: Value(createdAt),
+        ),
+      );
+  return (db.select(db.paymentTransactions)..where((p) => p.id.equals(id)))
+      .getSingle();
+}
+
+void main() {
+  late AppDatabase db;
+  late String businessId;
+
+  setUp(() async {
+    final boot = await bootstrapTestDb();
+    db = boot.db;
+    businessId = boot.businessId;
+  });
+
+  tearDown(() => db.close());
+
+  test(
+      'reversal leaves the original untouched and lands on its OWN created_at day',
+      () async {
+    final f = await _seed(db, businessId);
+    final saleDay = DateTime(2026, 7, 20, 10, 30);
+    final cancelDay = DateTime(2026, 7, 24, 15, 0);
+
+    final original = await _insertOriginal(
+      db,
+      businessId,
+      orderId: f.orderId,
+      staffId: f.staffId,
+      storeId: f.storeId,
+      createdAt: saleDay,
+    );
+
+    final reversal = await db.paymentTransactionsDao.postReversalPayment(
+      original: original,
+      reversalType: 'refund',
+      performedBy: f.staffId,
+      reason: 'order_cancelled',
+      at: cancelDay,
+    );
+
+    // Reversal is its own row, on the cancel day.
+    expect(reversal.id, isNot(original.id));
+    expect(reversal.type, 'refund');
+    expect(reversal.createdAt, cancelDay,
+        reason: 'reversal must land on its own creation day, not the sale day');
+    expect(reversal.amountKobo, original.amountKobo,
+        reason: 'amount defaults to the original amount');
+    expect(reversal.method, original.method);
+    expect(reversal.orderId, f.orderId,
+        reason: 'copies the original single typed reference (order_id)');
+    expect(reversal.storeId, f.storeId,
+        reason: 'store_id inherits from the original when not overridden');
+    expect(reversal.voidReason, 'order_cancelled');
+    expect(reversal.voidedAt, isNull,
+        reason: 'the reversal is a live compensating entry, not a voided row');
+
+    // Original is byte-for-byte unchanged — never voided, never re-dated.
+    final originalNow =
+        await (db.select(db.paymentTransactions)..where((p) => p.id.equals(original.id)))
+            .getSingle();
+    expect(originalNow.createdAt, saleDay);
+    expect(originalNow.voidedAt, isNull);
+    expect(originalNow.type, 'sale');
+    expect(originalNow.amountKobo, original.amountKobo);
+  });
+
+  test('reversal is enqueued as a payment_transactions upsert', () async {
+    final f = await _seed(db, businessId);
+    final original = await _insertOriginal(
+      db,
+      businessId,
+      orderId: f.orderId,
+      staffId: f.staffId,
+      storeId: f.storeId,
+      createdAt: DateTime(2026, 7, 20),
+    );
+
+    final reversal = await db.paymentTransactionsDao.postReversalPayment(
+      original: original,
+      reversalType: 'refund',
+      performedBy: f.staffId,
+    );
+
+    final pending = await getPendingQueue(db);
+    final reversalRows = pending
+        .where((r) => r.actionType == 'payment_transactions:upsert')
+        .map(decodePayload)
+        .where((p) => p['id'] == reversal.id)
+        .toList();
+    expect(reversalRows, hasLength(1),
+        reason: 'the reversal row must sync so peers converge');
+    expect(reversalRows.single['type'], 'refund');
+    expect(reversalRows.single['store_id'], f.storeId,
+        reason: 'store_id serializes to snake_case on push');
+  });
+
+  test('store_id and amount can be overridden explicitly', () async {
+    final f = await _seed(db, businessId);
+    final otherStore = UuidV7.generate();
+    await db.into(db.stores).insert(
+          StoresCompanion.insert(
+            id: Value(otherStore),
+            businessId: businessId,
+            name: 'Branch',
+          ),
+        );
+    final original = await _insertOriginal(
+      db,
+      businessId,
+      orderId: f.orderId,
+      staffId: f.staffId,
+      storeId: f.storeId,
+      createdAt: DateTime(2026, 7, 20),
+      amountKobo: 100000,
+    );
+
+    final reversal = await db.paymentTransactionsDao.postReversalPayment(
+      original: original,
+      reversalType: 'refund',
+      performedBy: f.staffId,
+      amountKobo: 40000,
+      storeId: otherStore,
+    );
+
+    expect(reversal.amountKobo, 40000);
+    expect(reversal.storeId, otherStore);
+  });
+}

--- a/test/sync/normalize_payload_whitelist_test.dart
+++ b/test/sync/normalize_payload_whitelist_test.dart
@@ -148,5 +148,38 @@ void main() {
           reason: 'stock voids append compensating rows, never re-push the '
               'original, so created_at is safe and intentionally preserved');
     });
+
+    // #169: the two crate ledgers were flagged scrubCreatedAt preemptively, so
+    // a future void re-push (a full-row upsert stamping the void columns) drops
+    // created_at exactly like the money ledgers — closing the P0001 orphan trap
+    // before any crate-void feature ships. Crate-shaped payloads to prove the
+    // real movement columns + void columns still ride.
+    for (final table in const ['crate_ledger', 'supplier_crate_ledger']) {
+      test('$table: void re-push drops created_at, movement + void cols survive',
+          () {
+        final scrubbed = SupabaseSyncService.scrubForTesting(table, {
+          'id': 'cl-1',
+          'business_id': 'biz',
+          'quantity_delta': -3,
+          'movement_type': 'returned',
+          'created_at': '2026-06-07T20:23:10.123456Z',
+          // the only legitimate mutation on an append-only ledger
+          'voided_at': '2026-07-24T09:00:00.000000Z',
+          'voided_by': 'u1',
+          'void_reason': 'order_cancelled',
+          'last_updated_at': '2026-07-24T09:00:00.000000Z',
+        });
+        expect(scrubbed.containsKey('created_at'), isFalse,
+            reason: 'crate-ledger created_at is cloud-owned; a void re-push '
+                'carrying it would trip the immutable-column trigger (P0001)');
+        expect(scrubbed['id'], 'cl-1');
+        expect(scrubbed['quantity_delta'], -3);
+        expect(scrubbed['movement_type'], 'returned');
+        expect(scrubbed['voided_at'], '2026-07-24T09:00:00.000000Z');
+        expect(scrubbed['voided_by'], 'u1');
+        expect(scrubbed['void_reason'], 'order_cancelled');
+        expect(scrubbed['last_updated_at'], '2026-07-24T09:00:00.000000Z');
+      });
+    }
   });
 }

--- a/test/sync/sync_registry_golden_test.dart
+++ b/test/sync/sync_registry_golden_test.dart
@@ -216,11 +216,15 @@ void main() {
     },
   };
 
-  // 5) The append-only ledger created_at-scrub set.
+  // 5) The append-only ledger created_at-scrub set. #169 added the two crate
+  //    ledgers preemptively (close the void-push orphan trap before any void
+  //    feature ships).
   const goldenScrubCreatedAt = <String>{
     'payment_transactions',
     'wallet_transactions',
     'supplier_ledger_entries',
+    'crate_ledger',
+    'supplier_crate_ledger',
   };
 
   // 6) The hard-delete tables (the two former switches, one set now).


### PR DESCRIPTION
Money integrity slice #1 (parent #155). Behavior-preserving prefactor — no user-visible flow changes.

## What landed
- `PaymentTransactionsDao.postReversalPayment` seam: posts a **dated** compensating `payment_transactions` reversal row (original untouched, lands on its own `created_at` day, copies the single typed reference, stamps `store_id`). Not yet called by correction paths — those are later slices.
- Schema (Drift v63→64 + cloud `0153`): nullable `payment_transactions.store_id` (stamped on all new rows; legacy rows null → business-wide as today), nullable `orders.confirmed_by` (unused until #171), payment-type CHECK widened to admit `crate_deposit` (unused until #175). All `*_kobo` stay bigint. Append-only trigger re-baked so `store_id` joins the immutable set.
- `scrubCreatedAt: true` added to `crate_ledger` + `supplier_crate_ledger` (closes the latent void-push orphan trap preemptively).
- ADR 0021 records the compensating-row + persisted-day-close decisions.
- Cash-flow reporting counts payment rows on their own `created_at` day (no-op today; the invariant later slices rely on).

## Verification
- `flutter analyze`: clean.
- Full `flutter test`: 1023 pass / 110 skip / 1 pre-existing environmental flake (`who_is_working_screen_test`, auth untouched).
- New tests: reversal seam, v63→v64 migration, whitelist normalize, sync-registry golden (scrub set).

## Deploy note
Cloud migration `0153` is authored but **not applied** — to be deployed with the money-integrity batch (no linked Supabase CLI in-repo).

Closes #169

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for recording who confirmed an order and associating payment transactions with a store.
  * Added crate deposits as a supported payment type.
  * Added payment reversal functionality that creates separate corrective transactions while preserving original records.
  * Expanded ledger synchronization safeguards for crate-related ledgers.

* **Bug Fixes**
  * Improved database upgrades from version 63 to 64 while preserving existing payment data and enforcing ledger integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->