### PR TITLE
feat(money): Confirm safety — gate + idempotency + blank-deposit=0 + seller attribution (#171)

### DIFF
--- a/CONTEXT/progress-tracker.md
+++ b/CONTEXT/progress-tracker.md
@@ -60,6 +60,66 @@ with NO user-visible flow change. Branch `feat/money-integrity-1-payments-seam` 
   slice threads store context — a feature-layer change out of this prefactor's scope.
   DO NOT push/deploy the cloud migration; the orchestrator sequences merge/deploy.
 
+### Money integrity #2 (#171) — Confirm safety (gate + idempotency + blank-part-deposit→0 + seller attribution) — CODE-COMPLETE (2026-07-24)
+First active till-leak fix of the #155 money-integrity PRD. Branch
+`feat/money-integrity-2-confirm-safety` off `main` (HEAD b99400f — includes the
+merged #169 prefactor, so `orders.confirmed_by` already exists). Stops Confirm
+(`OrdersDao.markCompleted` + the crate-deposit settlement in `OrderCommands.confirm`)
+from leaking till cash.
+- **Gate (new key `sales.confirm`, category Sales).** Two named gates added to the
+  Gate Registry: `Gates.confirmOrder` = `Gate.key('sales.confirm')`, and
+  `Gates.confirmOrderCashRefund` = `Gate.allKeys(['sales.confirm',
+  'customers.wallet.withdraw'])`. Tier lives in the SEEDED GRANTS (Cashier-tier and
+  above: CEO + Manager + Cashier; NOT Stock keeper), not a tier atom, so the key stays
+  the canonical axis (invariant #6). Enforced at the Confirm write boundary in
+  `orders_screen._executeMarkDelivered` with `.require()` (confirmOrder always; the
+  additional `confirmOrderCashRefund` only when the confirmer picked Cash), and the
+  Confirm button + the modal's Cash refund-destination chip render-gate (hide-don't-
+  block).
+- **Idempotency.** `markCompleted` re-reads the order status INSIDE its transaction
+  and aborts unless `pending` (also stops overwriting `staffId` — see below).
+  `OrderCommands._settleCrateReturns` re-reads status via `OrdersDao.findById` and
+  skips the WHOLE settlement (physical empties + crate-track netting + money-track
+  deposit) on a non-pending order — so two devices confirming the same order settle it
+  exactly once, while a single Confirm still settles every manufacturer (status stays
+  `pending` across the loop). NOTE: the guard is at the WHOLE-settlement seam, NOT
+  inside `settleCrateDepositReturn` (that primitive is exercised directly on already-
+  `completed` orders by the Ring 5 crate tests, so it settles unconditionally).
+- **Blank part-deposit → 0.** `crate_return_modal._confirm` now parses a blank count as
+  0 (`parseReturnedCrateCount`, was `?? r.expectedQty` = full refund) and BLOCKS
+  Confirm until every field is filled (`allCrateCountsFilled`) — both extracted as
+  pure top-level helpers for testing.
+- **Seller attribution.** Confirm records `orders.confirmed_by` (the confirmer) and
+  NEVER overwrites `orders.staffId` (the seller stays credited). `markCompleted`'s
+  second param renamed `staffId`→`confirmedBy`.
+- **Schema (Drift v64→**v65**, cloud `0154_money_integrity_confirm_gate.sql`).** Local:
+  `sales.confirm` added to `_defaultPermissionRows` (so `ensurePermissionsSeeded`
+  re-seeds it after `clearAllData` when COUNT==0) + a v65 onUpgrade `INSERT OR IGNORE`.
+  Cloud (DO NOT APPLY — orchestrator sequences deploy, MUST land before any grant syncs
+  for the role_permissions FK): catalogue insert + `seed_default_roles_for_business`
+  CREATE-OR-REPLACE (same signature, no overload) granting Manager + Cashier + backfill
+  for existing CEO/Manager/Cashier roles. No new synced table; no `*_kobo` columns.
+- **Tests (TDD).** `test/permissions/confirm_gate_test.dart` (pure gate algebra +
+  `.require()` guard: without `sales.confirm` denied; cash-refund needs wallet.withdraw
+  too); `test/orders/confirm_safety_test.dart` (double-Confirm two devices settles the
+  deposit + restocks empties ONCE; `markCompleted` status re-read no-op; staff_id
+  preserved + confirmed_by recorded); `test/orders/crate_return_blank_test.dart` (blank
+  →0, block until filled); `test/database/migration_upgrade_test.dart` v64→v65 re-seed.
+  Touched counts: `roles_v13_seed_test` catalogue 39→40; `roles_permissions_screen_test`
+  + `role_permissions_detail_test` visible-toggle 36→37; the CEO denominator fallback
+  `39`→`40` in `roles_permissions_screen.dart`.
+- **Verification.** `flutter analyze` clean (0/0 project-wide). Full `flutter test` =
+  **1042 pass / 110 skip / 1 fail** — the lone failure `who_is_working_screen_test`
+  (staff-card render, line 133) is the pre-existing environmental flake (staff/auth code
+  untouched here).
+- **Deviations / open questions.** Idempotency is implemented via the order-status
+  re-read (a settlement row for (order, manufacturer) exists iff a prior Confirm ran =
+  status `completed`), NOT a per-row wallet-table probe — a per-order wallet-row probe
+  would wrongly skip the 2nd+ manufacturer within a single multi-manufacturer Confirm,
+  and wallet_transactions carries no manufacturer_id. The simultaneous-both-offline
+  partition still double-posts until convergence (unavoidable; the audit's row-skip
+  can't prevent it either). DO NOT push/deploy the cloud migration.
+
 ### Crate pool #6 (#163) — net-position honesty (subtract held deposits + supplier debt) — CODE-COMPLETE (2026-07-24)
 Sixth slice of the crate-pool ledger-as-truth refactor (PRD #156, ADR 0020).
 Branch `feat/crate-pool-net-position-honesty` off `feat/crate-pool-cancel-completes-ledger`

--- a/lib/core/database/app_database.dart
+++ b/lib/core/database/app_database.dart
@@ -1875,7 +1875,7 @@ class AppDatabase extends _$AppDatabase {
   String? get currentAuthUserId => authUserIdResolver();
 
   @override
-  int get schemaVersion => 64;
+  int get schemaVersion => 65;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -4165,6 +4165,22 @@ class AppDatabase extends _$AppDatabase {
           await customStatement(stmt);
         }
       }
+      if (from < 65) {
+        // v65 (#171 Confirm safety, PRD #155). Seed the new `sales.confirm`
+        // permission key into the local catalogue so Roles & Permissions lists
+        // it and the Confirm gate can resolve. Confirm (the crate-deposit
+        // settlement + pending→completed flip) is gated on this key; it is
+        // granted Cashier-tier and above by default. The ROLE GRANTS arrive from
+        // the cloud via sync pull — the cloud catalogue + role_permissions
+        // backfill live in supabase/migrations/0154_money_integrity_confirm_gate.sql,
+        // which must deploy BEFORE any grant syncs (role_permissions FK). This
+        // step only adds the catalogue key. Idempotent — key is the PK.
+        await customStatement(
+          "INSERT OR IGNORE INTO permissions (key, description, category) "
+          "VALUES ('sales.confirm', "
+          "'Confirm an order and settle crate deposits', 'Sales')",
+        );
+      }
     },
     beforeOpen: (details) async {
       await customStatement('PRAGMA foreign_keys = ON');
@@ -4514,7 +4530,7 @@ const List<String> _v13HotPathIndexStatements = [
 // Identical on every device and on the cloud (mirror this list in
 // supabase/migrations/0043_seed_permissions_and_backfill_businesses.sql).
 // Each row: (key, description, category). Category groups toggles in
-// the CEO Settings > Roles & Permissions sub-page. 39 keys total.
+// the CEO Settings > Roles & Permissions sub-page. 40 keys total.
 const List<List<String>> _defaultPermissionRows = [
   // Stores — rendered first on the role page (§10.2). CEO-only by default.
   ['stores.manage', 'Add, edit, and remove stores', 'Stores'],
@@ -4536,6 +4552,8 @@ const List<List<String>> _defaultPermissionRows = [
   // Sales
   ['sales.make', 'Make a sale', 'Sales'],
   ['sales.cancel', 'Cancel a sale', 'Sales'],
+  // #171 — Confirm an order (settles crate deposits + flips pending→completed).
+  ['sales.confirm', 'Confirm an order and settle crate deposits', 'Sales'],
   ['sales.discount.give', 'Give a discount on a sale', 'Sales'],
   ['sales.set_custom_price', 'Set a custom price on a cart item', 'Sales'],
   // Products

--- a/lib/core/database/daos_orders.dart
+++ b/lib/core/database/daos_orders.dart
@@ -1048,6 +1048,15 @@ class OrdersDao extends DatabaseAccessor<AppDatabase>
     final extraDebt = forfeitValue > paidKobo ? forfeitValue - paidKobo : 0;
 
     await transaction(() async {
+      // NOTE (#171): this is the low-level money primitive — it settles the
+      // deposit unconditionally so it can be exercised directly (Ring 5 tests
+      // settle already-`completed` orders). Confirm idempotency lives one layer
+      // up, at the WHOLE-settlement seam: `OrderCommands._settleCrateReturns`
+      // re-reads the order status and skips the entire settlement (physical +
+      // deposit) on a non-pending order, and `markCompleted` re-reads it again
+      // inside its own transaction — so two devices confirming the same order
+      // settle it exactly once, while a single Confirm still settles every
+      // manufacturer (status stays `pending` across the loop).
       final wallet =
           await (select(customerWallets)
                 ..where(
@@ -1145,12 +1154,32 @@ class OrdersDao extends DatabaseAccessor<AppDatabase>
     });
   }
 
-  Future<void> markCompleted(String orderId, [String? staffId]) {
+  /// **Confirm** the order (§19.5 ceremony): flip `pending → completed` and
+  /// stamp who confirmed it. [confirmedBy] is recorded on `orders.confirmed_by`
+  /// (#169's column) — the SELLER's `staff_id` is left UNTOUCHED so the sale
+  /// stays credited to who sold it (#171; the old behaviour overwrote `staff_id`
+  /// with the confirmer and silently re-attributed the sale, corrupting
+  /// best-staff / commission figures).
+  ///
+  /// **Idempotent across devices (#171):** re-reads the order status INSIDE the
+  /// transaction and aborts unless it is still `pending`. Once any device's
+  /// Confirm has flipped the order to `completed` (and that state has converged),
+  /// a second Confirm is a no-op — two devices confirming the same order complete
+  /// it exactly once.
+  Future<void> markCompleted(String orderId, [String? confirmedBy]) {
     return db.transaction(() async {
+      final existing =
+          await (select(orders)
+                ..where((o) => o.id.equals(orderId) & whereBusiness(o)))
+              .getSingleOrNull();
+      if (existing == null || existing.status != 'pending') return;
       final comp = OrdersCompanion(
         id: Value(orderId),
         status: const Value('completed'),
-        staffId: staffId != null ? Value(staffId) : const Value.absent(),
+        // Record the confirmer separately; NEVER overwrite staffId (the seller).
+        confirmedBy: confirmedBy != null
+            ? Value(confirmedBy)
+            : const Value.absent(),
         completedAt: Value(DateTime.now().toUtc()),
         lastUpdatedAt: Value(DateTime.now()),
       );

--- a/lib/core/permissions/gate_registry.dart
+++ b/lib/core/permissions/gate_registry.dart
@@ -509,6 +509,34 @@ abstract final class Gates {
     rule: Gate.key('sales.cancel'),
   );
 
+  /// Confirm a pending order — the "Confirm" ("Mark as delivered") action on the
+  /// Orders Pending tab (#171 / PRD #155). Confirm is a real money boundary: it
+  /// runs the crate-deposit settlement (forfeit / refund / shortfall) before the
+  /// `pending → completed` flip, so it is gated on the dedicated `sales.confirm`
+  /// key. Seeded Cashier-tier and above (CEO + Manager + Cashier grant it by
+  /// default; a Stock keeper does NOT) — the tier lives in the seeded grants, not
+  /// a tier atom, so `sales.confirm` stays the canonical axis (invariant #6).
+  /// Cited by the Confirm button's render gate and re-checked with `.require()`
+  /// at the Confirm write boundary.
+  static const NamedGate confirmOrder = NamedGate(
+    name: 'confirmOrder',
+    action: 'Confirm Order',
+    rule: Gate.key('sales.confirm'),
+  );
+
+  /// Confirm an order whose crate-deposit refund is paid **as cash out of the
+  /// till** (#171). The cash-refund branch of deposit settlement additionally
+  /// requires the existing wallet-withdraw key on top of `sales.confirm`, so a
+  /// user who may Confirm (and refund to the credit balance) still cannot pay a
+  /// deposit refund out of the drawer unless they also hold
+  /// `customers.wallet.withdraw`. Cited by the Cash refund-destination chip's
+  /// render gate and re-checked with `.require()` when the confirmer picked Cash.
+  static const NamedGate confirmOrderCashRefund = NamedGate(
+    name: 'confirmOrderCashRefund',
+    action: 'Refund Deposit as Cash',
+    rule: Gate.allKeys(['sales.confirm', 'customers.wallet.withdraw']),
+  );
+
   /// See monetary values on Orders (§19.3): the per-order line prices / total /
   /// paid / discount, and the per-tab money summary stats (Total Value, Revenue,
   /// Collected, Crate Deposits). Roles below Manager see items + quantities only.
@@ -606,6 +634,8 @@ abstract final class Gates {
     suspendStaff,
     staffRemove,
     refundOrder,
+    confirmOrder,
+    confirmOrderCashRefund,
     seeOrderMoney,
     seeExtendedDateRanges,
     viewApprovals,

--- a/lib/core/settings/roles_permissions_screen.dart
+++ b/lib/core/settings/roles_permissions_screen.dart
@@ -84,11 +84,11 @@ class _RoleCard extends ConsumerWidget {
             .where((g) => !kHiddenPermissionKeys.contains(g.permissionKey))
             .length;
     // Derive the denominator from the global catalogue so it never goes stale
-    // if permission keys are added. Falls back to the seed count (39 minus the
+    // if permission keys are added. Falls back to the seed count (40 minus the
     // hidden keys) for the one frame before the catalogue stream resolves.
     final allPerms = ref.watch(allPermissionsProvider).valueOrNull;
     final total = allPerms == null
-        ? 39 - kHiddenPermissionKeys.length
+        ? 40 - kHiddenPermissionKeys.length
         : allPerms.where((p) => !kHiddenPermissionKeys.contains(p.key)).length;
     // CEO is locked all-on; show the full count regardless of sync state.
     final subtitle = isCeo

--- a/lib/features/orders/screens/orders_screen.dart
+++ b/lib/features/orders/screens/orders_screen.dart
@@ -639,6 +639,9 @@ class _OrdersScreenState extends ConsumerState<OrdersScreen>
     }
 
     final canRefund = Gates.refundOrder.allows(ref);
+    // #171: Confirm is gated Cashier-tier and above (sales.confirm). Hide the
+    // Confirm button entirely without it (hide-don't-block, hard rule #7).
+    final canConfirm = Gates.confirmOrder.allows(ref);
 
     // We add 1 to the child count if we are loading more to render the spinner.
     final childCount = list.length + (isLoadingMore ? 1 : 0);
@@ -675,7 +678,7 @@ class _OrdersScreenState extends ConsumerState<OrdersScreen>
             return _OrderCard(
               orderWithItems: item,
               status: status,
-              onMarkAsDelivered: status == 'pending'
+              onMarkAsDelivered: (status == 'pending' && canConfirm)
                   ? () => _markAsDelivered(item)
                   : null,
               onRefund: (status == 'pending' && canRefund)
@@ -746,6 +749,8 @@ class _OrdersScreenState extends ConsumerState<OrdersScreen>
 
     // §19.7: the Pending-tab Refund is gated to CEO + Manager (sales.cancel).
     final canRefund = Gates.refundOrder.allows(ref);
+    // #171: Confirm is gated Cashier-tier and above (sales.confirm).
+    final canConfirm = Gates.confirmOrder.allows(ref);
 
     return [
       SliverPadding(
@@ -761,7 +766,7 @@ class _OrdersScreenState extends ConsumerState<OrdersScreen>
             return _OrderCard(
               orderWithItems: item,
               status: status,
-              onMarkAsDelivered: status == 'pending'
+              onMarkAsDelivered: (status == 'pending' && canConfirm)
                   ? () => _markAsDelivered(item)
                   : null,
               // §19.7: Refund replaces the old Cancel button on the Pending
@@ -792,6 +797,18 @@ class _OrdersScreenState extends ConsumerState<OrdersScreen>
   void _executeMarkDelivered(OrderWithItems orderWithItems) async {
     final order = orderWithItems.order;
 
+    // ── Write-boundary gate (#171, ADR 0002) ────────────────────────────────
+    // Confirm runs the crate-deposit settlement (real money) before the status
+    // flip, so re-check the sales.confirm grant here with the throwing form. The
+    // Confirm button already hides without it, but a grant revoked mid-session —
+    // or a stale back-stack — must not reach the settlement.
+    try {
+      Gates.confirmOrder.require(ref);
+    } on GateDeniedError {
+      showGateDenied(context, Gates.confirmOrder);
+      return;
+    }
+
     if (!mounted) return;
     // The modal only COLLECTS the counted-back empties now (ADR 0004); the
     // settlement runs inside Confirm (markAsCompleted). null = cashier dismissed.
@@ -803,6 +820,18 @@ class _OrdersScreenState extends ConsumerState<OrdersScreen>
     if (crateResult == null) return;
 
     if (!mounted) return;
+
+    // #171: paying the deposit refund AS CASH out of the till additionally
+    // requires the wallet-withdraw permission on top of sales.confirm. The modal
+    // hides the Cash chip without it, but re-check at the write boundary.
+    if (crateResult.refundAsCash) {
+      try {
+        Gates.confirmOrderCashRefund.require(ref);
+      } on GateDeniedError {
+        showGateDenied(context, Gates.confirmOrderCashRefund);
+        return;
+      }
+    }
 
     try {
       await ref

--- a/lib/features/orders/widgets/crate_return_modal.dart
+++ b/lib/features/orders/widgets/crate_return_modal.dart
@@ -5,6 +5,8 @@ import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 
 import 'package:reebaplus_pos/core/providers/app_providers.dart';
 import 'package:reebaplus_pos/core/database/app_database.dart';
+import 'package:reebaplus_pos/core/permissions/permissions.dart';
+import 'package:reebaplus_pos/core/utils/notifications.dart';
 import 'package:reebaplus_pos/core/utils/number_format.dart';
 import 'package:reebaplus_pos/core/utils/responsive.dart';
 import 'package:reebaplus_pos/shared/services/orders/crate_return_input.dart';
@@ -34,6 +36,18 @@ List<int> allocateLegacyDeposit(int totalDeposit, List<int> weights) {
   }
   return out;
 }
+
+/// A2 (#171) — parse a returned-crate count field. A blank / non-numeric field
+/// means **0 returned** (NEVER "all crates came back"): an untouched blank must
+/// not silently trigger a full deposit refund plus a pool credit for crates that
+/// never arrived. Visible for testing.
+int parseReturnedCrateCount(String raw) => int.tryParse(raw.trim()) ?? 0;
+
+/// A2 (#171) — whether every crate-count field has been filled. Confirm is
+/// blocked until this is true, so a blank field can only ever be a deliberate 0
+/// the cashier typed, never an accidental "all returned". Visible for testing.
+bool allCrateCountsFilled(Iterable<String> rawCounts) =>
+    rawCounts.every((t) => t.trim().isNotEmpty);
 
 class CrateReturnModal extends ConsumerStatefulWidget {
   final OrderWithItems orderWithItems;
@@ -224,6 +238,22 @@ class _CrateReturnModalState extends ConsumerState<CrateReturnModal> {
   /// matching the old write loop.
   void _confirm() {
     if (_saving) return;
+
+    // A2 (#171): block Confirm until every crate-count field is filled. A blank
+    // field must NEVER fall back to "all crates returned" (a full refund + a pool
+    // credit for crates that never arrived), so force a count — 0 is valid, blank
+    // is not.
+    final counts = _rows
+        .where((r) => r.manufacturerId.isNotEmpty)
+        .map((r) => r.controller.text);
+    if (!allCrateCountsFilled(counts)) {
+      AppNotification.showError(
+        context,
+        'Enter the returned crate count for every manufacturer (0 is allowed).',
+      );
+      return;
+    }
+
     setState(() => _saving = true);
 
     final lines = _rows
@@ -232,7 +262,8 @@ class _CrateReturnModalState extends ConsumerState<CrateReturnModal> {
           (r) => CrateReturnLine(
             manufacturerId: r.manufacturerId,
             takenCrates: r.expectedQty,
-            returnedCrates: int.tryParse(r.controller.text) ?? r.expectedQty,
+            // A2 (#171): a blank count parses to 0, never r.expectedQty.
+            returnedCrates: parseReturnedCrateCount(r.controller.text),
             rateKobo: r.rateKobo,
             paidKobo: r.paidKobo,
           ),
@@ -320,13 +351,20 @@ class _CrateReturnModalState extends ConsumerState<CrateReturnModal> {
                 !_refundAsCash,
                 () => setState(() => _refundAsCash = false),
               ),
-              SizedBox(width: context.getRSize(10)),
-              chip(
-                'Cash',
-                FontAwesomeIcons.moneyBill.data,
-                _refundAsCash,
-                () => setState(() => _refundAsCash = true),
-              ),
+              // #171: paying a deposit refund AS CASH out of the till
+              // additionally requires the wallet-withdraw permission. Hide the
+              // Cash option otherwise (hide-don't-block, hard rule #7) — the
+              // refund then always goes to the credit balance, and the Confirm
+              // write boundary re-checks Gates.confirmOrderCashRefund.
+              if (Gates.refundCustomerWallet.allows(ref)) ...[
+                SizedBox(width: context.getRSize(10)),
+                chip(
+                  'Cash',
+                  FontAwesomeIcons.moneyBill.data,
+                  _refundAsCash,
+                  () => setState(() => _refundAsCash = true),
+                ),
+              ],
             ],
           ),
         ],

--- a/lib/shared/services/orders/order_commands.dart
+++ b/lib/shared/services/orders/order_commands.dart
@@ -215,6 +215,16 @@ class OrderCommands {
   }) async {
     if (crateReturns.isEmpty) return;
 
+    // Idempotency (#171): a prior Confirm already flipped this order to
+    // `completed` and settled its crate returns once. Re-read the status and
+    // skip the WHOLE settlement (physical empties, crate-track netting, AND
+    // money-track deposit settlement) when the order is no longer pending — so a
+    // second Confirm from another device never double-credits the empties pool or
+    // double-settles the deposit. `markCompleted` re-checks the same precondition
+    // inside its own transaction; `settleCrateDepositReturn` guards itself too.
+    final order = await _ordersDao.findById(orderId);
+    if (order == null || order.status != 'pending') return;
+
     // Walk-in customer: just record physical stock returns (no wallet/ledger).
     if (customerId == null || customerId.isEmpty) {
       for (final line in crateReturns) {

--- a/supabase/migrations/0154_money_integrity_confirm_gate.sql
+++ b/supabase/migrations/0154_money_integrity_confirm_gate.sql
@@ -1,0 +1,188 @@
+-- 0154_money_integrity_confirm_gate.sql
+--
+-- #171 / PRD #155 — Confirm safety. Adds the `sales.confirm` permission that
+-- gates the Confirm ceremony (crate-deposit settlement + pending→completed flip)
+-- on the Orders Pending tab. Confirm moves real money (deposit forfeit / refund /
+-- shortfall), so it is no longer ungated: it is granted **Cashier-tier and
+-- above** by default (CEO + Manager + Cashier; a Stock keeper does NOT get it).
+-- The cash-refund branch additionally requires the existing
+-- `customers.wallet.withdraw` key — enforced client-side by the composite gate,
+-- no separate key needed here.
+--
+-- Deploy-ordering: this must land on the cloud BEFORE any client on Drift
+-- schema v65 pushes a role_permissions grant for `sales.confirm` — the catalog
+-- key must exist first (role_permissions.permission_key FK), or the grant upsert
+-- fails and jams the outbox. Mirror the catalog row in
+-- lib/core/database/app_database.dart (`_defaultPermissionRows` + the v65
+-- onUpgrade INSERT OR IGNORE) so client and cloud stay in step.
+--
+-- Three idempotent passes (same shape as 0122):
+--   1. Insert the `sales.confirm` key into the global `permissions` catalog.
+--   2. CREATE OR REPLACE seed_default_roles_for_business so NEW businesses grant
+--      the key to Manager + Cashier. CEO already receives every key via
+--      `SELECT key FROM permissions`, so its block is unchanged. The signature is
+--      unchanged, so this is a plain replace (no overload).
+--   3. Backfill every EXISTING business: grant `sales.confirm` to all CEO +
+--      Manager + Cashier roles, stamping last_updated_at so the incremental pull
+--      (0048) ships them to devices.
+--
+-- The Manager + Cashier grant lists below are copied VERBATIM from 0122 with one
+-- added line each (`sales.confirm`). The `funds.*` rows are dead grants left from
+-- the removed Funds Register — preserved unchanged to keep this a surgical clone.
+
+BEGIN;
+
+-- =========================================================================
+-- 1. Catalog.
+-- =========================================================================
+INSERT INTO public.permissions (key, description, category) VALUES
+  ('sales.confirm', 'Confirm an order and settle crate deposits', 'Sales')
+ON CONFLICT (key) DO NOTHING;
+
+-- =========================================================================
+-- 2. New-business seed. Verbatim copy of the 0122 function with one added
+--    Manager grant line and one added Cashier grant line (`sales.confirm`).
+--    CEO still gets every key via the SELECT, so its block is unchanged.
+-- =========================================================================
+CREATE OR REPLACE FUNCTION public.seed_default_roles_for_business(
+  p_business_id uuid
+)
+RETURNS TABLE (
+  ceo_role_id          uuid,
+  manager_role_id      uuid,
+  cashier_role_id      uuid,
+  stock_keeper_role_id uuid
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $function$
+DECLARE
+  v_ceo  uuid;
+  v_mgr  uuid;
+  v_cash uuid;
+  v_sk   uuid;
+BEGIN
+  INSERT INTO public.roles (id, business_id, name, slug, is_system_default)
+    VALUES (gen_random_uuid(), p_business_id, 'CEO',          'ceo',          true)
+    ON CONFLICT (business_id, slug) DO UPDATE SET name = EXCLUDED.name
+    RETURNING id INTO v_ceo;
+
+  INSERT INTO public.roles (id, business_id, name, slug, is_system_default)
+    VALUES (gen_random_uuid(), p_business_id, 'Manager',      'manager',      true)
+    ON CONFLICT (business_id, slug) DO UPDATE SET name = EXCLUDED.name
+    RETURNING id INTO v_mgr;
+
+  INSERT INTO public.roles (id, business_id, name, slug, is_system_default)
+    VALUES (gen_random_uuid(), p_business_id, 'Cashier',      'cashier',      true)
+    ON CONFLICT (business_id, slug) DO UPDATE SET name = EXCLUDED.name
+    RETURNING id INTO v_cash;
+
+  INSERT INTO public.roles (id, business_id, name, slug, is_system_default)
+    VALUES (gen_random_uuid(), p_business_id, 'Stock keeper', 'stock_keeper', true)
+    ON CONFLICT (business_id, slug) DO UPDATE SET name = EXCLUDED.name
+    RETURNING id INTO v_sk;
+
+  -- CEO: all keys (includes the new sales.confirm key via the SELECT).
+  INSERT INTO public.role_permissions (business_id, role_id, permission_key)
+    SELECT p_business_id, v_ceo, key FROM public.permissions
+    ON CONFLICT (role_id, permission_key) DO NOTHING;
+
+  -- Manager: explicit list + sales.confirm (#171 Confirm gate).
+  INSERT INTO public.role_permissions (business_id, role_id, permission_key)
+  VALUES
+    (p_business_id, v_mgr, 'sales.make'),
+    (p_business_id, v_mgr, 'sales.cancel'),
+    (p_business_id, v_mgr, 'sales.confirm'),
+    (p_business_id, v_mgr, 'sales.discount.give'),
+    (p_business_id, v_mgr, 'products.add'),
+    (p_business_id, v_mgr, 'products.edit_price'),
+    (p_business_id, v_mgr, 'products.edit_buying_price'),
+    (p_business_id, v_mgr, 'products.delete'),
+    (p_business_id, v_mgr, 'stock.add'),
+    (p_business_id, v_mgr, 'stock.view'),
+    (p_business_id, v_mgr, 'stock.adjust'),
+    (p_business_id, v_mgr, 'expenses.create'),
+    (p_business_id, v_mgr, 'reports.see_sales'),
+    (p_business_id, v_mgr, 'reports.see_cost_prices'),
+    (p_business_id, v_mgr, 'reports.see_expenses'),
+    (p_business_id, v_mgr, 'customers.add'),
+    (p_business_id, v_mgr, 'customers.update'),
+    (p_business_id, v_mgr, 'customers.delete'),
+    (p_business_id, v_mgr, 'customers.wallet.update'),
+    (p_business_id, v_mgr, 'customers.set_debt_limit'),
+    (p_business_id, v_mgr, 'customers.wallet.totals.view'),
+    (p_business_id, v_mgr, 'customers.wallet.withdraw'),
+    (p_business_id, v_mgr, 'stores.request_transfer'),
+    (p_business_id, v_mgr, 'stores.dispatch_transfer'),
+    (p_business_id, v_mgr, 'stores.receive_transfer'),
+    (p_business_id, v_mgr, 'staff.invite'),
+    (p_business_id, v_mgr, 'staff.suspend'),
+    (p_business_id, v_mgr, 'staff.change_role'),
+    (p_business_id, v_mgr, 'funds.open_day'),
+    (p_business_id, v_mgr, 'funds.close_day'),
+    (p_business_id, v_mgr, 'funds.view')
+  ON CONFLICT (role_id, permission_key) DO NOTHING;
+
+  -- Cashier: 6 keys + sales.confirm (#171 — Cashier-tier and above can Confirm).
+  INSERT INTO public.role_permissions (business_id, role_id, permission_key)
+  VALUES
+    (p_business_id, v_cash, 'sales.make'),
+    (p_business_id, v_cash, 'sales.confirm'),
+    (p_business_id, v_cash, 'stock.view'),
+    (p_business_id, v_cash, 'reports.see_sales'),
+    (p_business_id, v_cash, 'customers.add'),
+    (p_business_id, v_cash, 'customers.update'),
+    (p_business_id, v_cash, 'customers.wallet.update')
+  ON CONFLICT (role_id, permission_key) DO NOTHING;
+
+  -- Stock keeper: 3 keys (unchanged — a stock keeper canNOT Confirm).
+  INSERT INTO public.role_permissions (business_id, role_id, permission_key)
+  VALUES
+    (p_business_id, v_sk, 'stock.add'),
+    (p_business_id, v_sk, 'stock.view'),
+    (p_business_id, v_sk, 'stock.adjust')
+  ON CONFLICT (role_id, permission_key) DO NOTHING;
+
+  INSERT INTO public.role_settings (business_id, role_id, setting_key, setting_value)
+  VALUES
+    (p_business_id, v_ceo,  'max_discount_percent',        '100'),
+    (p_business_id, v_ceo,  'max_expense_approval_kobo',   NULL),
+    (p_business_id, v_mgr,  'max_discount_percent',        '10'),
+    (p_business_id, v_mgr,  'max_expense_approval_kobo',   '0'),
+    (p_business_id, v_cash, 'max_discount_percent',        '0'),
+    (p_business_id, v_cash, 'max_expense_approval_kobo',   '0'),
+    (p_business_id, v_sk,   'max_discount_percent',        '0'),
+    (p_business_id, v_sk,   'max_expense_approval_kobo',   '0')
+  ON CONFLICT (role_id, setting_key) DO NOTHING;
+
+  RETURN QUERY SELECT v_ceo, v_mgr, v_cash, v_sk;
+END;
+$function$;
+
+REVOKE ALL    ON FUNCTION public.seed_default_roles_for_business(uuid) FROM public;
+GRANT EXECUTE ON FUNCTION public.seed_default_roles_for_business(uuid) TO authenticated, service_role;
+
+-- =========================================================================
+-- 3. Backfill existing businesses: grant sales.confirm to every CEO + Manager +
+--    Cashier role (Cashier-tier and above). last_updated_at = now() so the
+--    incremental pull (0048) ships the grants to devices.
+-- =========================================================================
+INSERT INTO public.role_permissions (business_id, role_id, permission_key, last_updated_at)
+  SELECT business_id, id, 'sales.confirm', now()
+    FROM public.roles
+   WHERE slug IN ('ceo', 'manager', 'cashier')
+ON CONFLICT (role_id, permission_key) DO NOTHING;
+
+COMMIT;
+
+-- =============================================================================
+-- Verification (run by hand after deploy):
+--   SELECT key FROM public.permissions WHERE key = 'sales.confirm'; -- 1 row
+--   SELECT r.slug, COUNT(*)
+--     FROM public.roles r
+--     JOIN public.role_permissions rp ON rp.role_id = r.id
+--    WHERE rp.permission_key = 'sales.confirm'
+--    GROUP BY r.slug ORDER BY r.slug;
+--   -- expect: ceo + manager + cashier (one per business); NOT stock_keeper
+-- =============================================================================

--- a/test/database/migration_upgrade_test.dart
+++ b/test/database/migration_upgrade_test.dart
@@ -1131,4 +1131,37 @@ void main() {
       );
     });
   });
+
+  group('onUpgrade v64 → v65 (sales.confirm permission, #171 Confirm gate)', () {
+    Future<bool> permissionExists(AppDatabase db, String key) async {
+      final rows = await db
+          .customSelect(
+            'SELECT 1 FROM permissions WHERE key = ?',
+            variables: [Variable<String>(key)],
+          )
+          .get();
+      return rows.isNotEmpty;
+    }
+
+    test('re-seeds sales.confirm into the local catalog', () async {
+      // Fresh v65 DB already seeds the key in onCreate (it's in
+      // _defaultPermissionRows). Delete it + revert to v64 so the re-open's v65
+      // block has work to do. Every other table is untouched.
+      final db1 = await openAndInit();
+      expect(await permissionExists(db1, 'sales.confirm'), isTrue,
+          reason: 'onCreate should seed the key');
+      await db1.customStatement(
+        "DELETE FROM permissions WHERE key = 'sales.confirm'",
+      );
+      expect(await permissionExists(db1, 'sales.confirm'), isFalse);
+      await db1.customStatement('PRAGMA user_version = 64');
+      await db1.close();
+
+      // Re-open → onUpgrade(64 → 65) re-inserts the key via INSERT OR IGNORE.
+      final db2 = await openAndInit();
+      addTearDown(db2.close);
+      expect(await permissionExists(db2, 'sales.confirm'), isTrue,
+          reason: 'v65 block must seed sales.confirm');
+    });
+  });
 }

--- a/test/database/roles_v13_seed_test.dart
+++ b/test/database/roles_v13_seed_test.dart
@@ -62,14 +62,15 @@ void main() {
       );
     });
 
-    test('permissions table seeded with 39 default rows on fresh install',
+    test('permissions table seeded with 40 default rows on fresh install',
         () async {
       final perms = await db.permissionsDao.getAll();
-      expect(perms.length, equals(39));
+      expect(perms.length, equals(40));
 
       // Spot-check a few keys + categories.
       final keys = perms.map((p) => p.key).toSet();
       expect(keys.contains('sales.make'), isTrue);
+      expect(keys.contains('sales.confirm'), isTrue); // #171 Confirm gate
       expect(keys.contains('sales.set_custom_price'), isTrue); // §13.4
       expect(keys.contains('expenses.approve'), isTrue);
       expect(keys.contains('settings.manage'), isTrue);

--- a/test/orders/confirm_safety_test.dart
+++ b/test/orders/confirm_safety_test.dart
@@ -1,0 +1,243 @@
+// #171 Confirm safety — idempotency + seller attribution, at the Order module's
+// DAO/service transaction boundary against in-memory Drift (the seam the PRD
+// names; prior art: order_module_test.dart's Confirm settlement test).
+//
+// Asserts external behaviour only — resulting rows, derived balances, and the
+// order header — never internal call order:
+//   * Double-Confirm across two "devices" (two Confirm calls on the converged
+//     DB, by two different confirmers) settles the crate deposit exactly ONCE.
+//   * Confirm records `confirmed_by` and leaves the seller's `staff_id`
+//     untouched (the sale stays credited to who sold it).
+
+import 'package:drift/drift.dart' hide isNull, isNotNull;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reebaplus_pos/core/database/app_database.dart';
+import 'package:reebaplus_pos/core/database/uuid_v7.dart';
+import 'package:reebaplus_pos/shared/services/orders/crate_return_input.dart';
+import 'package:reebaplus_pos/shared/services/orders/order_service.dart';
+
+import '../helpers/dispatch_test_utils.dart';
+
+void main() {
+  late AppDatabase db;
+  late String businessId;
+
+  setUp(() async {
+    final boot = await bootstrapTestDb();
+    db = boot.db;
+    businessId = boot.businessId;
+    // A crate-tracking business, and the local (v1) record-sale path so
+    // createOrder writes order_crate_lines itself.
+    await (db.update(db.businesses)..where((b) => b.id.equals(businessId)))
+        .write(const BusinessesCompanion(type: Value('Bar')));
+    await setFlag(db, 'feature.domain_rpcs_v2.record_sale', on: false);
+  });
+
+  tearDown(() => db.close());
+
+  // Seeds a money-track (deposit-held) order for `crates` crates of one brand
+  // and returns (orderId, mfrId, sellerId, confirmerId, customerId, storeId).
+  Future<
+      ({
+        String orderId,
+        String mfrId,
+        String sellerId,
+        String confirmerId,
+        String customerId,
+        String storeId,
+        int depositKobo,
+      })> seedMoneyTrackOrder({int crates = 5, int rateKobo = 50000}) async {
+    final storeId = UuidV7.generate();
+    await db.into(db.stores).insert(
+          StoresCompanion.insert(
+              id: Value(storeId), businessId: businessId, name: 'Main'),
+        );
+    final sellerId = UuidV7.generate();
+    await db.into(db.users).insert(UsersCompanion.insert(
+        id: Value(sellerId),
+        businessId: businessId,
+        name: 'Seller',
+        pin: '0000'));
+    final confirmerId = UuidV7.generate();
+    await db.into(db.users).insert(UsersCompanion.insert(
+        id: Value(confirmerId),
+        businessId: businessId,
+        name: 'Confirmer',
+        pin: '0000'));
+    final customerId = await db.customersDao.addCustomer(
+      CustomersCompanion.insert(businessId: businessId, name: 'Buyer'),
+    );
+
+    final mfrId = UuidV7.generate();
+    await db.into(db.manufacturers).insert(ManufacturersCompanion.insert(
+          id: Value(mfrId),
+          businessId: businessId,
+          name: 'Star',
+          depositAmountKobo: Value(rateKobo),
+        ));
+    final productId = UuidV7.generate();
+    await db.into(db.products).insert(ProductsCompanion.insert(
+          id: Value(productId),
+          businessId: businessId,
+          name: 'Star Bottle',
+          retailerPriceKobo: const Value(100000),
+          manufacturerId: Value(mfrId),
+          unit: const Value('Bottle'),
+          trackEmpties: const Value(true),
+        ));
+    await db.into(db.inventory).insert(InventoryCompanion.insert(
+          businessId: businessId,
+          productId: productId,
+          storeId: storeId,
+          quantity: const Value(100),
+        ));
+
+    final depositKobo = rateKobo * crates;
+    final goodsKobo = 100000 * crates;
+    final orderId = await db.ordersDao.createOrder(
+      order: OrdersCompanion.insert(
+        businessId: businessId,
+        orderNumber: 'ORD-${UuidV7.generate()}',
+        customerId: Value(customerId),
+        totalAmountKobo: goodsKobo + depositKobo,
+        netAmountKobo: goodsKobo + depositKobo,
+        amountPaidKobo: Value(goodsKobo + depositKobo),
+        paymentType: 'cash',
+        status: 'pending',
+        staffId: Value(sellerId), // the SELLER
+        storeId: Value(storeId),
+      ),
+      items: [
+        OrderItemsCompanion.insert(
+          businessId: businessId,
+          orderId: 'placeholder',
+          productId: Value(productId),
+          storeId: storeId,
+          quantity: crates,
+          unitPriceKobo: 100000,
+          totalKobo: goodsKobo,
+        ),
+      ],
+      customerId: customerId,
+      amountPaidKobo: goodsKobo + depositKobo,
+      totalAmountKobo: goodsKobo + depositKobo,
+      staffId: sellerId,
+      storeId: storeId,
+      crateDepositPaidByManufacturer: {mfrId: depositKobo},
+    );
+
+    return (
+      orderId: orderId,
+      mfrId: mfrId,
+      sellerId: sellerId,
+      confirmerId: confirmerId,
+      customerId: customerId,
+      storeId: storeId,
+      depositKobo: depositKobo,
+    );
+  }
+
+  Future<int> countRefundRows(String orderId) async {
+    final rows = await (db.select(db.walletTransactions)
+          ..where((t) =>
+              t.orderId.equals(orderId) &
+              t.referenceType.equals('crate_refund')))
+        .get();
+    return rows.length;
+  }
+
+  Future<int> emptyStock(String mfrId) async {
+    final m = await (db.select(db.manufacturers)..where((x) => x.id.equals(mfrId)))
+        .getSingle();
+    return m.emptyCrateStock;
+  }
+
+  group('Idempotency — double Confirm settles the deposit once', () {
+    test('two devices confirming the same order refund + restock exactly once',
+        () async {
+      final s = await seedMoneyTrackOrder(crates: 5, rateKobo: 50000);
+      final svc = OrderService(db);
+      final fullReturn = [
+        CrateReturnLine(
+          manufacturerId: s.mfrId,
+          takenCrates: 5,
+          returnedCrates: 5,
+          rateKobo: 50000,
+          paidKobo: s.depositKobo,
+        ),
+      ];
+
+      // Device A confirms.
+      await svc.markAsCompleted(s.orderId, s.confirmerId,
+          customerId: s.customerId,
+          storeId: s.storeId,
+          crateReturns: fullReturn);
+
+      expect(await countRefundRows(s.orderId), 1);
+      expect(await emptyStock(s.mfrId), 5);
+      final balAfterFirst =
+          await db.walletTransactionsDao.getBalanceKobo(s.customerId);
+
+      // Device B confirms the SAME (now-completed) order — must be a no-op.
+      await svc.markAsCompleted(s.orderId, s.confirmerId,
+          customerId: s.customerId,
+          storeId: s.storeId,
+          crateReturns: fullReturn);
+
+      expect(await countRefundRows(s.orderId), 1,
+          reason: 'deposit refunded once, not twice');
+      expect(await emptyStock(s.mfrId), 5,
+          reason: 'physical empties credited once, not twice');
+      expect(await db.walletTransactionsDao.getBalanceKobo(s.customerId),
+          balAfterFirst,
+          reason: 'the second Confirm posts no wallet legs');
+
+      final order = await db.ordersDao.findById(s.orderId);
+      expect(order!.status, 'completed');
+    });
+
+    test('markCompleted alone is idempotent (status re-read aborts a re-run)',
+        () async {
+      final s = await seedMoneyTrackOrder();
+      await db.ordersDao.markCompleted(s.orderId, s.confirmerId);
+      final first = await db.ordersDao.findById(s.orderId);
+      expect(first!.status, 'completed');
+      final firstCompletedAt = first.completedAt;
+
+      // A second markCompleted with a different confirmer must not touch it.
+      await db.ordersDao.markCompleted(s.orderId, s.sellerId);
+      final second = await db.ordersDao.findById(s.orderId);
+      expect(second!.confirmedBy, s.confirmerId,
+          reason: 'confirmedBy is stamped by the FIRST confirm only');
+      expect(second.completedAt, firstCompletedAt,
+          reason: 'the second call was a no-op');
+    });
+  });
+
+  group('Seller attribution — staff_id preserved, confirmed_by recorded', () {
+    test('Confirm keeps the seller and records the confirmer separately',
+        () async {
+      final s = await seedMoneyTrackOrder();
+      expect((await db.ordersDao.findById(s.orderId))!.staffId, s.sellerId);
+
+      await OrderService(db).markAsCompleted(s.orderId, s.confirmerId,
+          customerId: s.customerId,
+          storeId: s.storeId,
+          crateReturns: [
+            CrateReturnLine(
+              manufacturerId: s.mfrId,
+              takenCrates: 5,
+              returnedCrates: 5,
+              rateKobo: 50000,
+              paidKobo: s.depositKobo,
+            ),
+          ]);
+
+      final order = await db.ordersDao.findById(s.orderId);
+      expect(order!.staffId, s.sellerId,
+          reason: 'the sale stays credited to who sold it (#171)');
+      expect(order.confirmedBy, s.confirmerId,
+          reason: 'the confirmer is recorded separately on confirmed_by');
+    });
+  });
+}

--- a/test/orders/crate_return_blank_test.dart
+++ b/test/orders/crate_return_blank_test.dart
@@ -1,0 +1,46 @@
+// #171 A2 — a blank part-deposit crate-count field must parse as 0 (never "all
+// crates returned"), and Confirm is blocked until every field is filled. These
+// are pure functions extracted from CrateReturnModal so the rule is testable
+// without pumping the sheet.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reebaplus_pos/features/orders/widgets/crate_return_modal.dart';
+
+void main() {
+  group('parseReturnedCrateCount — blank means 0', () {
+    test('an empty field parses to 0, NOT the expected count', () {
+      expect(parseReturnedCrateCount(''), 0);
+    });
+
+    test('a whitespace-only field parses to 0', () {
+      expect(parseReturnedCrateCount('   '), 0);
+    });
+
+    test('a non-numeric field parses to 0', () {
+      expect(parseReturnedCrateCount('abc'), 0);
+    });
+
+    test('a real count parses to that number', () {
+      expect(parseReturnedCrateCount('3'), 3);
+      expect(parseReturnedCrateCount(' 12 '), 12);
+      expect(parseReturnedCrateCount('0'), 0);
+    });
+  });
+
+  group('allCrateCountsFilled — Confirm is blocked until every field is filled',
+      () {
+    test('a single blank field blocks Confirm', () {
+      expect(allCrateCountsFilled(['3', '']), isFalse);
+      expect(allCrateCountsFilled(['   ']), isFalse);
+    });
+
+    test('all fields filled (0 counts as filled) allows Confirm', () {
+      expect(allCrateCountsFilled(['3', '0']), isTrue);
+      expect(allCrateCountsFilled(['5']), isTrue);
+    });
+
+    test('an empty set is trivially filled (a non-crate order)', () {
+      expect(allCrateCountsFilled(const []), isTrue);
+    });
+  });
+}

--- a/test/permissions/confirm_gate_test.dart
+++ b/test/permissions/confirm_gate_test.dart
@@ -1,0 +1,162 @@
+// #171 Confirm-safety gates. Two seams:
+//   1. Pure Gate algebra — sales.confirm gates Confirm (Cashier-tier and above,
+//      expressed by the seeded grant, not a tier atom); the cash-refund branch
+//      ADDITIONALLY requires customers.wallet.withdraw.
+//   2. The imperative `require()` write-boundary guard — throws GateDeniedError
+//      when denied, returns when granted (the shape the Confirm path relies on).
+// No DB, no pumped widget for the algebra half; the require half uses the
+// module's own gateContextProvider seam, like guarded_test.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:reebaplus_pos/core/permissions/gate.dart';
+import 'package:reebaplus_pos/core/permissions/gate_registry.dart';
+import 'package:reebaplus_pos/core/permissions/guarded.dart';
+
+GateContext ctx({Set<String> keys = const {}, int? rank}) =>
+    GateContext(grantedKeys: keys, roleRank: rank, isReady: true);
+
+void main() {
+  group('Gates.confirmOrder (sales.confirm)', () {
+    test('grants a Cashier who holds sales.confirm', () {
+      expect(
+        Gates.confirmOrder.rule.evaluate(
+          ctx(keys: {'sales.confirm'}, rank: GateTier.cashier),
+        ),
+        isTrue,
+      );
+    });
+
+    test('denies a Stock keeper who does NOT hold sales.confirm', () {
+      expect(
+        Gates.confirmOrder.rule.evaluate(
+          ctx(keys: {'stock.add', 'stock.view'}, rank: GateTier.stockKeeper),
+        ),
+        isFalse,
+      );
+    });
+
+    test('denies anyone missing the key regardless of tier', () {
+      expect(
+        Gates.confirmOrder.rule.evaluate(ctx(rank: GateTier.manager)),
+        isFalse,
+      );
+    });
+  });
+
+  group('Gates.confirmOrderCashRefund (sales.confirm + wallet.withdraw)', () {
+    test('grants only when BOTH keys are held', () {
+      expect(
+        Gates.confirmOrderCashRefund.rule.evaluate(
+          ctx(
+            keys: {'sales.confirm', 'customers.wallet.withdraw'},
+            rank: GateTier.cashier,
+          ),
+        ),
+        isTrue,
+      );
+    });
+
+    test('a confirmer WITHOUT wallet.withdraw cannot cash-refund', () {
+      // Can Confirm (and refund to the credit balance), but not out of the till.
+      expect(
+        Gates.confirmOrder.rule
+            .evaluate(ctx(keys: {'sales.confirm'}, rank: GateTier.cashier)),
+        isTrue,
+      );
+      expect(
+        Gates.confirmOrderCashRefund.rule
+            .evaluate(ctx(keys: {'sales.confirm'}, rank: GateTier.cashier)),
+        isFalse,
+      );
+    });
+
+    test('wallet.withdraw alone (without sales.confirm) is not enough', () {
+      expect(
+        Gates.confirmOrderCashRefund.rule.evaluate(
+          ctx(keys: {'customers.wallet.withdraw'}, rank: GateTier.manager),
+        ),
+        isFalse,
+      );
+    });
+  });
+
+  group('require() at the Confirm write boundary', () {
+    late ProviderContainer container;
+    final source = StateProvider<GateContext>((ref) => GateContext.unresolved);
+
+    setUp(() {
+      container = ProviderContainer(
+        overrides: [
+          gateContextProvider.overrideWith((ref) => ref.watch(source)),
+        ],
+      );
+    });
+    tearDown(() => container.dispose());
+
+    Future<WidgetRef> pumpRef(WidgetTester tester, GateContext c) async {
+      container.read(source.notifier).state = c; // set BEFORE build
+      late WidgetRef out;
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: MaterialApp(
+            home: Consumer(
+              builder: (_, ref, __) {
+                out = ref;
+                return const SizedBox();
+              },
+            ),
+          ),
+        ),
+      );
+      return out;
+    }
+
+    testWidgets('confirmOrder throws without sales.confirm, returns with it',
+        (tester) async {
+      final ref = await pumpRef(
+        tester,
+        ctx(keys: {'stock.add'}, rank: GateTier.stockKeeper),
+      );
+      expect(
+        () => Gates.confirmOrder.require(ref),
+        throwsA(isA<GateDeniedError>()
+            .having((e) => e.gateName, 'gateName', 'confirmOrder')),
+      );
+
+      final ref2 = await pumpRef(
+        tester,
+        ctx(keys: {'sales.confirm'}, rank: GateTier.cashier),
+      );
+      expect(() => Gates.confirmOrder.require(ref2), returnsNormally);
+    });
+
+    testWidgets('the cash-refund branch require needs wallet.withdraw too',
+        (tester) async {
+      final ref = await pumpRef(
+        tester,
+        ctx(keys: {'sales.confirm'}, rank: GateTier.cashier),
+      );
+      // May Confirm…
+      expect(() => Gates.confirmOrder.require(ref), returnsNormally);
+      // …but the cash-refund branch is denied.
+      expect(
+        () => Gates.confirmOrderCashRefund.require(ref),
+        throwsA(isA<GateDeniedError>()
+            .having((e) => e.gateName, 'gateName', 'confirmOrderCashRefund')),
+      );
+
+      final ref2 = await pumpRef(
+        tester,
+        ctx(
+          keys: {'sales.confirm', 'customers.wallet.withdraw'},
+          rank: GateTier.cashier,
+        ),
+      );
+      expect(() => Gates.confirmOrderCashRefund.require(ref2), returnsNormally);
+    });
+  });
+}

--- a/test/settings/role_permissions_detail_test.dart
+++ b/test/settings/role_permissions_detail_test.dart
@@ -155,7 +155,7 @@ void main() {
 
     final switches =
         tester.widgetList<SwitchListTile>(find.byType(SwitchListTile)).toList();
-    expect(switches.length, 36, reason: 'all 36 permissions shown');
+    expect(switches.length, 37, reason: 'all 37 permissions shown');
     expect(
       switches.every((s) => s.onChanged == null && s.value == true),
       isTrue,

--- a/test/settings/roles_permissions_screen_test.dart
+++ b/test/settings/roles_permissions_screen_test.dart
@@ -83,7 +83,7 @@ void main() {
             permissionKey: 'settings.manage',
           ),
         );
-    // Cashier: two grants → its card subtitle should read "2 of 33 permissions".
+    // Cashier: two grants → its card subtitle should read "2 of 37 permissions".
     for (final key in ['sales.make', 'stock.view']) {
       await db.into(db.rolePermissions).insert(
             RolePermissionsCompanion.insert(
@@ -121,8 +121,8 @@ void main() {
     expect(find.text('Cashier'), findsOneWidget);
     expect(find.text('Stock keeper'), findsOneWidget);
 
-    expect(find.text('All 36 permissions'), findsOneWidget); // CEO, locked
-    expect(find.text('2 of 36 permissions'), findsOneWidget); // Cashier
+    expect(find.text('All 37 permissions'), findsOneWidget); // CEO, locked
+    expect(find.text('2 of 37 permissions'), findsOneWidget); // Cashier
   });
 
   testWidgets('tapping a role card opens its detail', (tester) async {


### PR DESCRIPTION
Money integrity slice #2 (parent #155).

## What landed
- **Gate**: new `sales.confirm` permission key. `Gates.confirmOrder` gates the Confirm action; `Gates.confirmOrderCashRefund` (`sales.confirm` + `customers.wallet.withdraw`) gates the cash refund-destination. Seeded **CEO + Manager + Cashier** (Cashier-tier+; not Stock keeper). `.require()` at the Confirm write boundary + render gates on the button and the Cash chip.
- **Idempotency**: `markCompleted` re-reads order status inside its transaction and aborts unless `pending`; `OrderCommands._settleCrateReturns` re-reads status at the whole-settlement seam. Two devices confirming the same converged order settle the deposit exactly once. (The low-level `settleCrateDepositReturn` primitive stays unconditional — exercised directly on completed orders by crate tests — with idempotency one layer up; chosen over a per-row wallet probe because `wallet_transactions` has no `manufacturer_id` and a probe would wrongly skip the 2nd+ manufacturer.)
- **Blank part-deposit → 0** (`parseReturnedCrateCount`) and Confirm blocked until every field is filled (`allCrateCountsFilled`).
- **Seller attribution**: Confirm records `orders.confirmed_by` (the #169 column) and **no longer overwrites `orders.staff_id`**.

## Schema
Drift v64→**v65** (seed `sales.confirm` + grants; `ensurePermissionsSeeded` re-seeds after `clearAllData`). Cloud migration **`0154_money_integrity_confirm_gate.sql`** (catalogue insert + role grants) — authored, not applied (must deploy before grants sync, per the role_permissions FK invariant).

## Verification
- `flutter analyze`: clean. Full suite: 1042 pass / 1 pre-existing flake.
- New tests: confirm idempotency + confirmed_by/staff_id (`confirm_safety_test`), gate algebra + `.require()` (`confirm_gate_test`), blank→0 (`crate_return_blank_test`); migration v64→v65 + all permission-count assertions updated.

Closes #171