### PR TITLE
feat(money): expense reject/delete + wallet top-up void post reversal rows (#173)

### DIFF
--- a/CONTEXT/progress-tracker.md
+++ b/CONTEXT/progress-tracker.md
@@ -10,6 +10,45 @@ The human updates it when resolving open questions or making architectural decis
 
 152 sessions logged. Codebase is live and being verified on-device.
 
+### Money integrity #4 (#173) — expense reject/delete + wallet top-up void post reversal rows — CODE-COMPLETE (2026-07-24)
+Second correction slice on the #169 seam (parent PRD #155). CODE-ONLY — **no
+schema/migration, no new permission key**. Branch
+`feat/money-integrity-4-expense-topup-reversals` off `main` (HEAD b99400f, which
+includes the merged #169 prefactor).
+- **Expense reject + soft-delete now post a compensating reversal**
+  (`daos_expenses.dart`). `addExpense` always writes a `type == 'expense'` payment
+  row (even while `pending`), so the recon cash card's `cashExpensesKobo` drained
+  forever on reject/delete. New private helper `_postExpenseCashReversal` sums the
+  CURRENT net `expense` cash for the expense and, if > 0, posts a **negative-amount
+  `expense`** row through the #169 seam (`postReversalPayment`), inside the same
+  transaction as the state change. Original (+X) + reversal (−X) → `cashExpensesKobo`
+  nets to **zero**, making the reject dialog's "No money moves" true and stopping the
+  delete-and-re-enter fix from double-counting. **Idempotent**: reverses only the
+  standing net, so reject-then-delete (or a double-tap) posts at most one reversal.
+- **Wallet top-up void** (`CreditLedgerService.voidTopup`, exposed via
+  `CustomerService.voidTopup`). One transaction: marks the original credit voided +
+  appends the compensating wallet DEBIT (referenceType `void`, mirrors
+  `WalletTransactionsDao.voidTransaction`) AND posts a **negative-amount
+  `wallet_topup`** reversal through the seam → the recon `cashDebtsCollectedKobo`
+  ("Debts collected (cash)") nets the voided collection to **zero**. Only genuine
+  top-ups (`topup_cash`/`topup_transfer`) are voidable; already-voided → no-op.
+- **Gated UI entry point** (customer detail screen credit-history rows): a trailing
+  "Void top-up" icon appears only on a LIVE cash/transfer top-up row AND when
+  `Gates.refundCustomerWallet` (`customers.wallet.withdraw`) allows — **reused an
+  existing permission, no new key** → no cloud-catalogue deploy-ordering concern.
+  Tapping it opens a confirm dialog (optional reason) → `voidTopup`, re-checking the
+  gate at the action boundary (hide-don't-block + defense-in-depth).
+- **Reversal `type` decision.** Verified against `recon_data.dart`'s cash loop
+  (`method=='cash'`, `voidedAt==null`, bucket by `type`): a same-type
+  negative-amount row is the ONLY choice that nets a cash-OUT `expense` (or a cash-IN
+  `wallet_topup`) to zero — a `refund` type would ADD to cash-out, not cancel it.
+  The seam copies the original's `method` so the reversal always lands in the same
+  bucket. No type-CHECK widening needed (both types already valid).
+- **Tests.** `test/expenses/expense_reversal_test.dart` (6) +
+  `test/wallet/topup_void_reversal_test.dart` (5) assert the compensating rows, the
+  net-to-zero via the recon's exact cash predicate, sync enqueue, idempotency, and
+  non-top-up rejection. All green; `flutter analyze` clean; golden suite unaffected.
+
 ### Money integrity #1 (#169) — payments compensating-row seam + sync/schema plumbing (prefactor) — CODE-COMPLETE (2026-07-24)
 Root prefactor of the #155 money-integrity PRD (ADR **0021**). Behavior-preserving:
 introduces the seam + schema/flag plumbing every later correction slice depends on,

--- a/lib/core/database/daos_expenses.dart
+++ b/lib/core/database/daos_expenses.dart
@@ -278,8 +278,60 @@ class ExpensesDao extends DatabaseAccessor<AppDatabase>
     }
   }
 
-  /// CEO rejects a pending expense with a reason (§20.4). No funds movement.
-  /// Notifies the recorder.
+  /// Posts a compensating reversal for an expense's paired cash record (#173 /
+  /// PRD #155). `addExpense` ALWAYS writes a `type == 'expense'`
+  /// payment_transactions row — even while the expense is still `pending` — so
+  /// the reconciliation's cash card (`recon_data.dart`, `cashExpensesKobo`:
+  /// cash-method `type == 'expense'` rows summed on their own `created_at` day)
+  /// keeps counting that cash OUT forever unless the row is reversed. Rejecting
+  /// or soft-deleting an expense therefore posts a NEGATIVE-amount `expense` row
+  /// through the #169 seam ([PaymentTransactionsDao.postReversalPayment]): the
+  /// original (+X) and the reversal (−X) net to zero on the cash card, so the
+  /// reject dialog's "No money moves" is actually true and the sanctioned
+  /// delete-and-re-enter fix stops double-counting cash out.
+  ///
+  /// Idempotent: it reverses only the CURRENT net `expense` cash still standing
+  /// for [expenseId], so a reject followed by a delete (or a double-tap) posts
+  /// at most one net-zeroing reversal. Must run inside the caller's transaction
+  /// so the reversal commits atomically with the state change; the seam opens no
+  /// transaction of its own, joining the ambient one.
+  Future<void> _postExpenseCashReversal({
+    required String expenseId,
+    required String performedBy,
+    required String reason,
+    required DateTime at,
+  }) async {
+    final rows =
+        await (select(paymentTransactions)..where(
+              (p) =>
+                  whereBusiness(p) &
+                  p.expenseId.equals(expenseId) &
+                  p.type.equals('expense'),
+            ))
+            .get();
+    if (rows.isEmpty) return;
+    // Net of the original expense row(s) minus any reversal already posted.
+    final netKobo = rows.fold<int>(0, (sum, r) => sum + r.amountKobo);
+    if (netKobo <= 0) return; // already reversed — stay idempotent
+    // Carry the original's typed reference (expense_id) + method into the
+    // reversal so it lands in the SAME cash bucket and cancels the original.
+    final original = rows.reduce(
+      (a, b) => a.createdAt.isBefore(b.createdAt) ? a : b,
+    );
+    await db.paymentTransactionsDao.postReversalPayment(
+      original: original,
+      reversalType: 'expense',
+      performedBy: performedBy,
+      amountKobo: -netKobo,
+      reason: reason,
+      at: at,
+    );
+  }
+
+  /// CEO rejects a pending expense with a reason (§20.4). No funds movement —
+  /// the paired cash record is reversed in the same transaction (#173) so the
+  /// reconciliation cash card nets this expense to zero, making the reject
+  /// dialog's "No money moves" true. Notifies the recorder.
   Future<void> rejectExpense({
     required String expenseId,
     required String approverId,
@@ -330,6 +382,15 @@ class ExpensesDao extends DatabaseAccessor<AppDatabase>
         staffId: approverId,
         storeId: exp.storeId,
         expenseId: expenseId,
+      );
+
+      // #173 — reverse the paired cash record so "No money moves on a reject"
+      // is true (nets cashExpensesKobo to zero for this expense).
+      await _postExpenseCashReversal(
+        expenseId: expenseId,
+        performedBy: approverId,
+        reason: 'Expense rejected',
+        at: now,
       );
     });
 
@@ -388,7 +449,10 @@ class ExpensesDao extends DatabaseAccessor<AppDatabase>
 
   /// Soft-deletes an expense (§20.3, CEO only, hard rule #9 — enqueueUpsert, not
   /// delete). The 24h / role gate is enforced by the caller. (Funds Register was
-  /// removed, §23, so a delete no longer reverses any account balance.)
+  /// removed, §23, so a delete no longer reverses any account balance.) The
+  /// paired cash record IS reversed in the same transaction (#173) so the
+  /// sanctioned delete-and-re-enter wrong-amount fix does not double-count cash
+  /// out on the reconciliation cash card.
   Future<void> softDeleteExpense({
     required String expenseId,
     required String performedBy,
@@ -429,6 +493,15 @@ class ExpensesDao extends DatabaseAccessor<AppDatabase>
         expenses,
       )..where((t) => t.id.equals(expenseId) & whereBusiness(t))).getSingle();
       await db.syncDao.enqueueUpsert('expenses', row.toCompanion(true));
+
+      // #173 — reverse the paired cash record so delete-then-re-create does not
+      // double-count cash out (nets cashExpensesKobo to zero for this expense).
+      await _postExpenseCashReversal(
+        expenseId: expenseId,
+        performedBy: performedBy,
+        reason: 'Expense deleted',
+        at: now,
+      );
     });
 
     if (didDelete) {

--- a/lib/features/customers/data/services/customer_service.dart
+++ b/lib/features/customers/data/services/customer_service.dart
@@ -185,6 +185,24 @@ class CustomerService extends ValueNotifier<List<Customer>> {
     );
   }
 
+  /// §18 / PRD #155 (#173) — voids a mistyped customer credit top-up
+  /// (CEO/Manager only; gated at the UI on `customers.wallet.withdraw`).
+  /// Delegates to [CreditLedgerService.voidTopup], which appends the
+  /// compensating wallet debit AND the reversal payment row atomically so the
+  /// voided amount drops out of the reconciliation's "Debts collected".
+  /// Returns whether a void was posted (false = not a live top-up).
+  Future<bool> voidTopup({
+    required String walletTxnId,
+    required String staffId,
+    String? reason,
+  }) {
+    return CreditLedgerService(_db).voidTopup(
+      walletTxnId: walletTxnId,
+      staffId: staffId,
+      reason: reason,
+    );
+  }
+
   Future<void> updateWalletLimit(String customerId, double newLimit) async {
     final customer = getById(customerId);
     if (customer == null) {

--- a/lib/features/customers/screens/customer_detail_screen.dart
+++ b/lib/features/customers/screens/customer_detail_screen.dart
@@ -898,6 +898,88 @@ class _CustomerDetailScreenState extends ConsumerState<CustomerDetailScreen> {
     }
   }
 
+  /// §18 / PRD #155 (#173) — confirm, then void a mistyped customer credit
+  /// top-up (CEO/Manager only, gated on `customers.wallet.withdraw`). Appends
+  /// the compensating wallet debit AND the reversal payment row so the amount
+  /// drops out of the reconciliation's "Debts collected". Only offered on a
+  /// live cash/transfer top-up row.
+  Future<void> _confirmVoidTopup(WalletTransactionData txn) async {
+    // Defense-in-depth: re-check the gate at the action boundary (hard rule #6).
+    if (!Gates.refundCustomerWallet.allowsNow(ref)) return;
+    final staffId = ref.read(authProvider).currentUser?.id;
+    if (staffId == null) {
+      AppNotification.showError(
+        context,
+        'Could not void this top-up yet — no active session.',
+      );
+      return;
+    }
+    final theme = Theme.of(context);
+    final reasonCtrl = TextEditingController();
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        backgroundColor: theme.colorScheme.surface,
+        title: const Text('Void this credit top-up?'),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              '${formatCurrency(txn.amountKobo / 100)} will be reversed from '
+              '$_name\'s credit balance and dropped from Debts collected. '
+              'This cannot be undone.',
+            ),
+            SizedBox(height: ctx.getRSize(12)),
+            TextField(
+              controller: reasonCtrl,
+              decoration: const InputDecoration(
+                labelText: 'Reason (optional)',
+              ),
+            ),
+          ],
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, false),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            child: const Text('Void', style: TextStyle(color: danger)),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true || !mounted) return;
+    final messenger = ScaffoldMessenger.of(context);
+    final reason = reasonCtrl.text.trim();
+    try {
+      final voided = await ref
+          .read(customerServiceProvider)
+          .voidTopup(
+            walletTxnId: txn.id,
+            staffId: staffId,
+            reason: reason.isEmpty ? null : reason,
+          );
+      if (!mounted) return;
+      messenger.showSnackBar(
+        SnackBar(
+          content: Text(
+            voided ? 'Top-up voided' : 'This top-up can no longer be voided',
+          ),
+          backgroundColor: voided ? success : danger,
+        ),
+      );
+    } catch (_) {
+      if (!mounted) return;
+      AppNotification.showError(
+        context,
+        'Could not void this top-up. Please try again.',
+      );
+    }
+  }
+
   /// §18 — open the prefilled Edit Customer Details sheet (CEO/Manager only,
   /// `customers.update`). Prefill comes from the live watched row, falling back
   /// to the row this screen was opened with.
@@ -1906,6 +1988,16 @@ class _CustomerDetailScreenState extends ConsumerState<CustomerDetailScreen> {
                     final isCredit = txn.type == 'credit';
                     final amount = txn.amountKobo / 100.0;
                     final color = isCredit ? success : danger;
+                    // #173 — a live cash/transfer top-up can be voided by anyone
+                    // who can withdraw from the wallet (the sanctioned fix for a
+                    // mistyped Add Credit). Hide-don't-block: no affordance
+                    // renders when the gate is denied or the row isn't a live
+                    // top-up.
+                    final isVoidableTopup =
+                        txn.voidedAt == null &&
+                        (txn.referenceType == 'topup_cash' ||
+                            txn.referenceType == 'topup_transfer') &&
+                        Gates.refundCustomerWallet.allows(ref);
                     return Padding(
                       padding: EdgeInsets.only(bottom: ctx.getRSize(10)),
                       child: _GlassyCard(
@@ -1962,6 +2054,24 @@ class _CustomerDetailScreenState extends ConsumerState<CustomerDetailScreen> {
                                 color: color,
                               ),
                             ),
+                            if (isVoidableTopup) ...[
+                              SizedBox(width: ctx.getRSize(6)),
+                              IconButton(
+                                visualDensity: VisualDensity.compact,
+                                padding: EdgeInsets.zero,
+                                constraints: BoxConstraints(
+                                  minWidth: ctx.getRSize(32),
+                                  minHeight: ctx.getRSize(32),
+                                ),
+                                tooltip: 'Void top-up',
+                                icon: Icon(
+                                  FontAwesomeIcons.arrowRotateLeft.data,
+                                  size: ctx.getRSize(14),
+                                  color: danger,
+                                ),
+                                onPressed: () => _confirmVoidTopup(txn),
+                              ),
+                            ],
                           ],
                         ),
                       ),

--- a/lib/shared/services/credit_ledger_service.dart
+++ b/lib/shared/services/credit_ledger_service.dart
@@ -291,4 +291,134 @@ class CreditLedgerService {
     voidedBy: voidedBy,
     reason: reason,
   );
+
+  /// §18 / PRD #155 (#173) — voids a customer credit TOP-UP by [walletTxnId]
+  /// (the top-up's `wallet_transactions` credit row). A mistyped Add-Credit
+  /// entry is corrected without fabricating an offsetting sale. In ONE
+  /// transaction it:
+  ///   1. marks the original credit voided and appends a compensating wallet
+  ///      DEBIT (referenceType `void`) — the same append-only pattern as
+  ///      [WalletTransactionsDao.voidTransaction], so the derived balance drops
+  ///      the credit; and
+  ///   2. reverses the paired `wallet_topup` payment row through the #169 seam
+  ///      ([PaymentTransactionsDao.postReversalPayment]) with a NEGATIVE amount,
+  ///      so the reconciliation cash card's "Debts collected (cash)"
+  ///      (`cashDebtsCollectedKobo`: cash-method `type == 'wallet_topup'` rows)
+  ///      nets this collection to zero — the voided amount drops out.
+  ///
+  /// Only genuine top-ups (referenceType `topup_cash` / `topup_transfer`) are
+  /// voidable here; anything else is a no-op. Idempotent — an already-voided
+  /// top-up returns false. The UI entry point (customer screen) is gated on
+  /// `customers.wallet.withdraw` (Gates.refundCustomerWallet). Returns whether a
+  /// void was posted.
+  Future<bool> voidTopup({
+    required String walletTxnId,
+    required String staffId,
+    String? reason,
+  }) async {
+    const topupRefs = {'topup_cash', 'topup_transfer'};
+    final businessId = _walletTxDao.requireBusinessId();
+
+    return _db.transaction(() async {
+      final original =
+          await (_db.select(_db.walletTransactions)
+                ..where(
+                  (t) =>
+                      t.businessId.equals(businessId) &
+                      t.id.equals(walletTxnId),
+                )
+                ..limit(1))
+              .getSingleOrNull();
+      if (original == null) return false;
+      if (original.voidedAt != null) return false; // already voided
+      if (!topupRefs.contains(original.referenceType)) return false;
+
+      final now = DateTime.now();
+
+      // 1a. Mark the original credit voided in place (retained metadata, as
+      //     WalletTransactionsDao.voidTransaction does).
+      await (_db.update(
+        _db.walletTransactions,
+      )..where((t) => t.id.equals(walletTxnId))).write(
+        WalletTransactionsCompanion(
+          voidedAt: Value(now),
+          voidedBy: Value(staffId),
+          voidReason: Value(reason),
+          lastUpdatedAt: Value(now),
+        ),
+      );
+
+      // 1b. Append the compensating wallet debit (opposite sign) so the derived
+      //     balance drops the credit.
+      final compId = UuidV7.generate();
+      final compComp = WalletTransactionsCompanion.insert(
+        id: Value(compId),
+        businessId: businessId,
+        walletId: original.walletId,
+        customerId: original.customerId,
+        type: original.type == 'credit' ? 'debit' : 'credit',
+        amountKobo: original.amountKobo,
+        signedAmountKobo: -original.signedAmountKobo,
+        referenceType: 'void',
+        orderId: Value(original.orderId),
+        performedBy: Value(staffId),
+        createdAt: Value(now),
+        lastUpdatedAt: Value(now),
+      );
+      await _db.into(_db.walletTransactions).insert(compComp);
+
+      final updatedOrig =
+          await (_db.select(_db.walletTransactions)
+                ..where((t) => t.id.equals(walletTxnId))
+                ..limit(1))
+              .getSingle();
+      await _db.syncDao.enqueueUpsert('wallet_transactions', updatedOrig);
+      await _db.syncDao.enqueueUpsert('wallet_transactions', compComp);
+
+      // 2. Reverse the paired payment row (#169 seam), negative so the cash
+      //    card nets the collection to zero. Legacy top-ups with no payment row
+      //    (e.g. pre-ledger data) simply skip this leg.
+      final payment =
+          await (_db.select(_db.paymentTransactions)
+                ..where(
+                  (p) =>
+                      p.businessId.equals(businessId) &
+                      p.walletTxnId.equals(walletTxnId) &
+                      p.type.equals('wallet_topup'),
+                )
+                ..limit(1))
+              .getSingleOrNull();
+      if (payment != null) {
+        await _db.paymentTransactionsDao.postReversalPayment(
+          original: payment,
+          reversalType: 'wallet_topup',
+          performedBy: staffId,
+          amountKobo: -payment.amountKobo,
+          reason: reason,
+          at: now,
+        );
+      }
+
+      // 3. Audit + notify (§24 money movement).
+      await _db.activityLogDao.logActivity(
+        action: 'customer.wallet.topup_voided',
+        description:
+            'Voided credit top-up of '
+            '${formatCurrency(original.amountKobo / 100)}'
+            '${reason != null && reason.trim().isNotEmpty ? ' — ${reason.trim()}' : ''}',
+        staffId: staffId,
+        entityType: 'customer',
+        entityId: original.customerId,
+      );
+      await _db.notificationsDao.fireNotification(
+        type: 'wallet_topup_voided',
+        message:
+            'A credit top-up of '
+            '${formatCurrency(original.amountKobo / 100)} was voided',
+        severity: 'info',
+        linkedRecordId: original.customerId,
+      );
+      return true;
+    });
+  }
 }

--- a/test/expenses/expense_reversal_test.dart
+++ b/test/expenses/expense_reversal_test.dart
@@ -1,0 +1,248 @@
+// expense_reversal_test.dart
+//
+// #173 / PRD #155 — rejecting or soft-deleting an expense posts a compensating
+// reversal payment row (through the #169 seam) so the reconciliation cash card
+// nets that expense's cash OUT to zero. Asserted at the DAO / in-memory-Drift
+// transaction boundary.
+//
+// The cash card (recon_data.dart) sums `cashExpensesKobo` as: for each
+// `payment_transactions` row with `voidedAt == null`, `method == 'cash'` and
+// `type == 'expense'` on its own `created_at` day, `+= amountKobo`. These tests
+// reproduce that exact predicate to prove the net after a correction is zero.
+
+import 'package:drift/drift.dart' hide isNotNull, isNull;
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:reebaplus_pos/core/database/app_database.dart';
+import 'package:reebaplus_pos/core/database/uuid_v7.dart';
+
+import '../helpers/dispatch_test_utils.dart';
+
+void main() {
+  late AppDatabase db;
+  late String businessId;
+  late String staffId;
+
+  setUp(() async {
+    final boot = await bootstrapTestDb();
+    db = boot.db;
+    businessId = boot.businessId;
+    staffId = UuidV7.generate();
+    await db.into(db.users).insert(
+          UsersCompanion.insert(
+            id: Value(staffId),
+            businessId: businessId,
+            name: 'Manager',
+            pin: '0000',
+          ),
+        );
+  });
+
+  tearDown(() => db.close());
+
+  /// The reconciliation's `cashExpensesKobo` contribution: cash-method,
+  /// non-voided `expense` payment rows summed on amount. Zero ⇒ nets out.
+  Future<int> cashExpensesNet() async {
+    final rows = await (db.select(db.paymentTransactions)
+          ..where((p) => p.type.equals('expense')))
+        .get();
+    return rows
+        .where((p) => p.voidedAt == null && p.method.toLowerCase() == 'cash')
+        .fold<int>(0, (s, p) => s + p.amountKobo);
+  }
+
+  Future<ExpenseData> onlyExpense() async {
+    return (db.select(db.expenses)..where((e) => e.isDeleted.not()))
+        .get()
+        .then((rows) => rows.single);
+  }
+
+  test('rejecting an expense posts a −amount reversal and nets the cash to zero',
+      () async {
+    await db.expensesDao.addExpense(
+      categoryName: 'Fuel',
+      amountKobo: 5000,
+      description: 'Generator fuel',
+      paymentMethod: 'cash',
+      recordedBy: staffId,
+      status: 'pending',
+    );
+    final exp = await onlyExpense();
+
+    // Before reject: the single 'expense' cash row drains the card.
+    expect(await cashExpensesNet(), 5000);
+
+    await db.expensesDao.rejectExpense(
+      expenseId: exp.id,
+      approverId: staffId,
+      reason: 'wrong category',
+    );
+
+    // After reject: original (+5000) + reversal (−5000) net to zero.
+    expect(await cashExpensesNet(), 0,
+        reason: '"No money moves on a reject" must be true on the cash card');
+
+    final expenseRows = await (db.select(db.paymentTransactions)
+          ..where((p) => p.type.equals('expense')))
+        .get();
+    expect(expenseRows, hasLength(2),
+        reason: 'original + one compensating reversal');
+    final reversal = expenseRows.firstWhere((p) => p.amountKobo < 0);
+    expect(reversal.amountKobo, -5000);
+    expect(reversal.type, 'expense',
+        reason: 'reversal stays in the SAME cash bucket so it cancels');
+    expect(reversal.expenseId, exp.id,
+        reason: 'reversal copies the original typed reference (expense_id)');
+    expect(reversal.method, 'cash',
+        reason: 'reversal inherits the original method so it nets in-bucket');
+    expect(reversal.voidedAt, isNull,
+        reason: 'a live compensating entry, not a voided row');
+
+    // The original expense row is untouched (append-only discipline).
+    final original = expenseRows.firstWhere((p) => p.amountKobo > 0);
+    expect(original.amountKobo, 5000);
+    expect(original.voidedAt, isNull);
+  });
+
+  test('the reversal row is enqueued for sync', () async {
+    await db.expensesDao.addExpense(
+      categoryName: 'Fuel',
+      amountKobo: 5000,
+      description: 'Fuel',
+      paymentMethod: 'cash',
+      recordedBy: staffId,
+      status: 'pending',
+    );
+    final exp = await onlyExpense();
+    await db.expensesDao.rejectExpense(
+      expenseId: exp.id,
+      approverId: staffId,
+      reason: 'x',
+    );
+
+    final reversal = await (db.select(db.paymentTransactions)
+          ..where((p) => p.type.equals('expense') & p.amountKobo.isSmallerThanValue(0)))
+        .getSingle();
+    final pending = await getPendingQueue(db);
+    final enqueued = pending
+        .where((r) => r.actionType == 'payment_transactions:upsert')
+        .map(decodePayload)
+        .where((p) => p['id'] == reversal.id)
+        .toList();
+    expect(enqueued, hasLength(1),
+        reason: 'the reversal must sync so peers converge');
+    expect(enqueued.single['amount_kobo'], -5000);
+  });
+
+  test('soft-deleting an expense posts a reversal and nets the cash to zero',
+      () async {
+    await db.expensesDao.addExpense(
+      categoryName: 'Rent',
+      amountKobo: 8000,
+      description: 'Shop rent',
+      paymentMethod: 'cash',
+      recordedBy: staffId,
+    );
+    final exp = await onlyExpense();
+    expect(await cashExpensesNet(), 8000);
+
+    await db.expensesDao.softDeleteExpense(
+      expenseId: exp.id,
+      performedBy: staffId,
+    );
+
+    expect(await cashExpensesNet(), 0);
+    final rows = await (db.select(db.paymentTransactions)
+          ..where((p) => p.type.equals('expense')))
+        .get();
+    expect(rows, hasLength(2));
+    expect(rows.firstWhere((p) => p.amountKobo < 0).amountKobo, -8000);
+  });
+
+  test('delete-then-re-create does NOT double-count cash out', () async {
+    // Wrong amount entered.
+    await db.expensesDao.addExpense(
+      categoryName: 'Rent',
+      amountKobo: 8000,
+      description: 'Shop rent (typo)',
+      paymentMethod: 'cash',
+      recordedBy: staffId,
+    );
+    final wrong = await onlyExpense();
+
+    // Sanctioned fix: soft-delete, then re-enter the correct amount.
+    await db.expensesDao.softDeleteExpense(
+      expenseId: wrong.id,
+      performedBy: staffId,
+    );
+    await db.expensesDao.addExpense(
+      categoryName: 'Rent',
+      amountKobo: 3000,
+      description: 'Shop rent (correct)',
+      paymentMethod: 'cash',
+      recordedBy: staffId,
+    );
+
+    // The cash card must reflect ONLY the correct 3,000 — not 8,000, not 11,000.
+    expect(await cashExpensesNet(), 3000);
+  });
+
+  test('reject then delete reverses at most once (idempotent)', () async {
+    await db.expensesDao.addExpense(
+      categoryName: 'Fuel',
+      amountKobo: 5000,
+      description: 'Fuel',
+      paymentMethod: 'cash',
+      recordedBy: staffId,
+      status: 'pending',
+    );
+    final exp = await onlyExpense();
+
+    await db.expensesDao.rejectExpense(
+      expenseId: exp.id,
+      approverId: staffId,
+      reason: 'wrong',
+    );
+    // A rejected expense can then be soft-deleted — it must not over-reverse.
+    await db.expensesDao.softDeleteExpense(
+      expenseId: exp.id,
+      performedBy: staffId,
+    );
+
+    expect(await cashExpensesNet(), 0);
+    final rows = await (db.select(db.paymentTransactions)
+          ..where((p) => p.type.equals('expense')))
+        .get();
+    expect(rows, hasLength(2),
+        reason: 'exactly one reversal — the delete sees net 0 and adds none');
+  });
+
+  test('a transfer-method expense reverses without touching the cash card',
+      () async {
+    await db.expensesDao.addExpense(
+      categoryName: 'Supplies',
+      amountKobo: 4000,
+      description: 'Bank transfer expense',
+      paymentMethod: 'transfer',
+      recordedBy: staffId,
+    );
+    final exp = await onlyExpense();
+    // A transfer expense never hit the cash card in the first place.
+    expect(await cashExpensesNet(), 0);
+
+    await db.expensesDao.softDeleteExpense(
+      expenseId: exp.id,
+      performedBy: staffId,
+    );
+
+    // Still zero on the cash card, and the reversal mirrors the method so the
+    // full-expense ledger nets out too.
+    expect(await cashExpensesNet(), 0);
+    final rows = await (db.select(db.paymentTransactions)
+          ..where((p) => p.type.equals('expense')))
+        .get();
+    final net = rows.fold<int>(0, (s, p) => s + p.amountKobo);
+    expect(net, 0);
+    expect(rows.firstWhere((p) => p.amountKobo < 0).method, 'transfer');
+  });
+}

--- a/test/wallet/topup_void_reversal_test.dart
+++ b/test/wallet/topup_void_reversal_test.dart
@@ -1,0 +1,220 @@
+// topup_void_reversal_test.dart
+//
+// #173 / PRD #155 — voiding a customer credit top-up posts a reversal payment
+// row (through the #169 seam) ALONGSIDE the compensating wallet leg, so the
+// voided amount drops out of the reconciliation's "Debts collected (cash)".
+// Asserted at the DAO / service transaction boundary against in-memory Drift.
+//
+// The cash card (recon_data.dart) sums `cashDebtsCollectedKobo` as: for each
+// non-voided cash-method `type == 'wallet_topup'` payment row, `+= amountKobo`.
+// These tests reproduce that predicate to prove the net after a void is zero.
+
+import 'package:drift/drift.dart' hide isNotNull, isNull;
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:reebaplus_pos/core/database/app_database.dart';
+import 'package:reebaplus_pos/core/database/uuid_v7.dart';
+import 'package:reebaplus_pos/shared/services/credit_ledger_service.dart';
+
+import '../helpers/dispatch_test_utils.dart';
+
+void main() {
+  late AppDatabase db;
+  late String businessId;
+  late String staffId;
+  late String customerId;
+  late CreditLedgerService ledger;
+
+  setUp(() async {
+    final boot = await bootstrapTestDb();
+    db = boot.db;
+    businessId = boot.businessId;
+    staffId = UuidV7.generate();
+    await db.into(db.users).insert(
+          UsersCompanion.insert(
+            id: Value(staffId),
+            businessId: businessId,
+            name: 'Manager',
+            pin: '0000',
+          ),
+        );
+    customerId = await db.customersDao.addCustomer(
+      CustomersCompanion.insert(name: 'Ada', businessId: businessId),
+    );
+    ledger = CreditLedgerService(db);
+  });
+
+  tearDown(() => db.close());
+
+  /// The reconciliation's `cashDebtsCollectedKobo` contribution: non-voided
+  /// cash-method `wallet_topup` rows summed on amount. Zero ⇒ dropped out.
+  Future<int> cashDebtsCollectedNet() async {
+    final rows = await (db.select(db.paymentTransactions)
+          ..where((p) => p.type.equals('wallet_topup')))
+        .get();
+    return rows
+        .where((p) => p.voidedAt == null && p.method.toLowerCase() == 'cash')
+        .fold<int>(0, (s, p) => s + p.amountKobo);
+  }
+
+  Future<WalletTransactionData> topupWalletTxn() async {
+    return (db.select(db.walletTransactions)
+          ..where((t) =>
+              t.referenceType.isIn(['topup_cash', 'topup_transfer']) &
+              t.type.equals('credit')))
+        .get()
+        .then((rows) => rows.single);
+  }
+
+  test('voiding a top-up posts a reversal + compensating wallet leg and drops '
+      'the amount from Debts collected', () async {
+    await ledger.topup(
+      customerId: customerId,
+      amountKobo: 10000,
+      method: 'cash',
+      staffId: staffId,
+    );
+
+    // Before void: collected as cash debt, credit balance +10,000.
+    expect(await cashDebtsCollectedNet(), 10000);
+    expect(await ledger.getBalanceKobo(customerId), 10000);
+
+    final topup = await topupWalletTxn();
+    final voided = await ledger.voidTopup(
+      walletTxnId: topup.id,
+      staffId: staffId,
+      reason: 'mistyped amount',
+    );
+    expect(voided, isTrue);
+
+    // Debts collected nets to zero.
+    expect(await cashDebtsCollectedNet(), 0,
+        reason: 'a voided collection must drop out of "Debts collected"');
+
+    // A NEGATIVE wallet_topup reversal payment row exists (seam), referencing
+    // the same wallet txn, still live (not voided-in-place).
+    final payRows = await (db.select(db.paymentTransactions)
+          ..where((p) => p.type.equals('wallet_topup')))
+        .get();
+    expect(payRows, hasLength(2));
+    final reversal = payRows.firstWhere((p) => p.amountKobo < 0);
+    expect(reversal.amountKobo, -10000);
+    expect(reversal.walletTxnId, topup.id);
+    expect(reversal.voidedAt, isNull);
+    // The original payment row is untouched.
+    expect(payRows.firstWhere((p) => p.amountKobo > 0).voidedAt, isNull);
+
+    // The compensating wallet leg zeroes the credit balance.
+    expect(await ledger.getBalanceKobo(customerId), 0);
+    final compLeg = await (db.select(db.walletTransactions)
+          ..where((t) => t.referenceType.equals('void')))
+        .getSingle();
+    expect(compLeg.signedAmountKobo, -10000);
+    expect(compLeg.type, 'debit');
+
+    // The original credit is marked voided (metadata retained).
+    final origNow = await (db.select(db.walletTransactions)
+          ..where((t) => t.id.equals(topup.id)))
+        .getSingle();
+    expect(origNow.voidedAt, isNotNull);
+  });
+
+  test('a transfer top-up void still zeroes the balance (not on the cash card)',
+      () async {
+    await ledger.topup(
+      customerId: customerId,
+      amountKobo: 7000,
+      method: 'transfer',
+      staffId: staffId,
+    );
+    expect(await cashDebtsCollectedNet(), 0); // transfer never on the cash card
+
+    final topup = await topupWalletTxn();
+    expect(await ledger.voidTopup(walletTxnId: topup.id, staffId: staffId),
+        isTrue);
+
+    expect(await ledger.getBalanceKobo(customerId), 0);
+    final net = await (db.select(db.paymentTransactions)
+          ..where((p) => p.type.equals('wallet_topup')))
+        .get()
+        .then((r) => r.fold<int>(0, (s, p) => s + p.amountKobo));
+    expect(net, 0, reason: 'the wallet_topup ledger nets out regardless');
+  });
+
+  test('the reversal payment row is enqueued for sync', () async {
+    await ledger.topup(
+      customerId: customerId,
+      amountKobo: 5000,
+      method: 'cash',
+      staffId: staffId,
+    );
+    final topup = await topupWalletTxn();
+    await ledger.voidTopup(walletTxnId: topup.id, staffId: staffId);
+
+    final reversal = await (db.select(db.paymentTransactions)
+          ..where((p) =>
+              p.type.equals('wallet_topup') &
+              p.amountKobo.isSmallerThanValue(0)))
+        .getSingle();
+    final enqueued = (await getPendingQueue(db))
+        .where((r) => r.actionType == 'payment_transactions:upsert')
+        .map(decodePayload)
+        .where((p) => p['id'] == reversal.id)
+        .toList();
+    expect(enqueued, hasLength(1));
+    expect(enqueued.single['amount_kobo'], -5000);
+  });
+
+  test('voiding twice is idempotent (second call is a no-op)', () async {
+    await ledger.topup(
+      customerId: customerId,
+      amountKobo: 5000,
+      method: 'cash',
+      staffId: staffId,
+    );
+    final topup = await topupWalletTxn();
+
+    expect(await ledger.voidTopup(walletTxnId: topup.id, staffId: staffId),
+        isTrue);
+    expect(await ledger.voidTopup(walletTxnId: topup.id, staffId: staffId),
+        isFalse,
+        reason: 'an already-voided top-up cannot be voided again');
+
+    // Still exactly one reversal — no double-reversal.
+    final reversals = await (db.select(db.paymentTransactions)
+          ..where((p) =>
+              p.type.equals('wallet_topup') &
+              p.amountKobo.isSmallerThanValue(0)))
+        .get();
+    expect(reversals, hasLength(1));
+    expect(await cashDebtsCollectedNet(), 0);
+  });
+
+  test('a non-top-up wallet entry is not voidable through this path', () async {
+    // Post a spendable refund credit (not a top-up).
+    final refundId = UuidV7.generate();
+    final wallet = await db.customerWalletsDao.getByCustomerId(customerId);
+    await db.into(db.walletTransactions).insert(
+          WalletTransactionsCompanion.insert(
+            id: Value(refundId),
+            businessId: businessId,
+            walletId: wallet!.id,
+            customerId: customerId,
+            type: 'credit',
+            amountKobo: 3000,
+            signedAmountKobo: 3000,
+            referenceType: 'refund',
+            performedBy: Value(staffId),
+          ),
+        );
+
+    expect(await ledger.voidTopup(walletTxnId: refundId, staffId: staffId),
+        isFalse,
+        reason: 'only genuine top-ups are voidable here');
+    // Untouched.
+    final row = await (db.select(db.walletTransactions)
+          ..where((t) => t.id.equals(refundId)))
+        .getSingle();
+    expect(row.voidedAt, isNull);
+  });
+}


### PR DESCRIPTION
Money integrity slice #4 (parent #155). Code-only; no schema/permission change.

## What landed
- **Expense reject + soft-delete** post a compensating **negative-amount `expense`** payment row (via the #169 `postReversalPayment` seam) inside the same transaction. `addExpense` writes the expense payment row even while pending, so the recon cash card counted it forever; the reversal nets it to zero → the reject dialog's "No money moves" is finally true, and delete-and-re-enter no longer double-counts. Reverses only the *net* standing expense cash → idempotent across reject-then-delete.
- **Wallet top-up void**: `CreditLedgerService.voidTopup` posts a compensating wallet debit + a negative-amount `wallet_topup` reversal row in one transaction; voided collections drop out of "Debts collected". New **gated** "Void top-up" entry point on the customer detail screen, reusing `Gates.refundCustomerWallet` (`customers.wallet.withdraw`, CEO+Manager).
- Signed-row reversal is consistent with ADR 0021 ("balances derived by summing signed rows"). Cloud `payment_transactions.amount_kobo` has no `>=0` CHECK, so negative rows sync fine; types stay within the CHECK.

## Verification
- `flutter analyze`: clean.
- Full suite: 1034 pass / ~110 skip / 1 pre-existing flake (`who_is_working_screen_test`). 11 new tests (expense reversal ×6, top-up void ×5) independently re-run green.

Closes #173