### PR TITLE
feat(money): cancel writes a compensating cash-out row; retire dead refunded (#172)

### DIFF
--- a/lib/core/database/daos_orders.dart
+++ b/lib/core/database/daos_orders.dart
@@ -1161,9 +1161,11 @@ class OrdersDao extends DatabaseAccessor<AppDatabase>
     });
   }
 
-  /// Cancel/refund an order (§19.7): append compensating stock rows, void the
-  /// payments, and reverse both wallet legs so the customer's wallet returns to
-  /// its pre-sale balance. Inventory is restored.
+  /// Cancel/refund an order (§19.7): append compensating stock rows, post a
+  /// dated refund cash-out row for the goods paid (the original sale payment is
+  /// left intact — money leaves on the cancel day, #172), and reverse both
+  /// wallet legs so the customer's wallet returns to its pre-sale balance.
+  /// Inventory is restored.
   Future<void> markCancelled(
     String orderId,
     String reason,
@@ -1265,22 +1267,43 @@ class OrdersDao extends DatabaseAccessor<AppDatabase>
         await db.syncDao.enqueueUpsert('inventory', invRow);
       }
 
-      // Payment: void metadata ONLY (never append a new payment row)
-      await (update(
-        paymentTransactions,
-      )..where((p) => p.orderId.equals(orderId) & p.voidedAt.isNull())).write(
-        PaymentTransactionsCompanion(
-          voidedAt: Value(now.toUtc()),
-          voidedBy: Value(staffId),
-          voidReason: Value('order_cancelled: $reason'),
-          lastUpdatedAt: Value(now),
-        ),
-      );
-      final updatedPays = await (select(
-        paymentTransactions,
-      )..where((p) => p.orderId.equals(orderId) & whereBusiness(p))).get();
-      for (final pay in updatedPays) {
-        await db.syncDao.enqueueUpsert('payment_transactions', pay);
+      // Payment: post a DATED compensating refund cash-out row through the #169
+      // seam (PRD #155) — the append-only ledger discipline. The ORIGINAL sale
+      // row is LEFT UNTOUCHED (no in-place void): cash reporting counts each
+      // payment row on its OWN created_at day, so the sale stays on the sale day
+      // — a day the owner may have already reviewed and banked against — and the
+      // refund lands on the CANCEL day ([now]). We reverse only the GOODS
+      // portion of the amount actually paid (`amountPaid − crateDepositPaid`);
+      // the crate deposit is released on the crate/wallet side above (#162's
+      // `crate_deposit_refunded` debit deflates "held"), never as a second
+      // cash-out here. The seam copies the sale row's single typed reference
+      // (order_id), its store, and its method, so the refund links back to the
+      // order and a cash tender yields a cash refund. (In practice createOrder
+      // writes exactly one 'sale' row per order; the loop is defensive.)
+      final orderRow = await (select(
+        orders,
+      )..where((o) => o.id.equals(orderId) & whereBusiness(o))).getSingle();
+      final salePayments =
+          await (select(paymentTransactions)..where(
+                (p) =>
+                    p.orderId.equals(orderId) &
+                    whereBusiness(p) &
+                    p.type.equals('sale') &
+                    p.voidedAt.isNull(),
+              ))
+              .get();
+      for (final sale in salePayments) {
+        final rawGoodsKobo = sale.amountKobo - orderRow.crateDepositPaidKobo;
+        final goodsPaidKobo = rawGoodsKobo < 0 ? 0 : rawGoodsKobo;
+        if (goodsPaidKobo <= 0) continue;
+        await db.paymentTransactionsDao.postReversalPayment(
+          original: sale,
+          reversalType: 'refund',
+          performedBy: staffId,
+          amountKobo: goodsPaidKobo,
+          reason: 'order_cancelled: $reason',
+          at: now,
+        );
       }
 
       // Wallet: reverse the legs the sale posted (§14.3 / §13.4) so the customer

--- a/lib/features/dashboard/reconciliation/recon_data.dart
+++ b/lib/features/dashboard/reconciliation/recon_data.dart
@@ -619,23 +619,18 @@ ReconData computeReconData(
   var discountsKobo = 0;
   var itemsSold = 0;
   var uncostedItems = 0;
-  var refundsKobo = 0;
   final skuSet = <String>{};
   final byStaff = <String?, int>{};
   final byProduct = <String, ({String name, int qty})>{};
   for (final o in orders) {
-    if (o.order.status == 'refunded') {
-      if (inSpan(o.order.createdAt) && inScope(o.order.storeId)) {
-        refundsKobo += o.order.amountPaidKobo;
-      }
-      continue;
-    }
-    // Recognized at checkout ('pending'), not at Confirm ('completed').
+    // Recognized at checkout ('pending'), not at Confirm ('completed'). A
+    // cancelled order is excluded here (orderCountsAsSale is false) — its money
+    // reversal is booked as a real refund payment row, summed below.
     if (!orderCountsAsSale(o.order.status) || !inSpan(o.order.createdAt)) {
       continue;
     }
     // Order-level discount (contra-revenue). Scoped by the order's store to
-    // match refunds above; lines carry the same storeId in practice.
+    // match the sales lines; lines carry the same storeId in practice.
     if (inScope(o.order.storeId)) discountsKobo += o.order.discountKobo;
     var orderRevenue = 0;
     for (final i in o.items) {
@@ -912,6 +907,25 @@ ReconData computeReconData(
         supplierPaidKobo += l.amountKobo;
       }
     }
+  }
+
+  // ── Refunds (P&L contra + net-result outflow) ────────────────────────────
+  // Every real refund payment row in the period, any tender — the amount
+  // actually paid back to customers. Derived from the append-only payment
+  // ledger (`type == 'refund'`), NOT the retired `orders.status == 'refunded'`
+  // (a status nothing writes, so the old figure read ₦0 forever — #172). A
+  // cancelled sale posts a dated refund cash-out row on the cancel day
+  // (OrdersDao.markCancelled), so refunds land on the day money left and a
+  // reviewed/banked sale day never silently shrinks. Scoped by the row's store
+  // (legacy null-store rows fold into the All-Stores aggregate, as elsewhere)
+  // and by its own created_at day.
+  var refundsKobo = 0;
+  for (final p in payments) {
+    if (p.voidedAt != null) continue;
+    if (p.type != 'refund') continue;
+    if (!inSpan(p.createdAt)) continue;
+    if (!inScope(p.storeId)) continue;
+    refundsKobo += p.amountKobo;
   }
 
   // ── Cash-flow summary (ADR 0014; business-wide, tender-tagged) ───────────

--- a/test/orders/cancel_cashout_test.dart
+++ b/test/orders/cancel_cashout_test.dart
@@ -1,0 +1,287 @@
+import 'package:drift/drift.dart' hide isNull, isNotNull;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reebaplus_pos/core/database/app_database.dart';
+import 'package:reebaplus_pos/core/database/uuid_v7.dart';
+
+import '../helpers/dispatch_test_utils.dart';
+
+/// #172 (Money integrity #3, PRD #155) — **Cancel writes a compensating
+/// cash-out row.** Cancelling a paid sale must record the money leaving on the
+/// day it leaves, so a reviewed/banked sale day never changes behind the
+/// owner's back:
+///   1. the ORIGINAL sale payment row is left intact (never voided) — the sale
+///      day's cash figure is unchanged;
+///   2. a dated `refund` cash-out row lands on the CANCEL day, linked to the
+///      order, for the goods actually paid;
+///   3. the refund is derived from a real payment row (not a dead order status)
+///      so reconciliation's Refunds figure is no longer ₦0.
+///
+/// Drives the full Checkout → Cancel path through `OrdersDao` on the v1 (live)
+/// sync path — the A1 regression named in the PRD's Testing Decisions.
+void main() {
+  late AppDatabase db;
+  late String businessId;
+
+  setUp(() async {
+    final boot = await bootstrapTestDb();
+    db = boot.db;
+    businessId = boot.businessId;
+    // v1 per-table path (the v2 cancel envelope is held off until it mints the
+    // reversal); createOrder + markCancelled both post rows locally.
+    await setFlag(db, 'feature.domain_rpcs_v2.record_sale', on: false);
+    await setFlag(db, 'feature.domain_rpcs_v2.cancel_order', on: false);
+  });
+
+  tearDown(() => db.close());
+
+  Future<(String storeId, String staffId, String customerId)> seedBase() async {
+    final storeId = UuidV7.generate();
+    await db.into(db.stores).insert(StoresCompanion.insert(
+        id: Value(storeId), businessId: businessId, name: 'Main'));
+    final staffId = UuidV7.generate();
+    await db.into(db.users).insert(UsersCompanion.insert(
+        id: Value(staffId), businessId: businessId, name: 'Cashier', pin: '0000'));
+    final customerId = await db.customersDao.addCustomer(
+        CustomersCompanion.insert(businessId: businessId, name: 'Buyer'));
+    return (storeId, staffId, customerId);
+  }
+
+  Future<String> seedProduct(String storeId) async {
+    final productId = UuidV7.generate();
+    await db.into(db.products).insert(ProductsCompanion.insert(
+        id: Value(productId),
+        businessId: businessId,
+        name: 'Beer',
+        retailerPriceKobo: const Value(100000)));
+    await db.into(db.inventory).insert(InventoryCompanion.insert(
+        businessId: businessId,
+        productId: productId,
+        storeId: storeId,
+        quantity: const Value(100)));
+    return productId;
+  }
+
+  // A cash sale of [qty] @ ₦1000, fully paid. Returns the order id.
+  Future<String> sell(
+    String storeId,
+    String staffId,
+    String customerId,
+    String productId,
+    int qty,
+  ) async {
+    final goodsKobo = qty * 100000;
+    return db.ordersDao.createOrder(
+      order: OrdersCompanion.insert(
+        businessId: businessId,
+        orderNumber: 'ORD-${UuidV7.generate()}',
+        customerId: Value(customerId),
+        totalAmountKobo: goodsKobo,
+        netAmountKobo: goodsKobo,
+        amountPaidKobo: Value(goodsKobo),
+        paymentType: 'cash',
+        status: 'pending',
+        staffId: Value(staffId),
+        storeId: Value(storeId),
+      ),
+      items: [
+        OrderItemsCompanion.insert(
+          businessId: businessId,
+          orderId: 'placeholder',
+          productId: Value(productId),
+          storeId: storeId,
+          quantity: qty,
+          unitPriceKobo: 100000,
+          totalKobo: goodsKobo,
+        ),
+      ],
+      customerId: customerId,
+      amountPaidKobo: goodsKobo,
+      totalAmountKobo: goodsKobo,
+      staffId: staffId,
+      storeId: storeId,
+    );
+  }
+
+  // Cash counted for a payment [type] within [day, day+1) — mirrors the
+  // reconciliation's cash-flow bucketing (each row on its OWN created_at day,
+  // voided rows excluded).
+  Future<int> cashOnDay(String type, DateTime day) async {
+    final next = day.add(const Duration(days: 1));
+    final rows = await (db.select(db.paymentTransactions)
+          ..where((p) =>
+              p.type.equals(type) &
+              p.voidedAt.isNull() &
+              p.createdAt.isBiggerOrEqualValue(day) &
+              p.createdAt.isSmallerThanValue(next)))
+        .get();
+    return rows.fold<int>(0, (s, r) => s + r.amountKobo);
+  }
+
+  test(
+      'cancel leaves the sale day cash unchanged and posts a refund on the '
+      'cancel day', () async {
+    final (storeId, staffId, customerId) = await seedBase();
+    final productId = await seedProduct(storeId);
+
+    // A ₦2,000 paid sale, then backdate its rows to a prior day so the sale day
+    // and the cancel day are distinct buckets.
+    final orderId = await sell(storeId, staffId, customerId, productId, 2);
+    // Whole-second precision: Drift stores DateTime as unix seconds, so a
+    // microsecond-bearing value would not round-trip equal.
+    final n = DateTime.now().subtract(const Duration(days: 4));
+    final saleDay =
+        DateTime(n.year, n.month, n.day, n.hour, n.minute, n.second);
+    // The payment ledger is append-only (created_at is immutable) — production
+    // never backdates a row. Drop the guard for this test-only backdate so the
+    // sale day and cancel day fall in distinct buckets.
+    await db.customStatement(
+        'DROP TRIGGER IF EXISTS payment_transactions_immutable');
+    await (db.update(db.paymentTransactions)
+          ..where((p) => p.orderId.equals(orderId)))
+        .write(PaymentTransactionsCompanion(createdAt: Value(saleDay)));
+    await (db.update(db.orders)..where((o) => o.id.equals(orderId)))
+        .write(OrdersCompanion(createdAt: Value(saleDay)));
+
+    // Sale day cash before the cancel: the full ₦2,000.
+    expect(await cashOnDay('sale', saleDay), 200000);
+
+    // Floor to the second: stored createdAt round-trips at unix-second
+    // granularity, so a microsecond-bearing bound would spuriously read as
+    // "after" the refund row.
+    final nowSec = DateTime.now();
+    final beforeCancel =
+        DateTime(nowSec.year, nowSec.month, nowSec.day, nowSec.hour,
+            nowSec.minute, nowSec.second);
+    await db.ordersDao.markCancelled(orderId, 'customer changed mind', staffId);
+
+    // 1. The original sale row is untouched — never voided, still on the sale
+    //    day. The sale day's cash figure is unchanged.
+    final sale = await (db.select(db.paymentTransactions)
+          ..where((p) => p.type.equals('sale')))
+        .getSingle();
+    expect(sale.voidedAt, isNull, reason: 'the sale row is never voided');
+    expect(sale.createdAt, saleDay, reason: 'the sale stays on the sale day');
+    expect(await cashOnDay('sale', saleDay), 200000,
+        reason: 'a reviewed/banked sale day never shrinks behind the owner');
+
+    // 2. A dated refund cash-out row lands on the CANCEL day (today), linked to
+    //    the order, for the goods paid, with the sale tender's method.
+    final refund = await (db.select(db.paymentTransactions)
+          ..where((p) => p.type.equals('refund')))
+        .getSingle();
+    expect(refund.amountKobo, 200000);
+    expect(refund.orderId, orderId);
+    expect(refund.method, sale.method);
+    expect(refund.voidedAt, isNull);
+    expect(refund.createdAt.isBefore(beforeCancel), isFalse,
+        reason: 'the refund lands on the cancel day, not the sale day');
+    expect(refund.createdAt.difference(saleDay).inDays, greaterThan(1),
+        reason: 'the refund is on the cancel day, distinct from the sale day');
+
+    // 3. Net cash over the two days is zero (money in on the sale day, out on
+    //    the cancel day) — but visibly, on the day each movement happened.
+    expect(await cashOnDay('refund', refund.createdAt), 200000);
+  });
+
+  test('the refund row syncs so peers converge', () async {
+    final (storeId, staffId, customerId) = await seedBase();
+    final productId = await seedProduct(storeId);
+    final orderId = await sell(storeId, staffId, customerId, productId, 1);
+
+    await db.ordersDao.markCancelled(orderId, 'refund', staffId);
+
+    final refund = await (db.select(db.paymentTransactions)
+          ..where((p) => p.type.equals('refund')))
+        .getSingle();
+    final pending = await getPendingQueue(db);
+    final enqueued = pending
+        .where((r) => r.actionType == 'payment_transactions:upsert')
+        .map(decodePayload)
+        .where((p) => p['id'] == refund.id)
+        .toList();
+    expect(enqueued, hasLength(1),
+        reason: 'the compensating refund row must push (a cancel reverses a '
+            'sale the cloud accepted)');
+    expect(enqueued.single['type'], 'refund');
+  });
+
+  test(
+      'a deposit sale refunds only the goods portion — the deposit is released '
+      'on the crate/wallet side', () async {
+    // A money-track deposit sale: ₦1,000 goods + ₦500 deposit = ₦1,500 paid.
+    await (db.update(db.businesses)..where((b) => b.id.equals(businessId)))
+        .write(const BusinessesCompanion(type: Value('Bar')));
+    final (storeId, staffId, customerId) = await seedBase();
+    final mfrId = UuidV7.generate();
+    await db.into(db.manufacturers).insert(ManufacturersCompanion.insert(
+        id: Value(mfrId),
+        businessId: businessId,
+        name: 'Star',
+        depositAmountKobo: const Value(50000)));
+    final productId = UuidV7.generate();
+    await db.into(db.products).insert(ProductsCompanion.insert(
+        id: Value(productId),
+        businessId: businessId,
+        name: 'Star Bottle',
+        retailerPriceKobo: const Value(100000),
+        manufacturerId: Value(mfrId),
+        unit: const Value('Bottle'),
+        trackEmpties: const Value(true)));
+    await db.into(db.inventory).insert(InventoryCompanion.insert(
+        businessId: businessId,
+        productId: productId,
+        storeId: storeId,
+        quantity: const Value(100)));
+
+    final orderId = await db.ordersDao.createOrder(
+      order: OrdersCompanion.insert(
+        businessId: businessId,
+        orderNumber: 'ORD-${UuidV7.generate()}',
+        customerId: Value(customerId),
+        totalAmountKobo: 150000,
+        netAmountKobo: 150000,
+        amountPaidKobo: const Value(150000),
+        paymentType: 'cash',
+        status: 'pending',
+        staffId: Value(staffId),
+        storeId: Value(storeId),
+        crateDepositPaidKobo: const Value(50000),
+      ),
+      items: [
+        OrderItemsCompanion.insert(
+          businessId: businessId,
+          orderId: 'placeholder',
+          productId: Value(productId),
+          storeId: storeId,
+          quantity: 1,
+          unitPriceKobo: 100000,
+          totalKobo: 100000,
+        ),
+      ],
+      customerId: customerId,
+      amountPaidKobo: 150000,
+      totalAmountKobo: 150000,
+      staffId: staffId,
+      storeId: storeId,
+      crateDepositPaidByManufacturer: {mfrId: 50000},
+    );
+
+    // The sale row records the full ₦1,500 tendered (goods + deposit bundled).
+    final sale = await (db.select(db.paymentTransactions)
+          ..where((p) => p.type.equals('sale')))
+        .getSingle();
+    expect(sale.amountKobo, 150000);
+
+    await db.ordersDao.markCancelled(orderId, 'refund', staffId);
+
+    // The refund cash-out reverses only the ₦1,000 goods portion — the ₦500
+    // deposit is released on the crate/wallet side (#162), not double-refunded.
+    final refund = await (db.select(db.paymentTransactions)
+          ..where((p) => p.type.equals('refund')))
+        .getSingle();
+    expect(refund.amountKobo, 100000,
+        reason: 'goods paid = amountPaid − crateDepositPaid');
+    // #162 still deflates deposits-held to 0 on the wallet side.
+    expect(await db.walletTransactionsDao.getDepositsHeldKobo(customerId), 0);
+  });
+}

--- a/test/orders/pr_4c_test.dart
+++ b/test/orders/pr_4c_test.dart
@@ -328,10 +328,17 @@ void main() {
       )..where((i) => i.storeId.equals(s.storeId))).getSingle();
       expect(inv.quantity, equals(10));
 
-      // Payment voided in place (not a new row)
+      // Payment: the ORIGINAL sale row is left intact (never voided) and a
+      // dated compensating refund cash-out row is appended for the goods paid
+      // (#172) — money leaves on the cancel day, the sale stays on its own day.
       final payments = await db.select(db.paymentTransactions).get();
-      expect(payments, hasLength(1));
-      expect(payments.first.voidedAt, isNotNull);
+      expect(payments, hasLength(2));
+      final saleRow = payments.firstWhere((p) => p.type == 'sale');
+      expect(saleRow.voidedAt, isNull, reason: 'sale row is never voided');
+      final refundRow = payments.firstWhere((p) => p.type == 'refund');
+      expect(refundRow.amountKobo, 200000);
+      expect(refundRow.orderId, orderId);
+      expect(refundRow.voidedAt, isNull);
     });
   });
 

--- a/test/sync/dispatch/orders_dao_cancel_dispatch_test.dart
+++ b/test/sync/dispatch/orders_dao_cancel_dispatch_test.dart
@@ -146,7 +146,7 @@ void main() {
 
   group('OrdersDao.markCancelled dispatch', () {
     test(
-        'flag OFF: order + stock_tx (compensation) + inventory + payment void '
+        'flag OFF: order + stock_tx (compensation) + inventory + refund cash-out '
         'enqueue, no domain envelope', () async {
       await setFlag(db, 'feature.domain_rpcs_v2.cancel_order', on: false);
       final s = await _seedCancelFixtures(db, businessId);
@@ -155,7 +155,7 @@ void main() {
       await db.ordersDao.markCancelled(orderId, 'changed mind', s.staffId);
 
       // Local mirror: order cancelled, compensating stock_tx inserted,
-      // payment voided, inventory restored.
+      // refund cash-out row appended (original sale intact), inventory restored.
       final order = await (db.select(db.orders)..where((t) => t.id.equals(orderId)))
           .getSingle();
       expect(order.status, 'cancelled');
@@ -167,9 +167,14 @@ void main() {
           stxRows.firstWhere((r) => r.movementType == 'return');
       expect(compensation.quantityDelta, 2);
 
+      // The sale row is never voided (#172); a dated 'refund' row is appended.
       final paymentRows = await db.select(db.paymentTransactions).get();
-      expect(paymentRows, hasLength(1));
-      expect(paymentRows.first.voidedAt, isNotNull);
+      expect(paymentRows, hasLength(2));
+      final saleRow = paymentRows.firstWhere((p) => p.type == 'sale');
+      expect(saleRow.voidedAt, isNull);
+      final refundRow = paymentRows.firstWhere((p) => p.type == 'refund');
+      expect(refundRow.orderId, orderId);
+      expect(refundRow.voidedAt, isNull);
 
       // Queue: per-table upserts only, no envelope.
       final pending = await getPendingQueue(db);


### PR DESCRIPTION
Money integrity slice #3 (parent #155). Builds on #162 (crate/wallet deposit-family reversal already shipped) — adds only the money leg.

## What landed
- `OrdersDao.markCancelled` no longer voids the sale payment row in place. It posts a **dated `'refund'` cash-out row** (via the #169 seam) for the **goods portion actually paid** (`amountPaid − crateDepositPaid`, floored at 0), linked to the order, dated the **cancel day**. The original sale row stays intact on the sale day → a reviewed/banked day never shrinks behind the owner. The crate deposit is released on the crate/wallet side (#162), never double-refunded here.
- **Retired the dead `refunded` order status** as a money source: the reconciliation's Refunds figure now derives from **real `type=='refund'` payment rows** (previously summed `orders.status=='refunded'`, a status nothing writes → ₦0 forever). `periodNetResultKobo` picks it up unchanged. Remaining `'refunded'` references are harmless legacy-tolerant filters/badges (0 rows).
- The cash-flow card's pre-existing `cashRefundsKobo` bucket nets the refund against the preserved sale row, on the correct days.

## Verification
- `flutter analyze` (lib + test): clean.
- New `cancel_cashout_test` (3 tests): sale-day cash unchanged + refund on cancel day; refund row syncs; deposit sale refunds only the goods portion. Updated `pr_4c_test` + `orders_dao_cancel_dispatch_test` to the new (append-not-void) behavior.
- Focused blast-radius suites (orders/dashboard/payments/crates/sync-dispatch): 237 pass.

Closes #172